### PR TITLE
docs: 三处「不做自动更新」的表述过期了

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -395,12 +395,12 @@ jobs:
             fi
           done
 
-          # `.tar.gz` 是**自动更新产物**，只在 `tauri.conf.json` 配了
-          # `bundle.createUpdaterArtifacts` 时才产出 —— 本产品有意不注册 updater 插件，
-          # 所以那个键没配、这个文件根本不会存在。原来这里 `exit 1`，等于让 macOS 那条腿
-          # 永远出不了包。降级成「有则带上」：真搭了发布渠道之后它会自动出现并被带进 release。
+          # `.tar.gz` 是**自动更新产物**，由 `tauri.conf.json` 的
+          # `bundle.createUpdaterArtifacts` 控制 —— 2026-08-04 起已开启，所以正常情况下
+          # 它一定存在。这里仍不 `exit 1`（上游原本是）：缺它只意味着这一版收不到自动更新，
+          # 而安装包本身是好的，不该因此让整条发布通道断掉。
           if [ -z "$TAR_GZ" ]; then
-            echo "○ 没有 .tar.gz 更新包产物（未启用 updater），跳过它，只发 .app / .dmg"
+            echo "⚠️ 没有 .tar.gz 更新包产物（签名密钥未配？）—— 只发 .app / .dmg，这一版收不到自动更新"
           fi
           if [ -z "$APP_PATH" ]; then
             echo "❌ No .app found" >&2
@@ -786,7 +786,8 @@ jobs:
 
             > Linux 包暂未提供。
 
-            > 暂无应用内自动更新，新版本请回本页下载。
+            > 应用内会自动检查更新（启动后几秒，失败静默）；也可在「设置 → 关于」手动检查。
+            > 免安装版不做原地更新 —— 它会带你回本页下载新版。
 
             ---
             ⚠️ **macOS 版本未经 Apple 签名与公证**（那需要 Apple Developer Program）。

--- a/LOONGPORT.md
+++ b/LOONGPORT.md
@@ -233,7 +233,5 @@ cargo test --manifest-path src-tauri/Cargo.toml --lib probe_live_site -- --ignor
 
 - **本地代理 / failover**：sub2api 原生支持 codex 的 `/v1/responses`，不需要协议转换。
   `proxy/` 那套留在仓里但不接线。
-- **自动更新**：`plugins.updater` 整块删了（上游端点会把用户升级成 cc-switch）。有自己的
-  发布渠道之后要同时配 endpoints + pubkey + 加回 `lib.rs` 里那段注册，缺一个都不行。
 - **凭据加密**：token 明文存 SQLite。同一个库里已经躺着明文 sk（上游行为），只加密 token
   没有实际收益。要做就两者一起进 keyring。


### PR DESCRIPTION
`bb46300d` 接上了自动更新，但三处旧表述还在说不做。按「过期表述改掉而不是在底下追一行更正」处理。

## 改了什么

- `LOONGPORT.md` 的**「已知不做的」**列表里那条整条移除 —— 它现在做了
- `release.yml` 里 `.tar.gz` 那段注释：从「有意不注册 updater 插件、那个键没配、这个文件根本不会存在」改成「已开启、正常情况下一定存在」。**仍不 `exit 1`**（上游原本是）—— 缺它只意味着这一版收不到自动更新，安装包本身是好的，不该让整条发布通道断掉
- **Release 说明里那句「暂无应用内自动更新，新版本请回本页下载」** —— 这句最要紧，它是给下载者看的。改成说清两件事：应用内会自动检查（启动后几秒、失败静默），以及免安装版不做原地更新、会带你回本页

顺带把两处「没有 .sig / .tar.gz（未启用 updater）」的提示改成「签名密钥未配？」—— updater 已启用，缺产物只可能是别的原因，旧措辞会把排查引向错误方向。

## 为什么走 PR

直推 main 会绕过必需检查并留一条 `Bypassed rule violations` 记录（`enforce_admins: false` 的预期行为，但没必要每次都用）。这条也顺便验证保护规则对自己的 PR 好不好用。