### PR TITLE
feat(updater): 补上定时检查 —— 挂着不关的用户收不到提醒

### DIFF
--- a/src/contexts/UpdateContext.tsx
+++ b/src/contexts/UpdateContext.tsx
@@ -27,6 +27,18 @@ interface UpdateContextValue {
 
 const UpdateContext = createContext<UpdateContextValue | undefined>(undefined);
 
+/** 启动后多久做第一次检查。留几秒让首屏渲染、数据库迁移、托盘创建先完成。 */
+const STARTUP_CHECK_DELAY_MS = 5_000;
+
+/**
+ * 之后每隔多久再查一次。
+ *
+ * **6 小时**：发版频率是天/周级，查得再密也不会更早发现；而每次检查是一次网络请求，
+ * 对挂着不关的用户（`minimize_to_tray_on_close` 默认为 true，所以这是常态）
+ * 一天四次已经足够及时。
+ */
+const PERIODIC_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
 export function UpdateProvider({ children }: { children: React.ReactNode }) {
   const DISMISSED_VERSION_KEY = "ccswitch:update:dismissedVersion";
   const LEGACY_DISMISSED_KEY = "dismissedUpdateVersion"; // 兼容旧键
@@ -115,27 +127,49 @@ export function UpdateProvider({ children }: { children: React.ReactNode }) {
     localStorage.removeItem(LEGACY_DISMISSED_KEY);
   }, []);
 
-  // 启动时自动检查一次。2026-08-04 接上自己的发布渠道后启用（在此之前 updater 插件
-  // 有意不注册，`check()` 必抛 ⇒ 那时这段每次启动只会吐一条错误，所以当时是删掉的）。
+  // 自动检查更新：**启动后一次 + 之后每 6 小时一次**。
   //
-  // 三个刻意的选择：
+  // 2026-08-04 接上自己的发布渠道后启用（在此之前 updater 插件有意不注册、`check()`
+  // 必抛，所以那时这段是删掉的）。2026-08-05 补上定时那半 —— 当初判断「桌面工具不是
+  // 常驻服务、用户重开就再查」，那是**错的**：`minimize_to_tray_on_close` 默认为 true
+  // ⇒ 用户点关闭是最小化到托盘、进程不退出 ⇒ 「挂着好几天」是常态而非例外，
+  // 只在启动时查等于那些用户永远收不到提醒。
   //
-  // **延迟 5 秒**，不跟启动争资源 —— 首屏要渲染、数据库要迁移、托盘要建，
-  // 而"有没有新版本"不着急这几秒。
+  // 四个刻意的选择：
+  //
+  // **启动延迟 5 秒**，不跟启动争资源 —— 首屏要渲染、数据库要迁移、托盘要建，
+  // 而「有没有新版本」不着急这几秒。
+  //
+  // **间隔 6 小时，且不做持久化。** 计时器只活在进程生命周期内 ⇒ 不需要存「上次查询
+  // 时间」，重启就是重新开始（那时启动那次已经查过了，语义上不缺）。有意不做「按真实
+  // 时间补偿」：睡眠唤醒后 `setInterval` 可能立刻触发一次，那恰好是我们想要的
+  // （睡了一晚醒来查一次），不是要修的 bug。
   //
   // **失败完全静默**（`checkUpdate` 内部把错误收进 `error` 状态，这里不弹任何东西）。
   // 检查更新要发网络，而离线、GitHub 不可达、公司网络拦截都是**常态而非异常** ——
-  // 为此弹一个"检查更新失败"是拿用户不关心的事打扰他。用户主动点"检查更新"时才提示，
-  // 那时他在等一个答复（见 `AboutSection` 的 `handleCheckUpdate`）。
+  // 为此弹一个「检查更新失败」是拿用户不关心的事打扰他。用户主动点「检查更新」时才
+  // 提示，那时他在等一个答复（见 `AboutSection` 的 `handleCheckUpdate`）。
   //
-  // **只查一次，不设轮询**。这是个桌面工具、不是常驻服务，用户重开就再查一次；
-  // 定时轮询要多一套"上次查询时间"的持久化状态，收益却只是"挂着不关也能收到提醒"。
-  // 真需要时再加（那时判据是：有多少用户会连着挂几天不重启）。
+  // **重复发现同一个版本不会重复打扰**：`checkUpdate` 会比对
+  // `DISMISSED_VERSION_KEY` —— 用户关掉过某个版本的提醒后，之后每次轮询到同一个版本
+  // 都仍是 dismissed 状态。所以 6 小时一次不会变成「6 小时一次弹窗」。
   useEffect(() => {
-    const timer = setTimeout(() => {
-      void checkUpdate();
-    }, 5000);
-    return () => clearTimeout(timer);
+    // ⚠️ **必须 `.catch()`，不能只写 `void checkUpdate()`。** `checkUpdate` 失败时会
+    // `throw err`（那是为主动点击那条路准备的 —— 调用方要据此弹提示），而自动检查这条
+    // 路没人接 ⇒ 每次失败都是一条 unhandled rejection。启动查一次时那只是一条噪音，
+    // 加上轮询后离线用户每 6 小时来一条，控制台会被刷满。
+    //
+    // 这里什么都不做是对的：错误已经被 `checkUpdate` 收进 `error` 状态、也已经
+    // `console.error` 过，自动检查失败本就不该打扰用户（见上面那段说明）。
+    const auto = () => {
+      checkUpdate().catch(() => {});
+    };
+    const initial = setTimeout(auto, STARTUP_CHECK_DELAY_MS);
+    const periodic = setInterval(auto, PERIODIC_CHECK_INTERVAL_MS);
+    return () => {
+      clearTimeout(initial);
+      clearInterval(periodic);
+    };
   }, [checkUpdate]);
 
   const value: UpdateContextValue = {

--- a/tests/contexts/updateAutoCheck.test.tsx
+++ b/tests/contexts/updateAutoCheck.test.tsx
@@ -1,0 +1,116 @@
+import type { ReactNode } from "react";
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { UpdateProvider } from "@/contexts/UpdateContext";
+
+/**
+ * 自动检查更新的三条行为，都是**改错了不会有编译错误、只会静默走歪**的那类。
+ *
+ * 为什么值得钉：
+ *
+ * 1. **轮询存在**。它是「用户挂着不关也能收到提醒」的唯一保证，而这个应用默认
+ *    `minimize_to_tray_on_close`（点关闭是最小化到托盘、进程不退出）⇒ 挂几天是常态。
+ *    2026-08-04 那版只在启动时查一次，那些用户永远收不到提醒。
+ * 2. **失败不产生 unhandled rejection**。`checkUpdate` 失败时会 `throw`（主动点击那条路
+ *    要据此弹提示），自动检查这条路没人接 ⇒ 写成 `void checkUpdate()` 的话，离线用户
+ *    每 6 小时来一条 unhandled rejection。
+ * 3. **卸载后不再触发**。忘了 `clearInterval` 的计时器会在组件卸载后继续跑。
+ */
+
+const updaterMocks = vi.hoisted(() => ({
+  checkForUpdate: vi.fn(),
+}));
+
+vi.mock("@/lib/updater", () => ({
+  checkForUpdate: (...args: unknown[]) => updaterMocks.checkForUpdate(...args),
+}));
+
+const wrap = (children: ReactNode) => (
+  <UpdateProvider>{children}</UpdateProvider>
+);
+
+describe("自动检查更新", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    updaterMocks.checkForUpdate.mockReset();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("启动后查一次，之后每 6 小时再查", async () => {
+    updaterMocks.checkForUpdate.mockResolvedValue({ status: "up-to-date" });
+    render(wrap(null));
+
+    // 启动那次有意延迟几秒（不跟首屏渲染争资源）——所以刚挂载时还没查。
+    expect(updaterMocks.checkForUpdate).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(updaterMocks.checkForUpdate).toHaveBeenCalledTimes(1);
+
+    // 再过 6 小时应该有第二次。**这条是「挂着不关也能收到提醒」的判据。**
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000);
+    });
+    expect(updaterMocks.checkForUpdate).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000);
+    });
+    expect(updaterMocks.checkForUpdate).toHaveBeenCalledTimes(3);
+  });
+
+  it("检查失败不产生 unhandled rejection", async () => {
+    // 离线、GitHub 不可达、公司网络拦截 —— 这条路是常态而非异常。
+    updaterMocks.checkForUpdate.mockRejectedValue(new Error("fetch failed"));
+
+    // ⚠️ **必须听 `process` 而不是 `window`。** jsdom 环境下 unhandled rejection 走的是
+    // Node 的 `process` 事件，`window.addEventListener("unhandledrejection")` 收不到
+    // ——2026-08-05 实测：把实现改回 `void checkUpdate()`，监听 window 的版本仍然全绿
+    // （那是个假的保险），换成 process 才真的变红。
+    const onUnhandled = vi.fn();
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      render(wrap(null));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000);
+      });
+      // 让 microtask 队列跑完 —— unhandled rejection 的判定发生在那之后。
+      await new Promise((resolve) => {
+        vi.useRealTimers();
+        setTimeout(resolve, 20);
+        vi.useFakeTimers();
+      });
+
+      // 两次都失败了，但都被 `.catch()` 接住。
+      expect(updaterMocks.checkForUpdate).toHaveBeenCalledTimes(2);
+      expect(onUnhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+
+  it("卸载之后不再检查", async () => {
+    updaterMocks.checkForUpdate.mockResolvedValue({ status: "up-to-date" });
+    const { unmount } = render(wrap(null));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(updaterMocks.checkForUpdate).toHaveBeenCalledTimes(1);
+
+    unmount();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000);
+    });
+    expect(updaterMocks.checkForUpdate).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
「每次打开软件检查」`bb46300d` 就做了（启动后 5 秒查一次）。缺的是**定时**那半，而当初不做的理由是**错的**：

我写的是「桌面工具不是常驻服务，用户重开就再查」—— 但 `minimize_to_tray_on_close` **默认为 true**，用户点关闭是最小化到托盘、进程不退出 ⇒「挂着好几天」是常态而非例外 ⇒ 那些用户一次提醒都收不到。

## 改成：启动后一次 + 之后每 6 小时一次

- **6 小时** — 发版频率是天/周级，查得更密也不会更早发现；一天四次对挂着的用户已经足够及时
- **不做持久化** — 计时器只活在进程生命周期内，不需要存「上次查询时间」；重启就重新开始（那时启动那次已经查过）。也有意**不做**「按真实时间补偿」：睡眠唤醒后 `setInterval` 可能立刻触发一次，那恰好是想要的（睡一晚醒来查一次），不是要修的 bug
- **失败静默** — 同启动那次。离线、GitHub 不可达是常态而非异常
- **不会变成「6 小时一次弹窗」** — `checkUpdate` 每次都重新比对 `DISMISSED_VERSION_KEY`，用户关掉过某版本的提醒后，之后轮询到同一版本仍是 dismissed。核过实现才这么说的

## 顺带修一个真 bug

原来的 `void checkUpdate()` 会产生 **unhandled rejection** —— `checkUpdate` 失败时 `throw err`（那是给主动点击那条路准备的，调用方要据此弹提示），自动检查这条路没人接。启动查一次时只是一条噪音；加上轮询后离线用户每 6 小时来一条，控制台会被刷满。

## 加了 3 个测试，并验证过它们真能抓到回归

⚠️ **第一版测试是假的保险。** 它监听 `window` 的 `unhandledrejection`，而我把实现改回 `void` 之后它**仍然全绿** —— jsdom 环境下 unhandled rejection 走的是 Node 的 `process` 事件，window 上收不到。换成 `process.on` 后再试同一个回归，这次真的变红（`1 failed`，收到两条 `fetch failed`）。

**测试写完必须验它会不会红**，否则只是让人安心。

三条都是「改错了不会有编译错误、只会静默走歪」的：轮询存在、失败不产生 unhandled rejection、卸载后不再触发。

## 验证

六道闸：tsc 干净 / prettier 干净 / vitest **686 passed（110 files）** / cargo test 0 失败。