### PR TITLE
docs(readme): 首屏加一个显眼的下载入口

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 ### Codex 只花官方的 5%，Claude 只花 20%，国内直连
 
+[![下载最新版](https://img.shields.io/github/v/release/SailingLoong/LoongPort?label=%E4%B8%8B%E8%BD%BD%E6%9C%80%E6%96%B0%E7%89%88&color=2ea44f&style=for-the-badge)](../../releases/latest)
+
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS-lightgrey.svg)](../../releases)
 [![Built with Tauri](https://img.shields.io/badge/built%20with-Tauri%202-orange.svg)](https://tauri.app/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)

--- a/README_EN.md
+++ b/README_EN.md
@@ -6,6 +6,8 @@
 
 ### Codex at 5% of official cost, Claude at 20%, no extra network setup
 
+[![Download](https://img.shields.io/github/v/release/SailingLoong/LoongPort?label=Download&color=2ea44f&style=for-the-badge)](../../releases/latest)
+
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS-lightgrey.svg)](../../releases)
 [![Built with Tauri](https://img.shields.io/badge/built%20with-Tauri%202-orange.svg)](https://tauri.app/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)


### PR DESCRIPTION
维护者反馈「GitHub 项目上面没找到 release 页」。

## 事实：Release 是有的，但入口不显眼

- `releases/latest` → 200，跳到 v3.20.0（Latest）
- 仓库首页 HTML 里确实有 Releases 区块（`releaseCount: 2`）

**问题是要往下滚到右侧栏才看得到，而 README 首屏一个下载入口都没有。** 那个 Platform badge 虽然链的就是 `../../releases`，但它长得像「平台标识」而不是「点这里下载」—— 没人会去点它。

## 改法

加一个 `for-the-badge` 尺寸的绿色下载 badge，独占一行放在其它 badge 之上。

**用 `shields.io/github/v/release` 而不是写死版本号** —— 它自动显示当前版本（实测渲染为 `下载最新版: V3.20.0` / `DOWNLOAD: V3.20.0`），所以发新版不必回来改这里。写死的那种漏改就会指向旧版本，且不报错。

**链到 `releases/latest` 而不是 `releases`** —— 少一次点击，且预发布不算 latest（正合 `release.yml` 里 `prerelease: contains(ref_name, '-')` 那条规则）。

## 验证

- `releases/latest` 200
- 两个 badge 都正确渲染出 `V3.20.0`（中英各一个 label）