### PR TITLE
fix(operator): 在 claude 页面切档位不该问「要不要退出 ChatGPT」

### DIFF
--- a/src/components/operator/OperatorSection.tsx
+++ b/src/components/operator/OperatorSection.tsx
@@ -106,6 +106,32 @@ export function OperatorSection({ appId }: OperatorSectionProps) {
    * 一对命令 + 一个 settings 键，那些现在全删了。
    */
   const isImageTab = appId === "codex-image";
+  /**
+   * 这一屏切档位会不会动到 `~/.codex/` —— 也就是**要不要理 ChatGPT 桌面版**。
+   *
+   * ## 为什么必须按 app 判，而不是只看 `chatgptNeedsAttention`
+   *
+   * `chatgptNeedsAttention` 的语义是「这台机器上要不要提示处理 ChatGPT」——
+   * 它只关**平台与安装状态**（非 macOS 恒为 true，见 `chatgpt_app::needs_user_attention`），
+   * **完全不含「切的是哪个 app」**。
+   *
+   * 于是 2026-08-05 维护者实测到：**在 claude 页面切档位，也会弹「要不要退出 ChatGPT」
+   * 的确认框，选完还提示「请手动重启 ChatGPT」** —— 而 claude 档位写的是
+   * `~/.claude/settings.json`，跟 ChatGPT 毫无关系。用户被要求为一件不存在的因果做决定。
+   *
+   * （这一处此前有句注释说 `chatgptNeedsAttention`「已经包含这个事实」，那是不属实的。）
+   *
+   * ## 判据
+   *
+   * ChatGPT 桌面版与命令行 codex **共用 `~/.codex`**，而它只在启动时读那个目录 ⇒
+   * 只有会改到 codex 主配置的那一屏才需要这道编排。
+   *
+   * ⚠️ **`codex-image` 有意不算在内。** 生图档位落的是 MCP 条目、不改 codex 的主模型
+   * 与 `base_url`，ChatGPT 桌面版并不消费它 —— 而首次注册那一步本来就要用户新开终端
+   * （见 README「在 CLI 里生图」那节），不需要再借道这个确认框。若将来发现桌面版
+   * 确实受影响，把它加进来即可，但要先有实测依据，不靠推测。
+   */
+  const touchesCodexConfig = appId === "codex";
   const [operators, setOperators] = useState<OperatorRowData[]>([]);
   /**
    * 待确认的切换：**显示名 + 真正执行它的函数**，`null` = 不弹。
@@ -661,8 +687,9 @@ export function OperatorSection({ appId }: OperatorSectionProps) {
   const handleVendorUse = (rowId: number) => {
     const row = vendorsRef.current.find((v) => v.id === rowId);
     const name = row?.vendorName ?? String(rowId);
-    // ChatGPT 没装就不必问，直接切（与 `handleSwitchTier` 同一判据）。
-    if (chatgptNeedsAttention) {
+    // 两个条件都要成立才问：这一屏会动 codex 配置，且这台机器上装着 ChatGPT。
+    // 少了前者就会在 claude 页面问一件无关的事（见 `touchesCodexConfig` 的说明）。
+    if (touchesCodexConfig && chatgptNeedsAttention) {
       setConfirmSwitch({
         name,
         run: (quitChatgpt) => void doVendorSwitch(rowId, quitChatgpt),
@@ -1011,8 +1038,9 @@ export function OperatorSection({ appId }: OperatorSectionProps) {
 
   const handleSwitchTier = (_operatorId: number, tier: TierInfo) => {
     if (tier.isCurrent) return;
-    // ChatGPT 没装就不必问「要不要关它」，直接切。
-    if (chatgptNeedsAttention) {
+    // 两个条件都要成立才问，见 `touchesCodexConfig` 的说明 ——
+    // 只看 `chatgptNeedsAttention` 会在 claude / gemini 页面问一件无关的事。
+    if (touchesCodexConfig && chatgptNeedsAttention) {
       setConfirmSwitch({
         name: tier.displayName,
         run: (quitChatgpt) => void doSwitch(tier, quitChatgpt),

--- a/tests/components/ChatgptPromptScopedToCodex.test.ts
+++ b/tests/components/ChatgptPromptScopedToCodex.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * 守「只有会动 codex 配置的那一屏才提 ChatGPT」这件事。
+ *
+ * ## 修的是什么
+ *
+ * 2026-08-05 维护者实测：**在 claude 页面切档位，也会弹「要不要退出 ChatGPT」的确认框，
+ * 选完还提示「请手动重启 ChatGPT」** —— 而 claude 档位写的是 `~/.claude/settings.json`，
+ * 跟 ChatGPT 桌面版毫无关系。用户被要求为一件不存在的因果做决定，而且那个决定
+ * （强制杀掉 ChatGPT）在 Windows 上是不可逆的。
+ *
+ * 根因：判据只用了 `chatgptNeedsAttention`，而它的语义是「**这台机器上**要不要提示
+ * 处理 ChatGPT」—— 只关平台与安装状态（非 macOS 恒为 true，见
+ * `chatgpt_app::needs_user_attention`），**完全不含「切的是哪个 app」**。
+ * 那一处此前的注释声称它「已经包含这个事实」，那是不属实的。
+ *
+ * 后端一直是对的（`operator.rs` 那句「不需要碰 ChatGPT（非 codex，或用户选了只切换）」），
+ * 只是前端没把 app 这一维传进判据。
+ *
+ * ## 为什么用读源码断言而不是渲染组件
+ *
+ * 与 `SwitchTierConfirmDialogPlatformCopy.test.ts` 同一套路：要守的是**判据里含 app
+ * 这一维**这件事本身。渲染要搭一整套 operator 数据（站点、档位、余额、mock 六个命令），
+ * 而那些与这条判据无关 —— 搭出来的复杂度会掩盖它真正在守什么。
+ *
+ * ⚠️ 这类断言的已知弱点是**改写法就失效**（把 `&&` 换成提前 return 也是对的实现，
+ * 但这条会误报红）。接受它：误报会让人来读这段说明，而漏报会让 bug 悄悄回来 ——
+ * 两种失败里前者可修，后者是这条测试存在的理由。
+ */
+const source = readFileSync(
+  resolve(__dirname, "../../src/components/operator/OperatorSection.tsx"),
+  "utf-8",
+);
+
+describe("ChatGPT 确认框只在 codex 那一屏出现", () => {
+  it("判据里含 app 这一维，不只看 chatgptNeedsAttention", () => {
+    expect(
+      source,
+      "OperatorSection 里应有一个按 appId 判断的派生值（当前叫 touchesCodexConfig）—— " +
+        "少了它就会在 claude / gemini 页面问一件与 ChatGPT 无关的事",
+    ).toContain("touchesCodexConfig");
+  });
+
+  it("那个派生值确实按 appId 算，且只认 codex", () => {
+    expect(source).toMatch(/touchesCodexConfig\s*=\s*appId === "codex"/);
+    // `codex-image` 有意不算：生图档位落的是 MCP 条目、不改 codex 主模型与 base_url，
+    // ChatGPT 桌面版不消费它；且首次注册本来就要用户新开终端。
+    // 若将来实测发现桌面版确实受影响再加，但要有依据。
+    expect(
+      source,
+      "codex-image 不该被算进去（除非有实测依据），见那个派生值的说明",
+    ).not.toMatch(/touchesCodexConfig[^;]*codex-image/);
+  });
+
+  it("两条切换路径都用上了这个判据", () => {
+    // 中转站档位（handleSwitchTier）与官网直连（handleVendorUse）各一处 ——
+    // 2026-08-04 那次修的正是「两条路走同一道编排」，这次不能只修一条。
+    const guarded = source.match(
+      /if \(touchesCodexConfig && chatgptNeedsAttention\)/g,
+    );
+    expect(
+      guarded?.length,
+      "应有两处（中转站档位 + 官网直连账号）都带上 touchesCodexConfig",
+    ).toBe(2);
+  });
+
+  it("没有残留的裸 chatgptNeedsAttention 判断", () => {
+    // 这条是防「只改了一处」：任何 `if (chatgptNeedsAttention)` 形式的裸判断都说明
+    // 有一条路径又会在无关的页面上问 ChatGPT。
+    expect(
+      source.match(/if \(chatgptNeedsAttention\)/g),
+      "还有裸的 `if (chatgptNeedsAttention)` —— 那条路径会在 claude 页面问无关的事",
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
维护者实测：**在 claude 页面切换供应商，也会弹「要不要退出 ChatGPT」的确认框，选完还提示「请手动重启 ChatGPT」** —— 而 claude 档位写的是 `~/.claude/settings.json`，跟 ChatGPT 桌面版毫无关系。

**后果不只是「多问一句」**：那个确认框是**强制杀掉 ChatGPT 的知情同意书** —— Windows 上点「退出并切换」会 `taskkill /F` 直接终止它、不提示保存（那边没有优雅手段，逐条实测见 `chatgpt_app.rs` 模块文档）。让用户为一件不存在的因果做这个决定，可能真丢他的工作。

## 根因

判据只用了 `chatgptNeedsAttention`，而它的语义是「**这台机器上**要不要提示处理 ChatGPT」—— 只关平台与安装状态（非 macOS 恒为 true），**完全不含「切的是哪个 app」**。

那一处此前有句注释声称 `chatgptNeedsAttention`「已经包含这个事实」—— 不属实，一并改掉。

**后端一直是对的**：`operator.rs:1921` 就写着「不需要碰 ChatGPT（非 codex，或用户选了只切换）」，且 `quit_chatgpt == false` 时走 `AroundOutcome::default()`（两个 bool 都 false）⇒ 提示自然落到「已切换到 XXX」。缺的只是前端把 app 这一维传进判据。

## 改法

新增 `touchesCodexConfig = appId === "codex"`，两条切换路径都改成 `touchesCodexConfig && chatgptNeedsAttention`：

- 中转站档位 `handleSwitchTier`
- 官网直连 `handleVendorUse`

⚠️ **`codex-image` 有意不算在内**：生图档位落的是 MCP 条目、不改 codex 主模型与 `base_url`，ChatGPT 桌面版不消费它；且首次注册那一步本来就要用户新开终端。我找不到它影响桌面版的依据 —— **不靠推测把它加进去**，若将来实测发现受影响再加。

## 4 条测试，验证过能抓回归

把修复退回原样后 **2 条变红**（「两条路径都接上」与「无裸 `chatgptNeedsAttention` 判断」）—— 不是那种「现在跑绿就算了」的假保险。

第四条特意防「只改一处」：2026-08-04 修过一次同类问题（官网直连那条路当时硬编码 `quitChatgpt: false`），教训正是这两条路要一起改。

## 验证

六道闸：tsc / prettier / vitest **690 passed（111 files）** / cargo test 0 失败 / clippy `-D warnings` / fmt。