### PR TITLE
fix(operator): 同一 app 内 DeepSeek ↔ 供应商切换后只亮一个"在用"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,3 +208,28 @@ npx tsc --noEmit && npx prettier --check "src/**/*.{js,jsx,ts,tsx,css,json}" && 
 
 **`cargo test` / `clippy` 全绿不代表能打包** —— CI 的 Backend Checks 不跑 `tauri build`，
 Tauri 的 npm↔crate 版本校验只在打包时触发（已踩过，见 `ca82a908`）。
+
+### 合并到远程 main：走 PR，且要过线上 4 个必需检查
+
+改动要进 `main` 一律走 PR（`gh pr create`），不要直接 push 到 `main`。
+**线上闸门是 4 个必需检查**（`Frontend Checks` + 三平台 `Backend Checks`，
+内容就是上面那六道闸，见 `.github/workflows/ci.yml`）—— 本地全绿不代表远程会绿，
+外部改动（fork PR）的验证点只有它。合并方式与仓库惯例一致用 merge commit
+（dependabot 的自动合才是 squash，见下）。
+
+标准流程（本地六道闸全过之后）：
+
+```
+git fetch origin main && git checkout -b fix/xxx origin/main
+# ...改动 + 本地六道闸...
+git push -u origin fix/xxx
+gh pr create --base main --head fix/xxx --title "..." --body-file pr_body.md
+gh pr merge fix/xxx --auto --merge    # 等 4 个必需检查全绿后自动合
+```
+
+`--auto` 只负责"检查绿了自动合"，**一道闸都没省**：main 的分支保护把 4 个
+必需检查设为 required，任何一个不过都不会合。`--merge`（merge commit）是
+人工 PR 的惯例；`dependabot-auto-merge.yml` 里那条用 `--squash` 是给
+dependabot 的，别照搬。PR 模板在 `.github/pull_request_template.md`。
+**main 只接受通过 PR 的改动** —— 这条与 design 仓无关（流程知识跟着代码走，
+不抄进档案仓，见全局准则 §1.4 唯一数据源）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,15 +196,18 @@ pub fn is_official_proxy_provider_id(id: &str) -> bool { /* 认新旧两个 */ }
 cd src-tauri
 cargo test && cargo clippy --all-targets -- -D warnings && cargo fmt --check
 cd ..
-npx tsc --noEmit && npx prettier --check "src/**/*.{js,jsx,ts,tsx,css,json}" && npx vitest run
+npx tsc --noEmit && npx prettier --check "{src,tests}/**/*.{js,jsx,ts,tsx,css,json,html}" && npx vitest run
 ```
 
 两个坑（都踩过）：
 
 - **`cargo` 不在默认 PATH 里**，先 `export PATH="$HOME/.cargo/bin:$PATH"`，
   否则拿到的是 `command not found` 而非真实结果。
-- **prettier 要用 CI 那个 glob**（`"src/**/*.{js,jsx,ts,tsx,css,json}"`）。
-  直接 `prettier --check src` 会把 `src/index.html` 也扫进来报 warn，那个不在闸内。
+- **prettier 的 glob 必须与 CI 一致**（`"{src,tests}/**/*.{js,jsx,ts,tsx,css,json,html}"`，
+  即 `package.json` 的 `format:check`）。别缩成 `src/**` —— 那会漏掉
+  `tests/` 与 `.html`，本地全绿而 CI 红（2026-08-07 实测：`tests/components/…`
+  的格式问题本地闸从来没扫到，合并时才被线上拦下）。直接跑
+  `pnpm format:check` 最省事，别手写 glob。
 
 **`cargo test` / `clippy` 全绿不代表能打包** —— CI 的 Backend Checks 不跑 `tauri build`，
 Tauri 的 npm↔crate 版本校验只在打包时触发（已踩过，见 `ca82a908`）。

--- a/src-tauri/src/commands/vendor.rs
+++ b/src-tauri/src/commands/vendor.rs
@@ -95,13 +95,17 @@ pub struct VendorAccountRow {
     /// 缺了它的后果（Task 6 实现时撞到的）：官网行的**「当前在用」高亮判不了**
     /// —— 前端只能靠「本次会话 provision 过」临时记住那个 id，app 一重启就没了。
     ///
-    /// ⚠️ 当前态的唯一事实源是 `providers` 表里那条记录（上游
-    /// `ProviderService::current`），前端拿这个 id 与它比即可。**本行没有 `is_current`
-    /// 这种字段** —— 库里那一列 2026-08-04 已删（从来没人写它，恒为 false），
-    /// 理由见 `vendor::creds::create_table` 的文档。
-    ///
     /// 空串 = 还没登录过（没有 `account_id` 就派生不出 id）。
     pub provider_id: String,
+    /// **当前 tab 那个 app** 下，这一行是不是正在用的那个。
+    ///
+    /// 判据是「`providers` 表里 `app_id` 那一栏的当前项 == 本行的 `provider_id`」——
+    /// 由后端在 `vendor_list_accounts` 里按 `app_id` 现算（同 `user_edited` 的时机），
+    /// **前端不自己维护**。与中转站档位的 `tier.is_current` 共用同一个事实源
+    /// （上游 `ProviderService::current`），所以一个 app 下所有组天然互斥。
+    ///
+    /// `false` 也可能是还没登录（`provider_id` 为空）—— 未登录的行不可能在用。
+    pub is_current: bool,
     /// **当前 tab 那个平台**的配置是不是被用户改过。
     ///
     /// ⚠️ **按平台算，不是整行一个值** —— 一行背后六条 provider 记录各自能被独立
@@ -136,9 +140,10 @@ impl From<creds::VendorRow> for VendorAccountRow {
             vendor_id: row.vendor_id,
             vendor_name,
             id: row.id,
-            // 这个 `From` 是纯转换、拿不到 DB。命令层用 `user_edited_for` 填它
-            // （要读 provider 记录才算得出来）。
+            // 这个 `From` 是纯转换、拿不到 DB。命令层用 `user_edited_for` / `is_current_for`
+            // 填它们（要读 provider 记录才算得出来）。
             user_edited: None,
+            is_current: false,
         }
     }
 }
@@ -176,16 +181,17 @@ pub async fn vendor_list_accounts(
     app_id: String,
 ) -> Result<Vec<VendorAccountRow>, String> {
     // 认不出的 app_id 不该让整条列表失败 —— 首屏契约是「只读本地、不卡」。
-    // 那种情况下 `user_edited` 全给 `None`（判不了就别断言）。
+    // 那种情况下 `user_edited` 全给 `None`、`is_current` 全给 `false`（判不了就别断言）。
     let app_type: Option<AppType> = app_id.parse().ok();
     with_conn(state.inner(), creds::list)
         .map(|rows| {
             rows.into_iter()
                 .map(|row| {
                     let mut out = VendorAccountRow::from(row);
-                    out.user_edited = app_type
-                        .as_ref()
-                        .and_then(|app| user_edited_for(state.inner(), &out, app));
+                    if let Some(app) = app_type.as_ref() {
+                        out.user_edited = user_edited_for(state.inner(), &out, app);
+                        out.is_current = is_current_for(state.inner(), &out, app);
+                    }
                     out
                 })
                 .collect()
@@ -224,6 +230,24 @@ fn user_edited_for(state: &AppState, row: &VendorAccountRow, app_type: &AppType)
         model,
         crate::vendor::provision::claude_roles_for(app_type),
     )
+}
+
+/// 这一行在 `app_type` 这个平台下**是不是正在用的那个**。
+///
+/// 判据与中转站档位的 `is_current` **同源**：`providers` 表里该 `app_type` 的当前项
+/// （上游 `ProviderService::current`）== 本行的 `provider_id`。所以「DeepSeek 官方组」
+/// 与「中转站档位 / 手工 provider」共享同一份互斥，一个 app 下永远只有一个在用。
+///
+/// ⚠️ **`provider_id` 为空时必须返回 `false`**：未登录的行派生不出 id（给空串），
+/// 而 `ProviderService::current` 在无当前项时也返回空串 —— 不守卫会让「从未登录」
+/// 的行被误判成当前项（空 == 空）。
+fn is_current_for(state: &AppState, row: &VendorAccountRow, app_type: &AppType) -> bool {
+    if row.provider_id.is_empty() {
+        return false;
+    }
+    ProviderService::current(state, app_type.clone())
+        .map(|current| current == row.provider_id)
+        .unwrap_or(false)
 }
 
 /// 开登录窗，等凭据回来，存成一行账号。
@@ -879,6 +903,54 @@ mod tests {
         r.vendor_id = "kimi".into();
         let dto = VendorAccountRow::from(r);
         assert_eq!(dto.vendor_name, "kimi", "认不出也要有个名字显示，不能空着");
+    }
+
+    // ─────────────── 当前在用：与中转站档位同源互斥 ───────────────
+
+    /// DeepSeek 行的「在用」必须与 `providers.is_current` 同源 —— 只有那样它才与
+    /// 中转站档位、手工 provider 一起互斥，一个 app 下只亮一个。
+    #[test]
+    fn is_current_tracks_the_providers_current_of_the_app() {
+        let db = std::sync::Arc::new(crate::database::Database::memory().expect("init db"));
+        let state = AppState::new(db.clone());
+
+        let in_use = VendorAccountRow::from(row("tok", "sk", Some("uuid-a")));
+        let idle = VendorAccountRow::from(row("tok", "sk", Some("uuid-b")));
+
+        db.save_provider(
+            "claude",
+            &crate::provider::Provider {
+                id: in_use.provider_id.clone(),
+                name: "DeepSeek".into(),
+                settings_config: serde_json::json!({}),
+                website_url: Some("https://platform.deepseek.com".into()),
+                category: Some("cn_official".into()),
+                created_at: None,
+                sort_index: Some(0),
+                notes: None,
+                meta: None,
+                icon: Some("deepseek".into()),
+                icon_color: None,
+                in_failover_queue: false,
+            },
+        )
+        .expect("save provider");
+        db.set_current_provider("claude", &in_use.provider_id)
+            .expect("set current");
+
+        assert!(is_current_for(&state, &in_use, &AppType::Claude));
+        assert!(!is_current_for(&state, &idle, &AppType::Claude));
+    }
+
+    /// 未登录的行（provider_id 为空）绝不能被判成当前项 ——
+    /// `ProviderService::current` 在无当前项时返回空串，空 == 空 会误判。
+    #[test]
+    fn an_unlogged_row_is_never_current() {
+        let db = std::sync::Arc::new(crate::database::Database::memory().expect("init db"));
+        let state = AppState::new(db.clone());
+        let never = VendorAccountRow::from(row("", "", None));
+        assert!(never.provider_id.is_empty());
+        assert!(!is_current_for(&state, &never, &AppType::Claude));
     }
 
     // ─────────────── meta ───────────────

--- a/src/components/operator/OperatorSection.tsx
+++ b/src/components/operator/OperatorSection.tsx
@@ -4,7 +4,7 @@ import { toast } from "sonner";
 import { Loader2, Plus } from "lucide-react";
 
 import { ConfirmDialog } from "@/components/ConfirmDialog";
-import { operatorApi, providersApi } from "@/lib/api";
+import { operatorApi } from "@/lib/api";
 import { PURCHASE_CLOSED_EVENT } from "@/lib/api/operator";
 import type { AppId, ProviderSwitchEvent } from "@/lib/api";
 import type {
@@ -179,17 +179,13 @@ export function OperatorSection({ appId }: OperatorSectionProps) {
   const [vendorBalances, setVendorBalances] = useState<
     Record<RowKey, string | null>
   >({});
-  // 当前 tab 正在用的 provider id。官网行靠它判「在用」（`isCurrent` 那个 DB 列
-  // 至今没有写入方，判不了当前态）。
-  const [currentProviderId, setCurrentProviderId] = useState<string | null>(
-    null,
-  );
   // 每个官网账号行对应的 provider id。**六个平台共用一个**，由 `vendor_provision`
   // 返回 —— 前端算不出（它是 `sha256(vendor_id + "/" + account_id)`，而行 DTO 里
   // 没有 account_id）。所以「切换」这条路必须先 provision 拿 id 再切。
   //
-  // **是 state 不是 ref**：「在用」高亮读它，ref 变了不会触发重渲染 ⇒ 高亮要等
-  // 下一次别的状态变化才浮现。
+  // **是 state 不是 ref**：切换时要在它里面找 id，变了得触发重渲染。
+  // ⚠️ 它不参与「在用」高亮 —— 那件事由后端 `vendor.list` 返回的 `isCurrent` 现算
+  // （与中转站档位同源），前端不再自维护当前态。
   const [vendorProviderIds, setVendorProviderIds] = useState<
     Record<number, string>
   >({});
@@ -224,10 +220,36 @@ export function OperatorSection({ appId }: OperatorSectionProps) {
   const { checkProvider, isChecking } = useStreamCheck(appId);
 
   /**
+   * 拉官网账号列表。**只读本地不发网络**（与 `listOperators` 同一条契约）。
+   *
+   * 在不支持 DeepSeek 的两个 tab（gemini / grokbuild）下**压根不调它** ——
+   * 那两个 tab 里官网行不该出现，拉回来也只能扔掉。
+   *
+   * `appId` 传给后端**只为算 `userEdited` / `isCurrent`**（一行背后六条 provider
+   * 记录，「改过没有」「是不是在用」必须按平台问）。**不是用它过滤行** —— 一把 sk
+   * 展开到全部平台，「这一行在哪些 tab 出现」仍由上面那个 `vendorSupportsApp` 判。
+   */
+  const reloadVendors = useCallback(async () => {
+    if (!vendorSupportsApp(appId)) {
+      setVendors([]);
+      return;
+    }
+    try {
+      setVendors(await vendorApi.list(appId));
+    } catch (e) {
+      toast.error(String(e));
+    }
+  }, [appId]);
+
+  /**
    * 读本地档位列表 + 异步补倍率。**不发 provision**（不重拉分组）。
    *
    * `onlySite` 限定只查哪个站的倍率 —— 每个档位一次 HTTP，用户给账号 A 获取
    * 密钥时不该把 B / C 的也全重查一遍。
+   *
+   * ⚠️ **顺带刷新官网账号列表**（见函数体末尾）：两类行的「当前在用」现在都由后端
+   * 现算（`tier.isCurrent` 与 vendor 的 `isCurrent` 同源），一次动作后必须把两类行
+   * 一起刷齐，否则切档位后 DeepSeek 行会停在旧高亮上（2026-08-07 修的互斥 bug）。
    */
   const reload = useCallback(
     async (onlySite?: string) => {
@@ -274,8 +296,11 @@ export function OperatorSection({ appId }: OperatorSectionProps) {
       } catch (e) {
         toast.error(String(e));
       }
+      // ⚠️ **官网行必须跟档位一起刷**（见上方 doc）：两类行的「当前在用」同源，
+      // 只刷一边就会让切完档位后 DeepSeek 行继续显示旧的「在用」高亮。
+      void reloadVendors();
     },
-    [appId],
+    [appId, reloadVendors],
   );
 
   useEffect(() => {
@@ -422,32 +447,6 @@ export function OperatorSection({ appId }: OperatorSectionProps) {
   // ══ 官网直连账号（vendor）══════════════════════════════════════════
 
   /**
-   * 拉官网账号列表。**只读本地不发网络**（与 `listOperators` 同一条契约）。
-   *
-   * 在不支持 DeepSeek 的两个 tab（gemini / grokbuild）下**压根不调它** ——
-   * 那两个 tab 里官网行不该出现，拉回来也只能扔掉。
-   *
-   * `appId` 传给后端**只为算 `userEdited`**（一行背后六条 provider 记录，「改过
-   * 没有」必须按平台问）。**不是用它过滤行** —— 一把 sk 展开到全部平台，
-   * 「这一行在哪些 tab 出现」仍由上面那个 `vendorSupportsApp` 判。
-   */
-  const reloadVendors = useCallback(async () => {
-    if (!vendorSupportsApp(appId)) {
-      setVendors([]);
-      return;
-    }
-    try {
-      setVendors(await vendorApi.list(appId));
-    } catch (e) {
-      toast.error(String(e));
-    }
-  }, [appId]);
-
-  useEffect(() => {
-    void reloadVendors();
-  }, [reloadVendors]);
-
-  /**
    * 一个站点都没有时自动弹「添加站点」引导。**每个进程只弹一次。**
    *
    * ## 判据为什么是「全局有没有站点」而不是这一区渲染出了几行
@@ -492,27 +491,6 @@ export function OperatorSection({ appId }: OperatorSectionProps) {
       cancelled = true;
     };
   }, []);
-
-  /**
-   * 读当前 tab 正在用的 provider id —— 官网行的「在用」高亮靠它。
-   *
-   * ⚠️ **不用行 DTO 的 `isCurrent`**：那个字段读的是 `loongport_vendor.is_current`
-   * 列，而 `vendor/creds.rs` 里**没有任何一处写这一列**（只有 `DEFAULT 0`）⇒
-   * 它恒为 false。真正的事实是「上游 providers 表里当前是哪条」，那才是切换命令
-   * 真正改的东西。
-   */
-  const reloadCurrentProvider = useCallback(async () => {
-    try {
-      setCurrentProviderId(await providersApi.getCurrent(appId));
-    } catch {
-      // 拿不到只是判不出「在用」高亮，不该打断主流程。
-      setCurrentProviderId(null);
-    }
-  }, [appId]);
-
-  useEffect(() => {
-    void reloadCurrentProvider();
-  }, [reloadCurrentProvider]);
 
   /**
    * 拉一行官网账号的余额。
@@ -742,7 +720,8 @@ export function OperatorSection({ appId }: OperatorSectionProps) {
               : t("loongport.switch.done", { name }),
         );
         for (const w of r.warnings) toast.warning(w);
-        await reloadCurrentProvider();
+        // 切到官网行会同时改两类行的「在用」：`reload` 顺带刷 vendors（见其 doc）。
+        await reload();
       } catch (e) {
         toast.error(String(e));
       }
@@ -763,9 +742,9 @@ export function OperatorSection({ appId }: OperatorSectionProps) {
           delete next[row.id];
           return next;
         });
-        await reloadVendors();
-        // 删掉的可能正是当前在用的那条 ⇒ 重读一次，否则高亮会停在一个不存在的行上。
-        await reloadCurrentProvider();
+        // 删掉的可能正是当前在用的那条 ⇒ 全量重读（`reload` 顺带刷 vendors），
+        // 否则高亮会停在一个不存在的行上。
+        await reload();
       } catch (e) {
         toast.error(String(e));
       }
@@ -787,26 +766,19 @@ export function OperatorSection({ appId }: OperatorSectionProps) {
   /**
    * 这一行的配置是不是当前 tab 正在用的那个。
    *
-   * **provider id 优先取行 DTO 的 `providerId`**（后端用
-   * `provision::provider_id_for(vendor_id, account_id)` 派生，前端算不出来）——
-   * 那让高亮在 **app 重启后依然正确**。
+   * ⚠️ **直接读后端算好的 `isCurrent`** —— `vendorApi.list(appId)` 返回的 DTO 里，
+   * 后端已按 `providers.is_current` 现算（与中转站档位的 `tier.isCurrent` 同源）。
+   * 前端**不再自维护 / 不自比较** current 值 —— 曾经历过「前端自己算 current」导致
+   * 切档位后 DeepSeek 行高亮停在上一个值、与档位同时显示「在用」的 bug（2026-08-07）。
    *
-   * 回落到 `vendorProviderIds`（本次会话 provision 返回的）只为覆盖一种情形：
-   * 行还没登录过 ⇒ 没有 `account_id` ⇒ 后端给空串。那种行本来也不该高亮。
-   *
-   * ⚠️ **不用行 DTO 的 `isCurrent`** —— 那个字段读的是 `loongport_vendor.is_current`
-   * 列，而**没有任何代码写过那一列**（只有建表的 `DEFAULT 0`）⇒ 恒 false。
-   * 当前态的唯一事实源是 `providers` 表（上游 `ProviderService::current`）。
-   *
-   * 空 id 一律不高亮 —— 猜错会让两行同时显示「在用」，比不高亮更糟。
+   * 空 id / 未登录的行后端给 `false` —— 那种行本来也不该高亮。
    */
   const isVendorCurrent = useCallback(
     (rowId: number) => {
       const row = vendors.find((v) => v.id === rowId);
-      const providerId = row?.providerId || vendorProviderIds[rowId];
-      return !!providerId && providerId === currentProviderId;
+      return row?.isCurrent ?? false;
     },
-    [vendors, vendorProviderIds, currentProviderId],
+    [vendors],
   );
 
   const handleLogin = (operatorId: number) =>

--- a/src/lib/api/vendor.ts
+++ b/src/lib/api/vendor.ts
@@ -43,11 +43,22 @@ export interface VendorAccountRow {
    *
    * 由后端派生（`sha256(vendorId + "/" + accountId)`）——
    * **前端算不出来**：DTO 有意不给 accountId，也没有 sha256。
-   * 官网行的「当前在用」高亮靠它与 `providersApi.getCurrent(appId)` 比。
+   *
+   * ⚠️ **不再用它判「当前在用」** —— 那件事改由下面的 `isCurrent`（后端现算）
+   * 表达。它只在「编辑 / 恢复默认 / 切换」时用（这几条命令吃 providerId）。
    *
    * 空串 = 还没登录过（没有 accountId 就派生不出 id）。
    */
   providerId: string;
+  /**
+   * **当前 tab 那个 app** 下，这一行是不是正在用的那个。
+   *
+   * 由后端按 `appId` 现算（判据与中转站档位的 `isCurrent` 同源 —— 都是
+   * `providers` 表的 `is_current`）。**前端不自己维护、也不拿它跟别的值比较**。
+   * 所以 DeepSeek 官网组与中转站档位 / 手工 provider 共享同一份互斥：
+   * 一个 app 下永远只有一个「在用」。
+   */
+  isCurrent: boolean;
   /**
    * **当前 tab 那个平台**的配置是不是被用户改过（`vendorApi.list` 的 `appId`）。
    *

--- a/tests/components/vendorTierEditing.test.ts
+++ b/tests/components/vendorTierEditing.test.ts
@@ -103,7 +103,9 @@ describe("编辑流程复用 useTierEditGuard", () => {
   it("保存失败仍然 throw —— 不能只 toast", () => {
     // `EditProviderDialog` 是 `await onSubmit(); onOpenChange(false)`：
     // 吃掉错误会让它照常关窗，用户刚敲的一屏配置全丢。
-    expect(EDIT_GUARD).toMatch(/toast\.error\(String\(e\)\);\s*\n\s*\/\/[^\n]*\n\s*throw e;/);
+    expect(EDIT_GUARD).toMatch(
+      /toast\.error\(String\(e\)\);\s*\n\s*\/\/[^\n]*\n\s*throw e;/,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary / 概述

修复：同一 app 内 DeepSeek ↔ 供应商来回切换后，**两个组同时显示"在用"**。

**根因**：同一 app 的"当前在用"被拆成两个前端事实源——
- 中转站档位 / cc-switch 默认组的高亮走 `providers.is_current`（后端 `listOperators` 现算）
- DeepSeek 官网行的高亮走前端自维护的 `currentProviderId`，**只在挂载与 DeepSeek 行切换时刷新**

于是从 DeepSeek 切到某个供应商（或经托盘 / deeplink 旁路）后，DeepSeek 行高亮停在旧值，与档位同时显示"在用"。

**修复：收敛到单一事实源**（方向 2，非补丁）。
- `vendor_list_accounts` 新增 `is_current` 字段，按 `providers.is_current` 现算 —— 与 `tier.isCurrent` **同源**
- 前端删除 `currentProviderId` state 与 `reloadCurrentProvider`，`isVendorCurrent` 直接读后端值
- `reload()` 顺带刷新官网行，一次动作把两类行刷齐

修复后，一个 app 下所有组（DeepSeek 官方组 / 中转站档位 / cc-switch 默认组）共享同一份互斥，只亮一个。

## Related Issue / 关联 Issue

无关联 Issue（修复来自用户实测反馈）。

Fixes #

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| 切换后两个组都显示"在用" | 只亮当前那一个 |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查（`tsc --noEmit` exit 0）
- [x] `pnpm format:check` passes / 通过代码格式检查（`prettier --check` exit 0）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（`clippy --all-targets -- -D warnings` exit 0）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（本次未改用户可见文案，无需更新）

补充：`cargo test` 全量通过（2659 个测试，含新增 2 个）；`vitest run` 通过（112 files / 703 tests）。CLAUDE.md §四 六道闸全部本地验证过。
