### PR TITLE
refactor(events): 跨语言事件名收敛到唯一数据源 + 一致性闸

### DIFF
--- a/src-tauri/src/commands/failover.rs
+++ b/src-tauri/src/commands/failover.rs
@@ -3,6 +3,7 @@
 //! 管理代理模式下的故障转移队列（基于 providers 表的 in_failover_queue 字段）
 
 use crate::database::FailoverQueueItem;
+use crate::events::PROVIDER_SWITCHED;
 use crate::provider::Provider;
 use crate::store::AppState;
 use std::str::FromStr;
@@ -201,7 +202,7 @@ pub async fn set_auto_failover_enabled(
             "providerId": p1_provider_id,
             "source": "failoverEnabled"
         });
-        let _ = app.emit("provider-switched", event_data);
+        let _ = app.emit(PROVIDER_SWITCHED, event_data);
     }
 
     // 刷新托盘菜单，确保状态同步

--- a/src-tauri/src/commands/operator.rs
+++ b/src-tauri/src/commands/operator.rs
@@ -35,6 +35,7 @@ use tauri::{Emitter, Manager, State};
 
 use crate::app_config::AppType;
 use crate::error::AppError;
+use crate::events::PURCHASE_CLOSED;
 use crate::operator::{api, chatgpt_app, creds, login, provision, purchase};
 use crate::provider::Provider;
 use crate::services::{McpService, ProviderService};
@@ -2217,7 +2218,7 @@ async fn open_purchase_window(
     // 只 emit 事件、不在这里查余额：查余额要发 HTTP，而这个回调不能 await。
     window.on_window_event(move |event| {
         if matches!(event, tauri::WindowEvent::Destroyed) {
-            let _ = handle_for_close.emit(PURCHASE_CLOSED_EVENT, closed_operator_id);
+            let _ = handle_for_close.emit(PURCHASE_CLOSED, closed_operator_id);
         }
     });
 
@@ -2443,13 +2444,6 @@ fn backup_codex_auth(auth_path: &std::path::Path) -> Result<Option<String>, AppE
     crate::config::copy_file(auth_path, &dest)?;
     Ok(Some(dest.to_string_lossy().to_string()))
 }
-
-/// 充值窗关闭的事件名。**payload 是 `operator_id`（i64）** —— 前端据此只刷那一行的余额。
-///
-/// 提成常量是因为它是跨语言契约：前端 `useTauriEvent(PURCHASE_CLOSED_EVENT, ...)` 那边
-/// 写的是同一个字符串，两处各写一遍字面量的话，改名时会变成「关窗后余额永远不刷」——
-/// 而那是个静默失效，没有任何东西会报错。
-pub const PURCHASE_CLOSED_EVENT: &str = "operator-purchase-closed";
 
 /// 这条 provider 是不是 LoongPort 管的。
 ///

--- a/src-tauri/src/commands/profile.rs
+++ b/src-tauri/src/commands/profile.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use tauri::{Emitter, Manager, State};
 
 use crate::database::Profile;
+use crate::events::{PROFILE_APPLIED, PROVIDER_SWITCHED};
 use crate::services::profile::{ProfilePayload, ProfileScope, ProfileService};
 use crate::store::AppState;
 
@@ -79,15 +80,15 @@ pub fn emit_profile_apply_events(
             "autoFailoverEnabled": auto_failover_enabled,
             "providerId": provider_id,
         });
-        if let Err(e) = app.emit("provider-switched", event_data) {
-            log::error!("发射 provider-switched 事件失败: {e}");
+        if let Err(e) = app.emit(PROVIDER_SWITCHED, event_data) {
+            log::error!("发射 {PROVIDER_SWITCHED} 事件失败: {e}");
         }
     }
     if let Err(e) = app.emit(
-        "profile-applied",
+        PROFILE_APPLIED,
         serde_json::json!({ "profileId": profile_id, "scope": scope.as_str() }),
     ) {
-        log::error!("发射 profile-applied 事件失败: {e}");
+        log::error!("发射 {PROFILE_APPLIED} 事件失败: {e}");
     }
     crate::tray::refresh_tray_menu(app);
 }

--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -5,6 +5,7 @@ use crate::app_config::AppType;
 use crate::commands::copilot::CopilotAuthState;
 use crate::commands::xai_oauth::XaiOAuthState;
 use crate::error::AppError;
+use crate::events::{PROVIDER_SWITCHED, UNIVERSAL_PROVIDER_SYNCED, USAGE_CACHE_UPDATED};
 use crate::provider::{ClaudeDesktopMode, Provider};
 use crate::services::{
     EndpointLatency, ProviderService, ProviderSortUpdate, SpeedtestService, SwitchResult,
@@ -293,10 +294,10 @@ pub(crate) fn emit_provider_switched(
         "appType": app_type.as_str(),
         "providerId": provider_id,
     });
-    if let Err(e) = app_handle.emit("provider-switched", payload) {
+    if let Err(e) = app_handle.emit(PROVIDER_SWITCHED, payload) {
         // 发不出去只是界面不刷新（用户重开面板就好），不该让切换本身失败 ——
         // 配置已经写进去了，报错会让用户以为没切成功而再切一次。
-        log::warn!("发射 provider-switched 事件失败: {e}");
+        log::warn!("发射 {PROVIDER_SWITCHED} 事件失败: {e}");
     }
 }
 
@@ -908,8 +909,8 @@ pub async fn queryProviderUsage(
             "providerId": &providerId,
             "data": snapshot,
         });
-        if let Err(e) = app_handle.emit("usage-cache-updated", payload) {
-            log::error!("emit usage-cache-updated (script) 失败: {e}");
+        if let Err(e) = app_handle.emit(USAGE_CACHE_UPDATED, payload) {
+            log::error!("emit {USAGE_CACHE_UPDATED} (script) 失败: {e}");
         }
         state
             .usage_cache
@@ -1302,7 +1303,7 @@ pub struct UniversalProviderSyncedEvent {
 
 fn emit_universal_provider_synced(app: &AppHandle, action: &str, id: &str) {
     let _ = app.emit(
-        "universal-provider-synced",
+        UNIVERSAL_PROVIDER_SYNCED,
         UniversalProviderSyncedEvent {
             action: action.to_string(),
             id: id.to_string(),

--- a/src-tauri/src/commands/subscription.rs
+++ b/src-tauri/src/commands/subscription.rs
@@ -29,8 +29,11 @@ pub async fn get_subscription_quota(
                 "appType": app_type.as_str(),
                 "data": snapshot,
             });
-            if let Err(e) = app.emit("usage-cache-updated", payload) {
-                log::error!("emit usage-cache-updated (subscription) 失败: {e}");
+            if let Err(e) = app.emit(crate::events::USAGE_CACHE_UPDATED, payload) {
+                log::error!(
+                    "emit {} (subscription) 失败: {e}",
+                    crate::events::USAGE_CACHE_UPDATED
+                );
             }
             state
                 .usage_cache

--- a/src-tauri/src/commands/vendor.rs
+++ b/src-tauri/src/commands/vendor.rs
@@ -30,17 +30,11 @@ use tauri::{Emitter, Manager, State};
 
 use crate::app_config::AppType;
 use crate::error::AppError;
+use crate::events::VENDOR_LOGIN_ERROR;
 use crate::provider::Provider;
 use crate::services::ProviderService;
 use crate::store::AppState;
 use crate::vendor::{creds, deepseek, provision, Vendor, VendorError};
-
-/// 登录出错时发给前端的事件名。
-///
-/// 提成常量是因为它是**跨语言契约**：前端 `useTauriEvent` 那边写同一个字符串，
-/// 两处各写一遍字面量的话，改名会变成「登录失败永远没有提示」——
-/// 而那是个静默失效，没有任何东西会报错（同型于 `PURCHASE_CLOSED_EVENT`）。
-pub const LOGIN_ERROR_EVENT: &str = "vendor-login-error";
 
 /// 等用户走完登录流程的上限。5 分钟够走完注册 + 短信验证码 + 微信扫码。
 ///
@@ -333,7 +327,7 @@ async fn do_login(
             }
             Some(Err(e)) => {
                 log::warn!("官网凭据回传解析失败: {e}");
-                let _ = handle_for_nav.emit(LOGIN_ERROR_EVENT, e.to_string());
+                let _ = handle_for_nav.emit(VENDOR_LOGIN_ERROR, e.to_string());
                 false
             }
         }
@@ -1134,9 +1128,9 @@ mod tests {
     /// 事件名是跨语言契约（前端 `useTauriEvent` 写同一个字符串）。
     #[test]
     fn the_login_error_event_name_is_stable() {
-        assert_eq!(LOGIN_ERROR_EVENT, "vendor-login-error");
+        assert_eq!(VENDOR_LOGIN_ERROR, "vendor-login-error");
         assert_ne!(
-            LOGIN_ERROR_EVENT, "operator-login-error",
+            VENDOR_LOGIN_ERROR, "operator-login-error",
             "两个登录窗各发自己的事件，撞名会让中转站的弹窗显示官网的错"
         );
     }

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -1,0 +1,89 @@
+//! 跨语言 Tauri 事件名的**唯一定义**（Rust 侧）。
+//!
+//! 前端有一份逐字一致的副本：`src/lib/api/events.ts`。本模块底部的一致性闸用
+//! `include_str!` 读那份 TS 文件逐个比对 —— 不一致会**测试红**，不会静默失效。
+//!
+//! ## 为什么单独一个模块（而不是散在各 emit 点所在的文件）
+//!
+//! 事件名是**跨文件、跨语言**的契约：Rust 侧要 emit、前端要 listen，两边的字符串
+//! 一旦分叉，界面就不刷新 / 弹错窗口，且编译过、测试绿、没有任何报错
+//! （CLAUDE.md §三点六 的"同一事实散在多处 = 静默失效"）。
+//!
+//! 历史教训：`provider-switched` 曾散在 7 处 Rust emit + 3 处前端监听，全是裸字面量，
+//! 没有任何东西守住它们一致。收进这里后，加新事件 = 两端各加一个常量 + 闸自动守。
+//!
+//! ## 什么时候该进这个模块
+//!
+//! **只在 Rust 侧 emit、前端不监听**的事件名（如 `proxy-flags-changed`、
+//! `operator-login-error`）**不要进** —— 单侧事实没有分叉风险，收进来只是噪音
+//! （尺子 2：不为不存在的跨语言契约预建）。判断标准：跨语言 = Rust emit + 前端 listen
+//! 两侧都有。
+
+/// 当前供应商切换后通知前端（`providersApi.onSwitched` / `OperatorSection` 监听）。
+pub const PROVIDER_SWITCHED: &str = "provider-switched";
+/// 项目应用完成后的统一收尾事件（`App.tsx` / `PromptPanel` 监听）。
+pub const PROFILE_APPLIED: &str = "profile-applied";
+/// 用量缓存写入后通知前端 React Query 失效（`useUsageCacheBridge` 监听）。
+pub const USAGE_CACHE_UPDATED: &str = "usage-cache-updated";
+/// 使用日志写入后通知前端（`useUsageEventBridge` 监听）。原定义在
+/// `usage_events::EVENT_USAGE_LOG_RECORDED`，迁入本模块统一管理。
+pub const USAGE_LOG_RECORDED: &str = "usage-log-recorded";
+/// deeplink 导入请求（`DeepLinkImportDialog` 监听）。
+pub const DEEPLINK_IMPORT: &str = "deeplink-import";
+/// 统一供应商同步完成（`App.tsx` 监听）。
+pub const UNIVERSAL_PROVIDER_SYNCED: &str = "universal-provider-synced";
+/// WebDAV 云同步状态变化（`App.tsx` 监听）。
+pub const WEBDAV_SYNC_STATUS_UPDATED: &str = "webdav-sync-status-updated";
+/// S3 云同步状态变化（`App.tsx` 监听）。
+pub const S3_SYNC_STATUS_UPDATED: &str = "s3-sync-status-updated";
+/// 充值窗关闭（`OperatorSection` 监听）。原名 `commands::operator::PURCHASE_CLOSED_EVENT`。
+pub const PURCHASE_CLOSED: &str = "operator-purchase-closed";
+/// 官网直连登录窗凭据解析失败（`OperatorSection` 监听）。原名
+/// `commands::vendor::LOGIN_ERROR_EVENT`。
+pub const VENDOR_LOGIN_ERROR: &str = "vendor-login-error";
+
+#[cfg(test)]
+mod consistency_tests {
+    /// 前后端各存一份的事件名**必须逐字一致**。
+    ///
+    /// 跨语言编译器管不到 `.ts`，不一致时不报错、不崩溃 —— 只是事件发出去前端收不到、
+    /// 界面不刷新。这道闸把那类问题从「静默失效」变成「测试红」。
+    ///
+    /// **新增跨语言事件时往下面的表里加一行。** 判据（CLAUDE.md §三点六）：
+    /// 凡「同一事实同时存在于 Rust 与非 Rust 文件」，就该在这里对上。
+    /// 形状照 `config.rs::brand_constant_consistency::frontend_copies_match`。
+    #[test]
+    fn frontend_copies_match() {
+        let ts = include_str!("../../src/lib/api/events.ts");
+
+        // (TS 里的常量名, Rust 侧的值)
+        let pairs: &[(&str, &str)] = &[
+            ("PROVIDER_SWITCHED", super::PROVIDER_SWITCHED),
+            ("PROFILE_APPLIED", super::PROFILE_APPLIED),
+            ("USAGE_CACHE_UPDATED", super::USAGE_CACHE_UPDATED),
+            ("USAGE_LOG_RECORDED", super::USAGE_LOG_RECORDED),
+            ("DEEPLINK_IMPORT", super::DEEPLINK_IMPORT),
+            (
+                "UNIVERSAL_PROVIDER_SYNCED",
+                super::UNIVERSAL_PROVIDER_SYNCED,
+            ),
+            (
+                "WEBDAV_SYNC_STATUS_UPDATED",
+                super::WEBDAV_SYNC_STATUS_UPDATED,
+            ),
+            ("S3_SYNC_STATUS_UPDATED", super::S3_SYNC_STATUS_UPDATED),
+            ("PURCHASE_CLOSED", super::PURCHASE_CLOSED),
+            ("VENDOR_LOGIN_ERROR", super::VENDOR_LOGIN_ERROR),
+        ];
+
+        for (ts_name, rust_value) in pairs {
+            let expected = format!("{ts_name} = \"{rust_value}\"");
+            assert!(
+                ts.contains(&expected),
+                "src/lib/api/events.ts 的 {ts_name} 与 Rust 侧不一致\n  \
+                 Rust 侧的值: {rust_value}\n  \
+                 期望 TS 里出现: {expected}"
+            );
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -42,6 +42,7 @@ mod store;
 #[cfg(test)]
 mod support_matrix;
 
+mod events;
 mod tray;
 mod usage_events;
 mod usage_script;
@@ -269,7 +270,7 @@ fn handle_deeplink_url(
                 request.name
             );
 
-            if let Err(e) = app.emit("deeplink-import", &request) {
+            if let Err(e) = app.emit(crate::events::DEEPLINK_IMPORT, &request) {
                 log::error!("✗ Failed to emit deeplink-import event: {e}");
             } else {
                 log::info!("✓ Emitted deeplink-import event to frontend");
@@ -1974,7 +1975,7 @@ pub fn run() {
                                     );
 
                                     if let Err(e) =
-                                        app_handle.emit("deeplink-import", &request)
+                                        app_handle.emit(crate::events::DEEPLINK_IMPORT, &request)
                                     {
                                         log::error!(
                                             "Failed to emit deep link event from RunEvent::Opened: {e}"

--- a/src-tauri/src/proxy/failover_switch.rs
+++ b/src-tauri/src/proxy/failover_switch.rs
@@ -7,6 +7,7 @@
 
 use crate::database::Database;
 use crate::error::AppError;
+use crate::events::PROVIDER_SWITCHED;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tauri::{Emitter, Manager};
@@ -125,8 +126,8 @@ impl FailoverSwitchManager {
                 "providerId": provider_id,
                 "source": "failover"  // 标识来源是故障转移
             });
-            if let Err(e) = app.emit("provider-switched", event_data) {
-                log::error!("[Failover] 发射事件失败: {e}");
+            if let Err(e) = app.emit(PROVIDER_SWITCHED, event_data) {
+                log::error!("[Failover] 发射 {PROVIDER_SWITCHED} 事件失败: {e}");
             }
         }
 

--- a/src-tauri/src/services/s3_auto_sync.rs
+++ b/src-tauri/src/services/s3_auto_sync.rs
@@ -98,7 +98,7 @@ fn emit_auto_sync_status_updated(app: &AppHandle, status: &str, error: Option<&s
         }),
     };
 
-    if let Err(err) = app.emit("s3-sync-status-updated", payload) {
+    if let Err(err) = app.emit(crate::events::S3_SYNC_STATUS_UPDATED, payload) {
         log::debug!("[S3] failed to emit sync status update event: {err}");
     }
 }

--- a/src-tauri/src/services/webdav_auto_sync.rs
+++ b/src-tauri/src/services/webdav_auto_sync.rs
@@ -98,7 +98,7 @@ fn emit_auto_sync_status_updated(app: &AppHandle, status: &str, error: Option<&s
         }),
     };
 
-    if let Err(err) = app.emit("webdav-sync-status-updated", payload) {
+    if let Err(err) = app.emit(crate::events::WEBDAV_SYNC_STATUS_UPDATED, payload) {
         log::debug!("[WebDAV] failed to emit sync status update event: {err}");
     }
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -9,6 +9,7 @@ use tauri_plugin_opener::OpenerExt;
 
 use crate::app_config::AppType;
 use crate::error::AppError;
+use crate::events::{PROFILE_APPLIED, PROVIDER_SWITCHED};
 use crate::store::AppState;
 
 use crate::config::OFFICIAL_WEBSITE;
@@ -420,10 +421,10 @@ pub fn handle_profile_tray_event(app: &tauri::AppHandle, event_id: &str) -> bool
         }
         // 通知主窗口刷新（profileId=null 表示该分组已清除当前项目）
         if let Err(e) = app.emit(
-            "profile-applied",
+            PROFILE_APPLIED,
             serde_json::json!({ "profileId": null, "scope": scope.as_str() }),
         ) {
-            log::error!("发射 profile-applied 事件失败: {e}");
+            log::error!("发射 {PROFILE_APPLIED} 事件失败: {e}");
         }
         refresh_tray_menu(app);
         return true;
@@ -602,8 +603,8 @@ fn handle_auto_click(app: &tauri::AppHandle, app_type: &AppType) -> Result<(), A
             log::error!("发射 proxy-flags-changed 事件失败: {e}");
         }
         // 发射 provider-switched 事件（保持向后兼容，Auto 切换也算一种切换）
-        if let Err(e) = app.emit("provider-switched", event_data) {
-            log::error!("发射 provider-switched 事件失败: {e}");
+        if let Err(e) = app.emit(PROVIDER_SWITCHED, event_data) {
+            log::error!("发射 {PROVIDER_SWITCHED} 事件失败: {e}");
         }
     }
     Ok(())
@@ -646,8 +647,8 @@ fn handle_provider_click(
             log::error!("发射 proxy-flags-changed 事件失败: {e}");
         }
         // 发射 provider-switched 事件（保持向后兼容）
-        if let Err(e) = app.emit("provider-switched", event_data) {
-            log::error!("发射 provider-switched 事件失败: {e}");
+        if let Err(e) = app.emit(PROVIDER_SWITCHED, event_data) {
+            log::error!("发射 {PROVIDER_SWITCHED} 事件失败: {e}");
         }
     }
     Ok(())

--- a/src-tauri/src/usage_events.rs
+++ b/src-tauri/src/usage_events.rs
@@ -16,8 +16,7 @@ use std::time::Duration;
 
 use tauri::{AppHandle, Emitter};
 
-/// 前端监听的事件名
-pub const EVENT_USAGE_LOG_RECORDED: &str = "usage-log-recorded";
+use crate::events::USAGE_LOG_RECORDED;
 
 /// 防抖窗口：合并 200ms 内的多次通知。
 const DEBOUNCE_WINDOW: Duration = Duration::from_millis(200);
@@ -64,8 +63,8 @@ pub fn notify_log_recorded() {
         // 下一轮防抖窗口会重新调度，不会丢失。
         EMIT_SCHEDULED.store(false, Ordering::Release);
 
-        if let Err(e) = handle.emit(EVENT_USAGE_LOG_RECORDED, ()) {
-            log::warn!("emit {EVENT_USAGE_LOG_RECORDED} 失败: {e}");
+        if let Err(e) = handle.emit(USAGE_LOG_RECORDED, ()) {
+            log::warn!("emit {USAGE_LOG_RECORDED} 失败: {e}");
         }
     });
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,10 @@ import { proxyKeys, useProvidersQuery, useSettingsQuery } from "@/lib/query";
 import {
   providersApi,
   settingsApi,
+  PROFILE_APPLIED,
+  S3_SYNC_STATUS_UPDATED,
+  UNIVERSAL_PROVIDER_SYNCED,
+  WEBDAV_SYNC_STATUS_UPDATED,
   type AppId,
   type ProviderSwitchEvent,
 } from "@/lib/api";
@@ -384,7 +388,7 @@ function App() {
     };
   }, [activeApp, refetch]);
 
-  useTauriEvent("universal-provider-synced", async () => {
+  useTauriEvent(UNIVERSAL_PROVIDER_SYNCED, async () => {
     await queryClient.invalidateQueries({ queryKey: ["providers"] });
     try {
       await providersApi.updateTrayMenu();
@@ -395,7 +399,7 @@ function App() {
 
   // 应用项目后刷新相关缓存（providers 由既有 provider-switched 监听承接；
   // proxy 状态由后端直接改 DB，不走 mutation，必须显式刷新）
-  useTauriEvent("profile-applied", async () => {
+  useTauriEvent(PROFILE_APPLIED, async () => {
     await queryClient.invalidateQueries({ queryKey: ["profiles"] });
     await queryClient.invalidateQueries({ queryKey: ["mcp", "all"] });
     await queryClient.invalidateQueries({ queryKey: ["skills"] });
@@ -409,7 +413,7 @@ function App() {
   });
 
   useTauriEvent<SyncStatusUpdatedPayload | null | undefined>(
-    "webdav-sync-status-updated",
+    WEBDAV_SYNC_STATUS_UPDATED,
     async (payload) => {
       const statusPayload = payload ?? {};
       await queryClient.invalidateQueries({ queryKey: ["settings"] });
@@ -425,7 +429,7 @@ function App() {
   );
 
   useTauriEvent<SyncStatusUpdatedPayload | null | undefined>(
-    "s3-sync-status-updated",
+    S3_SYNC_STATUS_UPDATED,
     async (payload) => {
       const statusPayload = payload ?? {};
       await queryClient.invalidateQueries({ queryKey: ["settings"] });

--- a/src/components/DeepLinkImportDialog.tsx
+++ b/src/components/DeepLinkImportDialog.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from "react";
 import { listen } from "@tauri-apps/api/event";
+import { DEEPLINK_IMPORT } from "@/lib/api/events";
 import { DeepLinkImportRequest, deeplinkApi } from "@/lib/api/deeplink";
 import { parseDeepLinkConfigPreview } from "@/utils/deepLinkConfigPreview";
 import {
@@ -60,7 +61,7 @@ export function DeepLinkImportDialog() {
   useEffect(() => {
     // Listen for deep link import events
     const unlistenImport = listen<DeepLinkImportRequest>(
-      "deeplink-import",
+      DEEPLINK_IMPORT,
       async (event) => {
         // If config is present, merge it to get the complete configuration
         if (event.payload.config || event.payload.configUrl) {

--- a/src/components/operator/OperatorSection.tsx
+++ b/src/components/operator/OperatorSection.tsx
@@ -4,8 +4,12 @@ import { toast } from "sonner";
 import { Loader2, Plus } from "lucide-react";
 
 import { ConfirmDialog } from "@/components/ConfirmDialog";
-import { operatorApi } from "@/lib/api";
-import { PURCHASE_CLOSED_EVENT } from "@/lib/api/operator";
+import {
+  operatorApi,
+  PURCHASE_CLOSED,
+  VENDOR_LOGIN_ERROR,
+  PROVIDER_SWITCHED,
+} from "@/lib/api";
 import type { AppId, ProviderSwitchEvent } from "@/lib/api";
 import type {
   OperatorRow as OperatorRowData,
@@ -17,7 +21,6 @@ import {
   vendorSupportsApp,
   DEEPSEEK_API_KEYS_URL,
   DEEPSEEK_VENDOR_ID,
-  VENDOR_LOGIN_ERROR_EVENT,
   type VendorAccountRow,
 } from "@/lib/api/vendor";
 import { useStreamCheck } from "@/hooks/useStreamCheck";
@@ -369,7 +372,7 @@ export function OperatorSection({ appId }: OperatorSectionProps) {
    *
    * payload 带 operatorId，所以只刷那一行，不整页 reload（那会连带重查所有倍率）。
    */
-  useTauriEvent<number | null>(PURCHASE_CLOSED_EVENT, (operatorId) => {
+  useTauriEvent<number | null>(PURCHASE_CLOSED, (operatorId) => {
     if (typeof operatorId !== "number") return;
     const row = operatorsRef.current.find((op) => op.id === operatorId);
     // 行已经不在了（用户删掉了它）就别拉 —— 那次请求必然报错，且没有地方显示结果。
@@ -394,7 +397,7 @@ export function OperatorSection({ appId }: OperatorSectionProps) {
    * 不过滤会让「切 claude 的供应商」也触发 codex 这一区重新拉一遍 ——
    * 多余的网络请求（每个档位一次倍率查询）。
    */
-  useTauriEvent<ProviderSwitchEvent>("provider-switched", (payload) => {
+  useTauriEvent<ProviderSwitchEvent>(PROVIDER_SWITCHED, (payload) => {
     if (payload?.appType !== appId) return;
     void reload();
   });
@@ -534,7 +537,7 @@ export function OperatorSection({ appId }: OperatorSectionProps) {
    * **必须报出来**：这条路径上用户看到的现象是「走完登录流程，界面什么都没发生」——
    * 不说的话他会反复重登。事件名是 vendor 自己那条（与 operator 有意不同）。
    */
-  useTauriEvent<string>(VENDOR_LOGIN_ERROR_EVENT, (message) => {
+  useTauriEvent<string>(VENDOR_LOGIN_ERROR, (message) => {
     toast.error(t("loongport.vendor.loginFailed", { reason: message }));
   });
 

--- a/src/components/prompts/PromptPanel.tsx
+++ b/src/components/prompts/PromptPanel.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FileText } from "lucide-react";
-import { type AppId } from "@/lib/api";
+import { type AppId, PROFILE_APPLIED } from "@/lib/api";
 import { usePromptActions } from "@/hooks/usePromptActions";
 import { useTauriEvent } from "@/hooks/useTauriEvent";
 import PromptListItem from "./PromptListItem";
@@ -61,7 +61,7 @@ const PromptPanel = React.forwardRef<PromptPanelHandle, PromptPanelProps>(
     }, [appId, reload]);
 
     // 应用项目 Profile 会切换激活的 prompt（prompts 非 react-query，需主动 reload）
-    useTauriEvent("profile-applied", reload);
+    useTauriEvent(PROFILE_APPLIED, reload);
 
     const handleAdd = () => {
       setEditingId(null);

--- a/src/hooks/useUsageCacheBridge.ts
+++ b/src/hooks/useUsageCacheBridge.ts
@@ -1,4 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
+import { USAGE_CACHE_UPDATED } from "@/lib/api/events";
 import type { AppId } from "@/lib/api/types";
 import type { UsageResult } from "@/types";
 import type { SubscriptionQuota } from "@/types/subscription";
@@ -27,7 +28,7 @@ type UsageCacheUpdatedPayload =
 export function useUsageCacheBridge() {
   const queryClient = useQueryClient();
 
-  useTauriEvent<UsageCacheUpdatedPayload>("usage-cache-updated", (payload) => {
+  useTauriEvent<UsageCacheUpdatedPayload>(USAGE_CACHE_UPDATED, (payload) => {
     if (payload.kind === "script") {
       queryClient.setQueryData<UsageResult>(
         usageKeys.script(payload.providerId, payload.appType),

--- a/src/hooks/useUsageEventBridge.ts
+++ b/src/hooks/useUsageEventBridge.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useQueryClient } from "@tanstack/react-query";
+import { USAGE_LOG_RECORDED } from "@/lib/api/events";
 import { usageKeys } from "@/lib/query/usage";
 
 /**
@@ -20,7 +21,7 @@ export function useUsageEventBridge() {
     let disposed = false;
 
     (async () => {
-      const off = await listen("usage-log-recorded", () => {
+      const off = await listen(USAGE_LOG_RECORDED, () => {
         // invalidate 整个 usage 命名空间：summary / trends / providerStats /
         // modelStats / logs 全部跟着重拉
         queryClient.invalidateQueries({ queryKey: usageKeys.all });

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -1,0 +1,42 @@
+/**
+ * 跨语言 Tauri 事件名的**唯一定义**（前端侧）。
+ *
+ * Rust 侧有一份逐字一致的副本：`src-tauri/src/events.rs`，其一致性闸用
+ * `include_str!` 读本文件逐个比对 —— 两边分叉会**测试红**，不会静默失效。
+ *
+ * ⚠️ **改这里的值必须同步改 `src-tauri/src/events.rs` 对应常量**，否则 Rust 侧
+ * 的 `events::consistency_tests::frontend_copies_match` 会红。
+ *
+ * ## 为什么单独一个文件（而不是散在各 api 模块）
+ *
+ * 事件名是跨文件、跨语言的契约：Rust 侧 emit、前端 listen，两边的字符串一旦分叉，
+ * 界面就不刷新 / 弹错窗口，且编译过、测试绿、没有任何报错（CLAUDE.md §三点六）。
+ * 历史教训：`provider-switched` 曾散在 7 处 Rust emit + 3 处前端监听，全是裸字面量。
+ * 收进这里后，加新事件 = 两端各加一个常量 + 闸自动守。
+ *
+ * ## 什么时候该进这个文件
+ *
+ * **只在 Rust 侧 emit、前端不监听**的事件名不要进 —— 单侧事实没有分叉风险
+ * （尺子 2）。判断标准：跨语言 = Rust emit + 前端 listen 两侧都有。
+ */
+
+/** 当前供应商切换后通知前端（`providersApi.onSwitched` / `OperatorSection` 监听）。 */
+export const PROVIDER_SWITCHED = "provider-switched";
+/** 项目应用完成后的统一收尾事件（`App.tsx` / `PromptPanel` 监听）。 */
+export const PROFILE_APPLIED = "profile-applied";
+/** 用量缓存写入后通知前端 React Query 失效（`useUsageCacheBridge` 监听）。 */
+export const USAGE_CACHE_UPDATED = "usage-cache-updated";
+/** 使用日志写入后通知前端（`useUsageEventBridge` 监听）。 */
+export const USAGE_LOG_RECORDED = "usage-log-recorded";
+/** deeplink 导入请求（`DeepLinkImportDialog` 监听）。 */
+export const DEEPLINK_IMPORT = "deeplink-import";
+/** 统一供应商同步完成（`App.tsx` 监听）。 */
+export const UNIVERSAL_PROVIDER_SYNCED = "universal-provider-synced";
+/** WebDAV 云同步状态变化（`App.tsx` 监听）。 */
+export const WEBDAV_SYNC_STATUS_UPDATED = "webdav-sync-status-updated";
+/** S3 云同步状态变化（`App.tsx` 监听）。 */
+export const S3_SYNC_STATUS_UPDATED = "s3-sync-status-updated";
+/** 充值窗关闭（`OperatorSection` 监听）。原在 `@/lib/api/operator`。 */
+export const PURCHASE_CLOSED = "operator-purchase-closed";
+/** 官网直连登录窗凭据解析失败（`OperatorSection` 监听）。原在 `@/lib/api/vendor`。 */
+export const VENDOR_LOGIN_ERROR = "vendor-login-error";

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,4 +1,5 @@
 export type { AppId } from "./types";
+export * from "./events";
 export { providersApi, universalProvidersApi } from "./providers";
 export { settingsApi } from "./settings";
 export { backupsApi } from "./settings";

--- a/src/lib/api/operator.ts
+++ b/src/lib/api/operator.ts
@@ -171,16 +171,6 @@ export interface RestoreOfficialLoginResult {
   warnings: string[];
 }
 
-/**
- * 充值窗关闭的事件名。**与 Rust 侧 `commands::operator::PURCHASE_CLOSED_EVENT`
- * 必须逐字一致**，payload 是 `operatorId`。
- *
- * 定在这一层（而不是各组件各写一份）是因为对不上的后果**完全静默**：
- * 关窗后余额永远不刷，编译过、测试绿、没有任何东西报错。
- * 组件从这里 import，三份字面量减成一份。
- */
-export const PURCHASE_CLOSED_EVENT = "operator-purchase-closed";
-
 export interface OperatorBalance {
   balance: number;
   frozenBalance: number;

--- a/src/lib/api/providers.ts
+++ b/src/lib/api/providers.ts
@@ -6,6 +6,7 @@ import type {
   UniversalProvidersMap,
 } from "@/types";
 import type { AppId } from "./types";
+import { PROVIDER_SWITCHED } from "./events";
 
 export interface ProviderSortUpdate {
   id: string;
@@ -148,7 +149,7 @@ export const providersApi = {
   async onSwitched(
     handler: (event: ProviderSwitchEvent) => void,
   ): Promise<UnlistenFn> {
-    return await listen("provider-switched", (event) => {
+    return await listen(PROVIDER_SWITCHED, (event) => {
       const payload = event.payload as ProviderSwitchEvent;
       handler(payload);
     });

--- a/src/lib/api/vendor.ts
+++ b/src/lib/api/vendor.ts
@@ -88,16 +88,6 @@ export interface VendorProvisionSummary {
 }
 
 /**
- * 登录窗凭据回传解析失败的事件名。**与 Rust 侧
- * `commands::vendor::LOGIN_ERROR_EVENT` 必须逐字一致**，payload 是错误字符串。
- *
- * ⚠️ 与 operator 那条 `"operator-login-error"` **有意不同**（两条链路的登录窗各自独立，
- * 混用会让一边的错误弹在另一边的界面上）。定在这一层的理由同 `PURCHASE_CLOSED_EVENT`：
- * 对不上的后果完全静默 —— 编译过、测试绿、只是登录失败永远没有提示。
- */
-export const VENDOR_LOGIN_ERROR_EVENT = "vendor-login-error";
-
-/**
  * 官网行会出现在哪些 tab。
  *
  * ⚠️ **`gemini` 与 `grokbuild` 不在里面** —— 上游没有 DeepSeek preset，协议不兼容

--- a/tests/lib/providerSwitchedEventContract.test.ts
+++ b/tests/lib/providerSwitchedEventContract.test.ts
@@ -68,7 +68,9 @@ describe("provider-switched 的跨页面契约", () => {
     // 2) emit_provider_switched 用的是常量而不是裸字面量（以后改事件名只改一处）
     // 3) 前端两个消费者都从常量 import，而不是自己写裸字符串
     const eventsRs = read("src-tauri/src/events.rs");
-    expect(eventsRs).toMatch(/pub const PROVIDER_SWITCHED:\s*&str\s*=\s*"provider-switched"/);
+    expect(eventsRs).toMatch(
+      /pub const PROVIDER_SWITCHED:\s*&str\s*=\s*"provider-switched"/,
+    );
 
     const providerRs = read("src-tauri/src/commands/provider.rs");
     expect(

--- a/tests/lib/providerSwitchedEventContract.test.ts
+++ b/tests/lib/providerSwitchedEventContract.test.ts
@@ -37,8 +37,6 @@ import { describe, expect, it } from "vitest";
  * 会红的改法：任一条切换路径不再发事件；`OperatorSection` 不再监听；
  * 事件名在任一侧被改。
  */
-const EVENT_NAME = "provider-switched";
-
 const read = (rel: string) => readFileSync(resolve(process.cwd(), rel), "utf8");
 
 describe("provider-switched 的跨页面契约", () => {
@@ -64,20 +62,31 @@ describe("provider-switched 的跨页面契约", () => {
   });
 
   it("发射用的事件名与前端监听的逐字相同", () => {
-    const providerRs = read("src-tauri/src/commands/provider.rs");
-    const emitted = providerRs.match(/\.emit\("([^"]+)",\s*payload\)/);
-    expect(
-      emitted,
-      "在 emit_provider_switched 里找不到 emit(...) —— 它被改写了？",
-    ).not.toBeNull();
-    expect(emitted![1]).toBe(EVENT_NAME);
+    // 事件名常量收在 events.rs / events.ts 两侧（一致性闸在 events.rs 的
+    // consistency_tests 里守逐字一致）。这里验证三件事：
+    // 1) 两侧常量值确实是 "provider-switched"
+    // 2) emit_provider_switched 用的是常量而不是裸字面量（以后改事件名只改一处）
+    // 3) 前端两个消费者都从常量 import，而不是自己写裸字符串
+    const eventsRs = read("src-tauri/src/events.rs");
+    expect(eventsRs).toMatch(/pub const PROVIDER_SWITCHED:\s*&str\s*=\s*"provider-switched"/);
 
-    // 前端两个消费者都用这个名字。
-    expect(read("src/lib/api/providers.ts")).toContain(
-      `listen("${EVENT_NAME}"`,
+    const providerRs = read("src-tauri/src/commands/provider.rs");
+    expect(
+      providerRs,
+      "emit_provider_switched 该用 PROVIDER_SWITCHED 常量 —— 裸字面量会让事件名失去唯一源",
+    ).toMatch(/\.emit\(PROVIDER_SWITCHED,\s*payload\)/);
+
+    const eventsTs = read("src/lib/api/events.ts");
+    expect(eventsTs).toMatch(
+      /export const PROVIDER_SWITCHED\s*=\s*"provider-switched"/,
     );
-    expect(read("src/components/operator/OperatorSection.tsx")).toContain(
-      `"${EVENT_NAME}"`,
+
+    // 前端两个消费者都用常量。
+    expect(read("src/lib/api/providers.ts")).toMatch(
+      /listen\(PROVIDER_SWITCHED/,
+    );
+    expect(read("src/components/operator/OperatorSection.tsx")).toMatch(
+      /useTauriEvent<ProviderSwitchEvent>\(PROVIDER_SWITCHED/,
     );
   });
 

--- a/tests/lib/purchaseClosedEventContract.test.ts
+++ b/tests/lib/purchaseClosedEventContract.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { PURCHASE_CLOSED_EVENT } from "@/lib/api/operator";
+import { PURCHASE_CLOSED } from "@/lib/api/events";
 
 /**
  * 闸：**充值窗关闭事件的名字，Rust 侧与 TS 侧必须逐字一致**。
@@ -16,39 +16,36 @@ import { PURCHASE_CLOSED_EVENT } from "@/lib/api/operator";
  *   的附加信息，所以既不报错也不弹 toast
  * - `tsc` 管不到（两边是各自合法的字符串字面量）、单测也不会碰到（没有人断言它）
  *
- * 那个 Rust 常量的文档注释自己就预言过这件事。既然预言了就该配一道闸，
- * 而不是只写一句警告 —— 警告拦不住重命名。
- *
- * ⚠️ **本仓此前没有「测试读 `src-tauri/`」的先例**（这是第一处）。选它而不是
- * 「靠人记得同步改两处」，判据是：这条契约的失效是静默的，而静默失效必须有闸。
- * Rust 侧同样有一份镜像闸（`config.rs` 的 `brand_constant_consistency`
- * 就是反方向读 `constants.ts` 的同一个模式），所以这不是新发明的模式。
+ * 事件名常量统一收在 `src-tauri/src/events.rs`（Rust）与 `src/lib/api/events.ts`（TS），
+ * 两端各自的镜像闸（Rust 侧 `events::consistency_tests`、本测试）保证它们逐字一致。
+ * 2026-08-07 前 `PURCHASE_CLOSED_EVENT` 定义在 `commands/operator.rs`，迁入 `events.rs`
+ * 统一管理（名字也随迁为 `PURCHASE_CLOSED`）。
  */
 describe("充值窗关闭事件的跨语言契约", () => {
-  it("Rust 侧的 PURCHASE_CLOSED_EVENT 与 TS 侧逐字相同", () => {
+  it("Rust 侧的 PURCHASE_CLOSED 与 TS 侧逐字相同", () => {
     // 从仓库根解析（vitest 的 cwd 就是根）。**不用 `import.meta.url`** ——
     // 本仓的 vitest 配置下它不是 `file:` scheme，`fileURLToPath` 会抛
     // `ERR_INVALID_URL_SCHEME`（实测踩过）。
     const rustSource = readFileSync(
-      resolve(process.cwd(), "src-tauri/src/commands/operator.rs"),
+      resolve(process.cwd(), "src-tauri/src/events.rs"),
       "utf8",
     );
 
-    // 匹配 `pub const PURCHASE_CLOSED_EVENT: &str = "...";`
+    // 匹配 `pub const PURCHASE_CLOSED: &str = "...";`
     const match = rustSource.match(
-      /pub const PURCHASE_CLOSED_EVENT:\s*&str\s*=\s*"([^"]+)"/,
+      /pub const PURCHASE_CLOSED:\s*&str\s*=\s*"([^"]+)"/,
     );
 
     // 找不到本身就是失败：常量被改名或删掉时，这条要红而不是静默跳过。
     expect(
       match,
-      "在 commands/operator.rs 里找不到 PURCHASE_CLOSED_EVENT —— 它被改名或删了？",
+      "在 src-tauri/src/events.rs 里找不到 PURCHASE_CLOSED —— 它被改名或删了？",
     ).not.toBeNull();
 
-    expect(match![1]).toBe(PURCHASE_CLOSED_EVENT);
+    expect(match![1]).toBe(PURCHASE_CLOSED);
   });
 
   it("事件名不是空串（空串会让 listen 匹配到意外的东西）", () => {
-    expect(PURCHASE_CLOSED_EVENT.length).toBeGreaterThan(0);
+    expect(PURCHASE_CLOSED.length).toBeGreaterThan(0);
   });
 });

--- a/tests/lib/vendorLoginErrorEventContract.test.ts
+++ b/tests/lib/vendorLoginErrorEventContract.test.ts
@@ -2,8 +2,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { PURCHASE_CLOSED_EVENT } from "@/lib/api/operator";
-import { VENDOR_LOGIN_ERROR_EVENT } from "@/lib/api/vendor";
+import { PURCHASE_CLOSED, VENDOR_LOGIN_ERROR } from "@/lib/api/events";
 
 /**
  * 闸：**官网登录出错事件的名字，Rust 侧与 TS 侧必须逐字一致**。
@@ -15,24 +14,27 @@ import { VENDOR_LOGIN_ERROR_EVENT } from "@/lib/api/vendor";
  *
  * CLAUDE.md §三点六：新增任何「跨语言 / 跨文件的同一事实」时一并加闸 ——
  * 否则它迟早分叉，而分叉那天没人会收到通知。
+ *
+ * 2026-08-07 前 `VENDOR_LOGIN_ERROR_EVENT` 定义在 `commands/vendor.rs`，迁入
+ * `events.rs` / `events.ts` 统一管理（名字也随迁为 `VENDOR_LOGIN_ERROR`）。
  */
 describe("官网登录出错事件的跨语言契约", () => {
-  it("Rust 侧的 LOGIN_ERROR_EVENT 与 TS 侧逐字相同", () => {
+  it("Rust 侧的 VENDOR_LOGIN_ERROR 与 TS 侧逐字相同", () => {
     const rustSource = readFileSync(
-      resolve(process.cwd(), "src-tauri/src/commands/vendor.rs"),
+      resolve(process.cwd(), "src-tauri/src/events.rs"),
       "utf8",
     );
 
     const match = rustSource.match(
-      /pub const LOGIN_ERROR_EVENT:\s*&str\s*=\s*"([^"]+)"/,
+      /pub const VENDOR_LOGIN_ERROR:\s*&str\s*=\s*"([^"]+)"/,
     );
 
     expect(
       match,
-      "在 commands/vendor.rs 里找不到 LOGIN_ERROR_EVENT —— 它被改名或删了？",
+      "在 src-tauri/src/events.rs 里找不到 VENDOR_LOGIN_ERROR —— 它被改名或删了？",
     ).not.toBeNull();
 
-    expect(match![1]).toBe(VENDOR_LOGIN_ERROR_EVENT);
+    expect(match![1]).toBe(VENDOR_LOGIN_ERROR);
   });
 
   /**
@@ -42,7 +44,7 @@ describe("官网登录出错事件的跨语言契约", () => {
    * 另一边的界面上 —— 而 Rust 侧已有测试钉着 vendor 那条的取值。
    */
   it("与 operator 的事件名不同（两条链路各自独立）", () => {
-    expect(VENDOR_LOGIN_ERROR_EVENT).not.toBe(PURCHASE_CLOSED_EVENT);
-    expect(VENDOR_LOGIN_ERROR_EVENT).not.toBe("operator-login-error");
+    expect(VENDOR_LOGIN_ERROR).not.toBe(PURCHASE_CLOSED);
+    expect(VENDOR_LOGIN_ERROR).not.toBe("operator-login-error");
   });
 });


### PR DESCRIPTION
## Summary / 概述

**跨语言 Tauri 事件名收敛到唯一数据源 + 一致性闸**（唯源问题修复，续 PR #33）。

### 问题
`provider-switched` 曾散在 7 处 Rust emit + 3 处前端监听、全是裸字面量，无常量、无闸。事件名是跨文件、跨语言的契约，分叉的后果**完全静默**：Rust 照常 emit、TS 照常 listen，只是名字不同 ⇒ 界面不刷新 / 弹错窗口，编译过、测试绿、没有任何报错（CLAUDE.md §三点六）。

### 改动
两侧各建一个事件名常量模块 + 一致性闸：
- `src-tauri/src/events.rs`：所有跨语言事件名 `pub const`
- `src/lib/api/events.ts`：逐字一致的 TS 副本
- `events.rs` 加 `consistency_tests::frontend_copies_match`（`include_str!` 比对，照 `config.rs::brand_constant_consistency` 既有模式）—— 分叉变**测试红**，不再静默

替换全部 emit / listen / `useTauriEvent` 的裸字面量为常量，覆盖：
`provider-switched` / `profile-applied` / `usage-cache-updated` / `usage-log-recorded` / `deeplink-import` / `universal-provider-synced` / `webdav-sync-status-updated` / `s3-sync-status-updated`。
`PURCHASE_CLOSED_EVENT` / `VENDOR_LOGIN_ERROR_EVENT` 从各命令模块迁入 `events.rs` 统一管理（原三份前端契约测试同步指向新位置）。

**范围**：只在单侧存在的事件名（`proxy-flags-changed` / `operator-login-error`）不收敛 —— 无跨语言分叉风险，收进来只是噪音（尺子 2 管预埋不管收口，但这里没有「口」可收）。

### 后续影响
- 加新跨语言事件 = 两端各加一个常量 + 闸自动守
- 以后改事件名，改任一侧即测试红，不会静默失效

## Related Issue / 关联 Issue

无（延续 PR #33 的唯源修复方向）。

Fixes #

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| `provider-switched` 散在 7 处裸字面量 | 常量收在 `events.rs` / `events.ts`，闸守住一致 |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查（`tsc --noEmit` exit 0）
- [x] `pnpm format:check` passes / 通过代码格式检查（`prettier --check` exit 0）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（`clippy --all-targets -- -D warnings` exit 0）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（本次未改用户可见文案）

补充：`cargo test` 全量通过（2654 passed，含新增 `events::consistency_tests`）；`vitest run` 通过（703 passed，含更新后的 3 个契约测试）。CLAUDE.md §四 六道闸全部本地验证。
