### PR TITLE
docs: 打包产物归档路径唯一收在 LOONGPORT.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,3 +236,12 @@ gh pr merge fix/xxx --auto --merge    # 等 4 个必需检查全绿后自动合
 dependabot 的，别照搬。PR 模板在 `.github/pull_request_template.md`。
 **main 只接受通过 PR 的改动** —— 这条与 design 仓无关（流程知识跟着代码走，
 不抄进档案仓，见全局准则 §1.4 唯一数据源）。
+
+### 打包与产物归档：唯一源在 LOONGPORT.md，这里只指路
+
+打包命令、DMG 坑、产物路径、归档约定（mac 落 `~/下载`、windows 落 `D:\`）
+**全部收在 [LOONGPORT.md](LOONGPORT.md) 的打包章节**，这里是**唯一一份**，
+别在 CLAUDE.md 里复制第二遍（见全局准则 §1.4）。要打包时去读那份。
+
+唯一属于 CLAUDE.md（维护视角）的是上面那条警告：**`cargo test` / `clippy` 全绿
+不代表能打包** —— Tauri 的 npm↔crate 版本校验只在打包时触发。

--- a/LOONGPORT.md
+++ b/LOONGPORT.md
@@ -131,6 +131,27 @@ hdiutil create -volname LoongPort -srcfolder "$STAGE" -ov -format UDZO \
 rm -rf "$(dirname "$STAGE")"
 ```
 
+### 产物归档：mac 落 `~/下载`、windows 落 `D:\`，两边同一个约定
+
+产物别留在 `src-tauri/target/release/bundle/`（构建中间目录，下次 build 会清掉），
+打完了**复制到固定位置**再试用 / 分发 —— 归档位置就是「装到哪、从哪试」：
+
+| 平台 | 归档目录 | 产物 |
+|---|---|---|
+| macOS | `~/下载` | `LoongPort.app`（整个 .app 目录） |
+| Windows | `D:\`（D 盘根） | `LoongPort_<ver>_x64.msi` / `.exe` |
+
+```bash
+# mac：把 .app 复制到 ~/下载
+cp -R src-tauri/target/release/bundle/macos/LoongPort.app ~/下载/
+
+# windows（在 Windows 机器 / CI 上）：复制到 D 盘根
+# copy /Y src-tauri\target\release\bundle\nsis\LoongPort_*.exe D:\
+```
+
+版本号从 `src-tauri/tauri.conf.json` 读，别写死；产物名里带架构后缀
+（`aarch64` / `x64`），归档时**别去掉** —— 分发时要能一眼看出是哪个架构的。
+
 ## Tauri 命令
 
 **唯一权威是 `lib.rs` 的 `invoke_handler` 注册表**（`generate_handler!` 那一段）——


### PR DESCRIPTION
## Summary / 概述

**打包产物归档路径唯一收进 LOONGPORT.md**（mac `~/下载`、windows `D:\`）。

- **LOONGPORT.md**（用户视角产品说明，打包知识的唯一源）新增"产物归档"小节：产物别留在 `target/release/bundle/`（构建中间目录），mac 复制到 `~/下载`、windows 复制到 `D:\` 根，两边同一个约定
- **CLAUDE.md** 只留一行指针指向 LOONGPORT.md + 维护特有的打包警告（npm↔crate 校验只在打包时触发），**不复制第二遍** —— 遵循唯源原则（§1.4）

## Related Issue / 关联 Issue

无（本地打包验证时发现：`.app` 打好了，但产物归档位置没有约定，且不该在 CLAUDE.md 重复 LOONGPORT.md 已有的打包内容）。

Fixes #

## Screenshots / 截图

无（纯文档改动）。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查（文档改动，不影响）
- [x] `pnpm format:check` passes / 通过代码格式检查（文档改动，不影响）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（未改 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（未改用户可见文案）
