### PR TITLE
docs: sub2api 源码位置指正（design 仓子模块，非独立 clone）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,8 @@
 ### 查 sub2api 的行为：先找它的 Go 源码，别逆推线上 JS
 
 对接 sub2api（端点、字段、鉴权、计费规则）时，**优先看 sub2api 后端的 Go 源码**
-（开源，`Wei-Shaw/sub2api`；维护者本机已 clone，路径见工作区那份 CLAUDE.md）。
+（开源，`Wei-Shaw/sub2api`；源码在本机 design 仓的 `upstream/sub2api` 子模块，
+路径见工作区那份 CLAUDE.md —— 维护者本机布局唯一源）。
 它是契约本身，比读线上 SPA 的 minified bundle、比历史实测记录都权威一个量级 ——
 能给到「哪个 handler 第几行填了哪个字段」级别的证据。
 


### PR DESCRIPTION
## Summary / 概述

CLAUDE.md §查 sub2api 的源码位置描述指正：
- 原句"维护者本机已 clone"不准确 —— sub2api 其实没有独立 clone，它就是 design 仓的 `upstream/sub2api` 只读子模块
- 改成准确描述，并指向工作区 `CLAUDE.md`（维护者本机布局唯一源，不入仓）

属于"维护者本机信息"清理的一部分：公开仓里不再出现本机布局细节，统一指向不入仓的工作区 CLAUDE.md。

## Related Issue / 关联 Issue

无。

Fixes #

## Screenshots / 截图

无（纯文档改动）。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查（文档改动，不影响）
- [x] `pnpm format:check` passes / 通过代码格式检查（文档改动，不影响）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（未改 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（未改用户可见文案）
