### PR TITLE
release: 版本号升到 3.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-switch",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "description": "All-in-One Assistant for Claude Code, Codex & Gemini CLI",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # （裁决见 CLAUDE.md「三点五」）。面向用户的二进制名走 tauri.conf.json 的
 # `mainBinaryName`（已是 `LoongPort`）。
 name = "cc-switch"
-version = "3.21.0"
+version = "3.22.0"
 description = "同样的 Codex，成本省 95% 以上 —— 填一个域名、登录一次，其余自动配好"
 authors = ["SailingLoong", "Jason Young"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LoongPort",
   "mainBinaryName": "LoongPort",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "identifier": "dev.loongport.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary / 概述

版本号 3.21.0 → 3.22.0（3 处：`tauri.conf.json` / `Cargo.toml` / `package.json`）。

此批含 #33-#40：DeepSeek ↔ 供应商互斥修复、跨语言事件名收敛 + 一致性闸、deeplink 补发 provider-switched、DeepSeek 1M 模型对齐、cc-switch 一键导入、Claude 默认语言（2 个 feat + 多个 fix）。

合并后打 tag `v3.22.0` 触发 release workflow 发版。

## Related Issue / 关联 Issue

无。

Fixes #

## Screenshots / 截图

无（纯版本号改动）。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查（版本号改动，不影响）
- [x] `pnpm format:check` passes / 通过代码格式检查（版本号改动，不影响）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（未改 Rust 逻辑）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（未改文案）
