### PR TITLE
feat(ui): 首页平台 tab 折叠（gemini 起收起）+ Cargo.lock 版本同步

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "cc-switch"
-version = "3.22.0"
+version = "3.22.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src/components/AppSwitcher.tsx
+++ b/src/components/AppSwitcher.tsx
@@ -3,7 +3,13 @@ import type { VisibleApps } from "@/types";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { LAST_APP_STORAGE_KEY } from "@/config/constants";
 import { cn } from "@/lib/utils";
-import { Image as ImageIcon, Monitor, Terminal } from "lucide-react";
+import {
+  ChevronDown,
+  Image as ImageIcon,
+  Monitor,
+  Terminal,
+} from "lucide-react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 const APP_BADGE_ICON: Partial<
@@ -33,6 +39,13 @@ const ALL_APPS: AppId[] = [
   "openclaw",
   "hermes",
 ];
+
+/**
+ * 固定显示的平台数：claude / claude-desktop / codex / codex-image 前 4 个常驻，
+ * 从这一位起的平台（gemini、grokbuild、opencode、openclaw、hermes）折叠进「更多」。
+ * 跟 `ALL_APPS` 的排列顺序绑定 —— 别按名字猜「4 个」。
+ */
+const COLLAPSED_START_INDEX = 4;
 
 export function AppSwitcher({
   activeApp,
@@ -79,57 +92,87 @@ export function AppSwitcher({
     return visibleApps[app];
   });
 
+  // 前 4 个固定显示，其余折叠进「更多」。
+  const pinnedApps = appsToShow.slice(0, COLLAPSED_START_INDEX);
+  const collapsedApps = appsToShow.slice(COLLAPSED_START_INDEX);
+  // 当前激活的平台在折叠组里时**自动展开** —— 否则切到 gemini 却看不到它被收在哪。
+  const activeInCollapsed = collapsedApps.includes(activeApp);
+  const [moreOpen, setMoreOpen] = useState(false);
+  const showCollapsed = moreOpen || activeInCollapsed;
+
+  const appButton = (app: AppId) => {
+    const badgeConfig = APP_BADGE_ICON[app];
+    const BadgeIcon = badgeConfig?.icon;
+    const isActive = activeApp === app;
+    return (
+      <button
+        key={app}
+        type="button"
+        onClick={() => handleSwitch(app)}
+        title={appDisplayName[app]}
+        aria-label={appDisplayName[app]}
+        className={cn(
+          "group inline-flex items-center px-3 h-8 rounded-md text-sm font-medium transition-all duration-200",
+          isActive
+            ? "bg-background text-foreground shadow-sm"
+            : "text-muted-foreground hover:text-foreground hover:bg-background/50",
+        )}
+      >
+        <span className="relative inline-flex shrink-0">
+          <ProviderIcon
+            icon={appIconName[app]}
+            name={appDisplayName[app]}
+            size={iconSize}
+          />
+          {BadgeIcon && (
+            <span
+              className={cn(
+                "absolute -bottom-0.5 -right-0.5 flex items-center justify-center rounded-[3px] border h-[11px] w-[11px]",
+                isActive
+                  ? "bg-background border-border text-foreground"
+                  : "bg-muted border-background text-muted-foreground group-hover:bg-background group-hover:text-foreground",
+              )}
+              aria-hidden="true"
+            >
+              <BadgeIcon
+                className="h-[8px] w-[8px]"
+                strokeWidth={2.5}
+                style={
+                  badgeConfig?.offsetY
+                    ? { transform: `translateY(${badgeConfig.offsetY}px)` }
+                    : undefined
+                }
+              />
+            </span>
+          )}
+        </span>
+      </button>
+    );
+  };
+
   return (
     <div className="inline-flex bg-muted rounded-xl p-1 gap-1">
-      {appsToShow.map((app) => {
-        const badgeConfig = APP_BADGE_ICON[app];
-        const BadgeIcon = badgeConfig?.icon;
-        const isActive = activeApp === app;
-        return (
-          <button
-            key={app}
-            type="button"
-            onClick={() => handleSwitch(app)}
-            title={appDisplayName[app]}
-            aria-label={appDisplayName[app]}
+      {pinnedApps.map(appButton)}
+      {collapsedApps.length > 0 && (
+        <button
+          type="button"
+          onClick={() => setMoreOpen((v) => !v)}
+          aria-expanded={showCollapsed}
+          aria-label={t("apps.more")}
+          title={t("apps.more")}
+          className={cn(
+            "group inline-flex items-center px-2 h-8 rounded-md text-muted-foreground transition-all duration-200 hover:text-foreground hover:bg-background/50",
+          )}
+        >
+          <ChevronDown
             className={cn(
-              "group inline-flex items-center px-3 h-8 rounded-md text-sm font-medium transition-all duration-200",
-              isActive
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground hover:bg-background/50",
+              "h-4 w-4 transition-transform duration-200",
+              showCollapsed && "rotate-180",
             )}
-          >
-            <span className="relative inline-flex shrink-0">
-              <ProviderIcon
-                icon={appIconName[app]}
-                name={appDisplayName[app]}
-                size={iconSize}
-              />
-              {BadgeIcon && (
-                <span
-                  className={cn(
-                    "absolute -bottom-0.5 -right-0.5 flex items-center justify-center rounded-[3px] border h-[11px] w-[11px]",
-                    isActive
-                      ? "bg-background border-border text-foreground"
-                      : "bg-muted border-background text-muted-foreground group-hover:bg-background group-hover:text-foreground",
-                  )}
-                  aria-hidden="true"
-                >
-                  <BadgeIcon
-                    className="h-[8px] w-[8px]"
-                    strokeWidth={2.5}
-                    style={
-                      badgeConfig?.offsetY
-                        ? { transform: `translateY(${badgeConfig.offsetY}px)` }
-                        : undefined
-                    }
-                  />
-                </span>
-              )}
-            </span>
-          </button>
-        );
-      })}
+          />
+        </button>
+      )}
+      {showCollapsed && collapsedApps.map(appButton)}
     </div>
   );
 }

--- a/src/components/ProviderIcon.tsx
+++ b/src/components/ProviderIcon.tsx
@@ -17,6 +17,17 @@ interface ProviderIconProps {
   showFallback?: boolean; // 是否显示 fallback
 }
 
+/**
+ * 剥掉注入 SVG 里的 `<title>` —— 浏览器悬停时 SVG title 会作为**原生 tooltip**
+ * 显示，优先于外层 span 的 `title={name}`。于是图标左半边提示的是 SVG 里的
+ * 名字（如 openai.svg 的 `OpenAI`），而不是组件想给的供应商名（如「Codex 生图」）。
+ * 已确认 `extracted/` 里 56 个 SVG 带 `<title>`，统一剥掉是根修 ——
+ * 悬停提示交给外层 `title={name}` 一处负责。
+ */
+function stripSvgTitle(svg: string): string {
+  return svg.replace(/<title[^>]*>[\s\S]*?<\/title>/gi, "");
+}
+
 export const ProviderIcon: React.FC<ProviderIconProps> = ({
   icon,
   name,
@@ -28,7 +39,7 @@ export const ProviderIcon: React.FC<ProviderIconProps> = ({
   // 获取内联 SVG 字符串
   const iconSvg = useMemo(() => {
     if (icon && !isUrlIcon(icon) && hasIcon(icon)) {
-      return getIcon(icon);
+      return stripSvgTitle(getIcon(icon));
     }
     return "";
   }, [icon]);

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -905,7 +905,8 @@
     "grokbuild": "Grok Build",
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
-    "hermes": "Hermes"
+    "hermes": "Hermes",
+    "more": "More"
   },
   "grokBuild": {
     "apiBackend": "API backend",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -905,7 +905,8 @@
     "grokbuild": "Grok Build",
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
-    "hermes": "Hermes"
+    "hermes": "Hermes",
+    "more": "その他"
   },
   "grokBuild": {
     "apiBackend": "API Backend",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -906,7 +906,8 @@
     "grokbuild": "Grok Build",
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
-    "hermes": "Hermes"
+    "hermes": "Hermes",
+    "more": "更多"
   },
   "grokBuild": {
     "apiBackend": "API Backend",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -905,7 +905,8 @@
     "grokbuild": "Grok Build",
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
-    "hermes": "Hermes"
+    "hermes": "Hermes",
+    "more": "更多"
   },
   "grokBuild": {
     "apiBackend": "API Backend",


### PR DESCRIPTION
首页顶部平台切换只保留 claude / claude-desktop / codex / codex-image 前 4 个，gemini 及以后的平台折叠进「更多」chevron（点击展开，激活的平台在折叠组里自动展开）。附带 Cargo.lock crate 版本同步到 3.22.1。此改动并入 v3.22.1（已取消先前的 release run，合并后重打 tag）。