### PR TITLE
fix(macos): 配 ad-hoc 签名 —— 修 .app 一启动就被内核 SIGKILL

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -51,7 +51,8 @@
       }
     },
     "macOS": {
-      "minimumSystemVersion": "12.0"
+      "minimumSystemVersion": "12.0",
+      "signingIdentity": "-"
     }
   },
   "plugins": {


### PR DESCRIPTION
## 问题

macOS 下 `tauri build` 产出的 `.app` 签名结构不完整，从 Downloads 启动时被内核 SIGKILL，崩溃报告里没有任何调用栈（`frames: []`），业务代码一行都没执行到：

```
Exception Type: EXC_CRASH (SIGKILL (Code Signature Invalid))
codeSigningID: ""     codeSigningTeamID: ""     codeSigningFlags: 0x1000200
```

## 根因

`bundle.macOS` 缺 `signingIdentity` → Tauri 不对 `.app` 做签名 → 产物只剩 cargo 链接时的 linker-signed 二进制。

| 检查项 | 修复前 | 修复后 |
|---|---|---|
| 签名标识 | `cc_switch-b363132b1a8b176a`（crate 名） | `dev.loongport.desktop` |
| 签名 flags | `0x20002 (adhoc, **linker-signed**)` | `0x10002 (adhoc, runtime)` |
| `Info.plist` | `not bound` | entries=15 |
| `Sealed Resources` | `none` | version=2 |
| `_CodeSignature/` | **不存在** | 存在 |

`codesign --verify` 报 `code has no resources but signature indicates they must be present` —— 签名声明有 sealed resources 但 bundle 里没有，属结构性损坏。

**触发条件是「签名损坏 + quarantine」两者共同作用**，这点值得说清楚：

- 本机构建、无 quarantine 的副本，即使签名损坏**也能正常启动**（实测存活）
- 一旦带上 `com.apple.quarantine`（下载、AirDrop、传输、分发给用户），Gatekeeper 校验签名失败 → 内核 SIGKILL（崩溃时 `codeSigningFlags 0x1000200` 含 `CS_KILL`，且**无** `CS_ADHOC` 位，说明内核没能解析出有效 ad-hoc 签名）

所以这是**分发路径上的缺陷**：维护者本机自测感知不到，拿到安装包的用户必然撞上「已损坏」或直接闪退。

## 改动

按 [Tauri 官方 macOS 签名文档](https://v2.tauri.app/distribute/sign/macos/)，用伪身份 `-` 配置 ad-hoc 签名 —— 该文档明确指出这正是为「Apple Silicon 要求所有 app 签名」场景准备的。

```json
"macOS": {
  "minimumSystemVersion": "12.0",
  "signingIdentity": "-"
}
```

选它而不是「在文档里加一步手工 `codesign`」：坏的是构建产物本身，手工补是绕开而非修根，且靠人记得的步骤必然会漏；签名行为归 `tauri.conf.json` 一处管，不散成「配置 + 人的记忆」两份。

## 验证

- 构建日志出现 `Signing with identity "-"`，二进制与 `.app` 均被签名
- `codesign --verify --deep --strict` → `valid on disk` + `satisfies its Designated Requirement`
- **打上 quarantine 后的 Gatekeeper 判定对比**（即分发场景）：

  | | 修复前 | 修复后 |
  |---|---|---|
  | `spctl --assess` | `code has no resources…`（签名损坏，评估都做不了） | `rejected`（签名有效，仅未公证） |

  修复后仍是 `rejected` 属预期 —— ad-hoc 签名未经 Apple 公证，用户需在「隐私与安全性」放行。区别在于：修复前是**签名损坏、放行不了**，修复后是**签名有效、可放行**。
- **实际启动 app**：主窗口正常显示、deep-link 注册成功 —— 确认 `hardenedRuntime`（默认 true，签名 flags 含 `runtime`）未影响 WebView 的 JIT
- 六道闸全绿：`cargo test`（0 failed）/ `clippy -D warnings` / `cargo fmt --check` / `tsc` / `prettier` / `vitest`（112 文件 703 测试）

## 附注（不在本 PR 范围）

两处与本问题无关、但发版流程需要留意的：

1. 构建末尾报 `A public key has been found, but no private key. Make sure to set TAURI_SIGNING_PRIVATE_KEY` —— 这是 **updater artifact 签名**（`createUpdaterArtifacts: true` + 已配 `pubkey`），本地构建缺私钥属预期；`.app` 在该步之前已打好。发版若依赖自动更新，需在 CI 注入该私钥。
2. ad-hoc 签名的 app 用户首次打开仍需手工放行。要彻底消除这一步，需 Developer ID 证书 + 公证（notarization），那是另一件事。

🤖 Generated with [Claude Code](https://claude.com/claude-code)