### PR TITLE
chore: bump version to 3.22.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-switch",
-  "version": "3.22.1",
+  "version": "3.22.2",
   "description": "All-in-One Assistant for Claude Code, Codex & Gemini CLI",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "cc-switch"
-version = "3.22.1"
+version = "3.22.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # （裁决见 CLAUDE.md「三点五」）。面向用户的二进制名走 tauri.conf.json 的
 # `mainBinaryName`（已是 `LoongPort`）。
 name = "cc-switch"
-version = "3.22.1"
+version = "3.22.2"
 description = "同样的 Codex，成本省 95% 以上 —— 填一个域名、登录一次，其余自动配好"
 authors = ["SailingLoong", "Jason Young"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LoongPort",
   "mainBinaryName": "LoongPort",
-  "version": "3.22.1",
+  "version": "3.22.2",
   "identifier": "dev.loongport.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
patch 小版本，为 `v3.22.2` 打 tag 做准备。

内容只有版本号：修运营商 claude 档位端点多带 `/v1`（#51）—— Claude Code 自己拼
`/v1/models`，base 再带一段就打成 `/v1/v1/models` 404 ⇒ 模型列表拉空 ⇒ 用户选任何模型
都报「不在可用列表里」。

三处 manifest 同步改（`tauri.conf.json` / `Cargo.toml` / `package.json`），`config.rs`
那道一致性闸保持不动。`Cargo.lock` 里 crate 自身的版本**一并入库**，不再像 3.22.1 那样
另开一个 `sync Cargo.lock` 的跟进提交。

CHANGELOG.md 不动 —— 它最后停在 3.21.0，3.22.0 / 3.22.1 两次 patch 都没写，本次沿用同一惯例。

六道闸：cargo test 2658 ✅ / clippy -D warnings ✅ / fmt --check ✅ / tsc ✅ /
format:check ✅ / vitest 703 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)