### PR TITLE
chore: bump version to 3.22.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-switch",
-  "version": "3.22.2",
+  "version": "3.22.3",
   "description": "All-in-One Assistant for Claude Code, Codex & Gemini CLI",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "cc-switch"
-version = "3.22.2"
+version = "3.22.3"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # （裁决见 CLAUDE.md「三点五」）。面向用户的二进制名走 tauri.conf.json 的
 # `mainBinaryName`（已是 `LoongPort`）。
 name = "cc-switch"
-version = "3.22.2"
+version = "3.22.3"
 description = "同样的 Codex，成本省 95% 以上 —— 填一个域名、登录一次，其余自动配好"
 authors = ["SailingLoong", "Jason Young"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LoongPort",
   "mainBinaryName": "LoongPort",
-  "version": "3.22.2",
+  "version": "3.22.3",
   "identifier": "dev.loongport.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
patch 小版本，包含 Gemini 档位端点修复（#55）。

Gemini CLI 自己拼 `/v1beta`，中转站 base 保持站点根；此前 LoongPort 给了带 `/v1` 的形状，
实际请求变成 `/v1/v1beta` 并返回 404。

四处版本号同步改：`package.json` / `src-tauri/Cargo.toml` / `src-tauri/Cargo.lock` /
`src-tauri/tauri.conf.json`。

六道闸：cargo test 2785 ✅ / clippy -D warnings ✅ / fmt --check ✅ / tsc ✅ /
format:check ✅ / vitest 703 ✅

CHANGELOG.md 沿用 3.22.2 惯例不动（文件最后停在 3.21.0）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)