### PR TITLE
fix(windows): migrate installer updates to NSIS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,8 +353,8 @@ jobs:
           $ErrorActionPreference = 'Stop'
           # ⚠️ 两个参数都不能省，x64 与 arm64 同构：
           #
-          # `--bundles msi`：tauri.conf.json 的 bundle.targets 是 "all"，裸 build 会连 NSIS
-          # 一起打，而 NSIS 要额外下载工具链（见 windows-build.yml 的注释）。给人试用只需 msi。
+          # `--bundles nsis`：普通用户与应用内自动更新统一走 NSIS，避开 MSI 每次升级
+          # 都写 Config.Msi 回滚文件、从而被部分安全软件拦截的路径。
           #
           # `--target`：本仓用 per-user WiX 模板（src-tauri/wix/per-user-main.wxs，上游自带），
           # 在默认 target 目录布局下过不了 WiX 的 ICE 校验 ——
@@ -365,9 +365,9 @@ jobs:
           # 改这里要连带改 "Prepare Windows Assets" 的 $targetRoot —— 带 --target 的产物落在
           # target/<triple>/release/ 而不是 target/release/，只改一处等于白改。
           if ($env:WINDOWS_RELEASE_ARCH -eq 'arm64') {
-            pnpm tauri build --target aarch64-pc-windows-msvc --bundles msi
+            pnpm tauri build --target aarch64-pc-windows-msvc --bundles nsis
           } else {
-            pnpm tauri build --target x86_64-pc-windows-msvc --bundles msi
+            pnpm tauri build --target x86_64-pc-windows-msvc --bundles nsis
           }
 
       - name: Build Tauri App (Linux)
@@ -583,30 +583,30 @@ jobs:
           $targetRoot = if ($isArm64) { 'src-tauri/target/aarch64-pc-windows-msvc/release' } else { 'src-tauri/target/x86_64-pc-windows-msvc/release' }
           $assetSuffix = if ($isArm64) { '-arm64' } else { '' }
 
-          # MSI 安装器（+ `.sig`，仅在启用 updater 时才有，见下）
-          $msi = Get-ChildItem -Path (Join-Path $targetRoot 'bundle/msi') -Recurse -Include *.msi -ErrorAction SilentlyContinue | Select-Object -First 1
-          if ($null -eq $msi) {
-            # 兜底：全局搜索 .msi
-            $msi = Get-ChildItem -Path (Join-Path $targetRoot 'bundle') -Recurse -Include *.msi -ErrorAction SilentlyContinue | Select-Object -First 1
+          # NSIS 安装器（+ `.sig`，供 updater 校验）。旧 MSI 用户第一次收到这个包时，
+          # installer hook 会按历史 UpgradeCode 卸载 per-user MSI，再继续安装；之后均为
+          # NSIS → NSIS 更新，不再经过 Config.Msi。
+          $installer = Get-ChildItem -Path (Join-Path $targetRoot 'bundle/nsis') -Recurse -Include *-setup.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+          if ($null -eq $installer) {
+            # 兜底：全局搜索 NSIS setup
+            $installer = Get-ChildItem -Path (Join-Path $targetRoot 'bundle') -Recurse -Include *-setup.exe -ErrorAction SilentlyContinue | Select-Object -First 1
           }
-          # 缺 MSI 对两个架构都是硬失败：原先 x64 只 Write-Warning，于是 release 会**静默**
+          # 缺 Setup 对两个架构都是硬失败：原先 x64 只 Write-Warning，于是 release 会**静默**
           # 少一个 Windows 安装包（fail-fast: false 之下其它平台照常发完，没人注意到）。
-          if ($null -eq $msi) {
-            throw "No Windows MSI installer found under $targetRoot/bundle"
+          if ($null -eq $installer) {
+            throw "No Windows NSIS installer found under $targetRoot/bundle"
           }
-          $dest = "LoongPort-$VERSION-Windows$assetSuffix.msi"
-          Copy-Item $msi.FullName (Join-Path release-assets $dest)
+          $dest = "LoongPort-$VERSION-Windows$assetSuffix-Setup.exe"
+          Copy-Item $installer.FullName (Join-Path release-assets $dest)
           Write-Host "Installer copied: $dest"
-          # `.sig` 缺失对两个架构都只是提示，不是失败：
-          # updater 插件**有意未启用**（见 src-tauri/src/lib.rs 那段说明 —— 上游端点会把用户
-          # 升级成 cc-switch），`createUpdaterArtifacts` 也没开，所以 `.sig` 现在必然不存在。
-          # 原先 arm64 分支在这里 throw ⇒ 那个 job 必然失败。启用 updater 后它会自动出现。
-          $sigPath = "$($msi.FullName).sig"
+          # `.sig` 缺失对两个架构都只是提示，不是失败：没有 release signing secret 时
+          # 仍保留可手动安装的 Setup，但 assemble-latest-json 不会把它放进自动更新清单。
+          $sigPath = "$($installer.FullName).sig"
           if (Test-Path $sigPath) {
             Copy-Item $sigPath (Join-Path release-assets ("$dest.sig"))
             Write-Host "Signature copied: $dest.sig"
           } else {
-            Write-Host "○ 没有 .sig（签名密钥未配？updater 自 2026-08-04 起已启用），跳过"
+            Write-Host "○ 没有 .sig（未配置自动更新签名密钥），跳过"
           }
 
           # 绿色版（portable）：仅可执行文件打 zip（不参与 Updater）
@@ -627,7 +627,7 @@ jobs:
           # 路径复用上面的 $targetRoot，别再单独列一份候选路径：那份在 x64 加 `--target` 那次
           # 就已经过时了（还把空的 target/release/ 排在第一位）。同一事实两处写等着分叉。
           $exePath = Join-Path $targetRoot 'LoongPort.exe'
-          # 缺 exe 对两个架构都是硬失败，理由同 MSI：release notes 承诺了绿色版，
+          # 缺 exe 对两个架构都是硬失败：release notes 承诺了绿色版，
           # 静默少一个包比整个 job 红更难发现。
           if (-not (Test-Path $exePath)) {
             throw "Portable exe not found: $exePath"
@@ -781,8 +781,8 @@ jobs:
             ### 下载
 
             - **macOS**: `LoongPort-${{ github.ref_name }}-macOS.dmg`（推荐）或 `LoongPort-${{ github.ref_name }}-macOS.zip`（解压即用）
-            - **Windows (x86_64)**: `LoongPort-${{ github.ref_name }}-Windows.msi`（安装版）或 `LoongPort-${{ github.ref_name }}-Windows-Portable.zip`（绿色版）
-            - **Windows (ARM64)**: `LoongPort-${{ github.ref_name }}-Windows-arm64.msi`（安装版）或 `LoongPort-${{ github.ref_name }}-Windows-arm64-Portable.zip`（绿色版）
+            - **Windows (x86_64)**: `LoongPort-${{ github.ref_name }}-Windows-Setup.exe`（安装版）或 `LoongPort-${{ github.ref_name }}-Windows-Portable.zip`（绿色版）
+            - **Windows (ARM64)**: `LoongPort-${{ github.ref_name }}-Windows-arm64-Setup.exe`（安装版）或 `LoongPort-${{ github.ref_name }}-Windows-arm64-Portable.zip`（绿色版）
 
             > Linux 包暂未提供。
 
@@ -799,26 +799,9 @@ jobs:
             ```
 
             ---
-            ⚠️ **Windows：装新版本时若报「无法设置文件安全性 / could not set file security」**
-
-            少数装了安全软件（如腾讯电脑管家）的机器上，**覆盖安装**旧版本会失败：
-
-            ```
-            could not set file security for file 'D:\Config.Msi\xxxxxxx.rbf'  Error: 5
-            ```
-
-            那是安全软件拦住了安装程序**备份旧文件**的动作，**不是安装包坏了**。
-            两个办法，任选一个：
-
-            1. **先卸载旧版本再装**（设置 → 应用 → 卸载 LoongPort，然后双击新安装包）。
-               全新安装不需要备份旧文件，就不会被拦。**账号和配置不会丢** ——
-               它们存在用户目录下，卸载不动它们，装回来仍是登录状态。
-               <!-- 2026-08-04 在维护者的 Windows 机上实测过这条路：卸载 + 全新装
-                    退出码 0，且 Config.Msi 里一个 .rbf 都没写（全新装无旧文件可备份
-                    ⇒ 压根不触发那一步）；~/.loongport 前后都是 8 个文件。 -->
-            2. **用绿色版**（上面的 `-Portable.zip`），解压即用，不经过 Windows 安装程序。
-
-            > 首次安装的用户不会遇到这个 —— 它只在覆盖旧版本时出现。
+            > 从旧 MSI 版首次升级时，Setup 会先卸载旧安装登记再安装新版；账号和配置位于
+            > 用户目录，不会被删除。完成这次迁移后，后续自动更新均走 NSIS，不再使用
+            > `Config.Msi` 回滚目录。
           files: release-assets/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -869,9 +852,9 @@ jobs:
               *.tar.gz)
                 # 视为 macOS updater artifact
                 mac_url="$url"; mac_sig="$sig_content";;
-              *-Windows-arm64.msi)
+              *-Windows-arm64-Setup.exe)
                 win_arm64_url="$url"; win_arm64_sig="$sig_content";;
-              *-Windows.msi)
+              *-Windows-Setup.exe)
                 win_x64_url="$url"; win_x64_sig="$sig_content";;
               *-Linux-arm64.AppImage|*-Linux-arm64.appimage)
                 linux_arm64_url="$url"; linux_arm64_sig="$sig_content";;

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,7 +1,7 @@
 # 不打 tag 也能出一个 Windows 安装包 —— 拿任意分支的代码给人试用时用它。
 #
 # **与 `release.yml` 的分工**：那个由 tag 触发，出全平台产物并建 GitHub Release；
-# 这个只手动触发、只出 Windows msi，不建 Release、不碰 tag。
+# 这个只手动触发、只出 Windows NSIS Setup，不建 Release、不碰 tag。
 # （两者在零 secrets 下都能跑绿 —— 2026-08-04 用 `v3.19.2-rc.1` 演练验过。）
 #
 # 不签名的代价：用户第一次运行会看到 SmartScreen 的「未知发布者」警告，要点「更多信息 →
@@ -10,7 +10,7 @@ name: Windows Build
 
 on:
   # **只手动触发。** 出包是个有意的动作，不该每次 push 都烧 CI 额度；
-  # 打 tag 那条路归 `release.yml` —— 它已经出 msi + 免安装版、x64 + arm64 四个产物，
+  # 打 tag 那条路归 `release.yml` —— 它已经出 Setup + 免安装版、x64 + arm64 四个产物，
   # 这个 workflow 再跟着 tag 跑一遍就是白编两次 Windows（实测 17 分钟起）。
   workflow_dispatch:
     inputs:
@@ -96,12 +96,13 @@ jobs:
           cargo test --manifest-path src-tauri/Cargo.toml
 
       - name: 打包
-        # 只出 msi。nsis 那条要额外下载安装器工具链，给人试用不需要两种包。
-        run: pnpm tauri build --target ${{ matrix.target }} --bundles msi
+        # 手动测试包不参与自动更新，所以显式关闭 updater artifact；否则没有 release
+        # signing secret 的 workflow 会在安装包已生成后因缺私钥返回失败。
+        run: pnpm tauri build --target ${{ matrix.target }} --bundles nsis --config '{"bundle":{"createUpdaterArtifacts":false}}'
 
       - uses: actions/upload-artifact@v4
         with:
           name: LoongPort-windows-${{ matrix.arch }}
-          path: src-tauri/target/${{ matrix.target }}/release/bundle/msi/*.msi
+          path: src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*-setup.exe
           if-no-files-found: error
           retention-days: 30

--- a/LOONGPORT.md
+++ b/LOONGPORT.md
@@ -51,7 +51,7 @@
 | CLI | codex · claude | gemini / grok（`platform_map` 映射表已建全，缺各自的配置写入形状） |
 | 平台 | macOS · Windows | Linux |
 
-**Windows 自 2026-08-03 起可用**（MSI 已在维护者机器上打出并验证）。
+**Windows 自 2026-08-03 起可用**（安装包已在维护者机器上打出并验证）。
 
 **ChatGPT 自动退出/重开两个平台都已实现**（Windows 于 2026-08-04 补完）。
 但**手段与语义不同，写对外文案时别当成完全等价**：
@@ -139,7 +139,7 @@ rm -rf "$(dirname "$STAGE")"
 | 平台 | 归档目录 | 产物 |
 |---|---|---|
 | macOS | `~/下载` | `LoongPort.app`（整个 .app 目录） |
-| Windows | `D:\`（D 盘根） | `LoongPort_<ver>_x64.msi` / `.exe` |
+| Windows | `D:\`（D 盘根） | `LoongPort_<ver>_x64-setup.exe` / Portable `.zip` |
 
 ```bash
 # mac：把 .app 复制到 ~/下载

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ LoongPort 免费，不经手付款、不从你的余额抽成。你充值给的�
 
 | 平台 | 文件 | 说明 |
 |---|---|---|
-| **Windows** | `…-Windows-Portable.zip` | **推荐** —— 解压出一个 exe 就能跑，没有安装步骤，也就没有会被安全软件拦住的动作 |
-| | `…-Windows.msi` | 安装版，会建开始菜单项 |
+| **Windows** | `…-Windows-Setup.exe` | **推荐** —— 安装版，会建开始菜单项并支持应用内自动升级 |
+| | `…-Windows-Portable.zip` | 免安装版，解压即用；发现新版后需手动下载 |
 | **macOS** | `…-macOS.dmg` | 两种芯片通用 |
 
 ARM64 的 Windows 机器（如骁龙笔记本）用带 `-arm64` 的那两个。
@@ -122,8 +122,7 @@ ARM64 的 Windows 机器（如骁龙笔记本）用带 `-arm64` 的那两个。
 > xattr -dr com.apple.quarantine /Applications/LoongPort.app
 > ```
 >
-> 之后正常打开，只做这一次。这条命令做了什么、为什么安全，以及升级时
-> 「无法设置文件安全性」那个报错怎么处理，都在
+> 之后正常打开，只做这一次。这条命令做了什么、为什么安全，都在
 > **[loongport.dev/zh/download](https://loongport.dev/zh/download)**。
 
 ## 怎么用
@@ -165,7 +164,7 @@ ARM64 的 Windows 机器（如骁龙笔记本）用带 `-arm64` 的那两个。
 
 ## 怎么升级
 
-**安装版（msi）与 macOS 版会自己检查更新**：启动几秒后在后台问一次，有新版本就在
+**Windows Setup 安装版与 macOS 版会自己检查更新**：启动几秒后在后台问一次，有新版本就在
 「设置 → 关于」提示，点一下即下载、安装、重启。检查失败不打扰你（离线、连不上 GitHub
 都很常见），也可以随时手动点「检查更新」。
 
@@ -238,10 +237,8 @@ pnpm dev           # 开发模式，前端热更新
 # macOS
 pnpm tauri build --bundles app
 
-# Windows —— 两个参数都不能省。裸 `pnpm tauri build` 会在 MSI 链接那步炸
-# （WiX ICE38，本仓用的是 per-user WiX 模板），且 bundle.targets 是 "all"，
-# 还会去下载 NSIS 工具链。
-pnpm tauri build --target x86_64-pc-windows-msvc --bundles msi
+# Windows x64 NSIS Setup（应用内更新也使用同一种安装器）
+pnpm tauri build --target x86_64-pc-windows-msvc --bundles nsis
 ```
 
 macOS 上本机构建出来的应用不带隔离标记，Gatekeeper 不会介入。

--- a/README_EN.md
+++ b/README_EN.md
@@ -127,8 +127,8 @@ by GitHub Actions:
 
 | Platform | File | Notes |
 |---|---|---|
-| **Windows** | `…-Windows-Portable.zip` | **Recommended** — unzips to a single exe; no install step, so there is nothing for security software to block |
-| | `…-Windows.msi` | Installer, adds a Start menu entry |
+| **Windows** | `…-Windows-Setup.exe` | **Recommended** — installer with a Start menu entry and in-app updates |
+| | `…-Windows-Portable.zip` | No-install build; download new versions manually |
 | **macOS** | `…-macOS.dmg` | Universal binary |
 
 On ARM64 Windows machines (Snapdragon laptops and the like), use the two files with
@@ -142,8 +142,8 @@ On ARM64 Windows machines (Snapdragon laptops and the like), use the two files w
 > xattr -dr com.apple.quarantine /Applications/LoongPort.app
 > ```
 >
-> It opens normally after that, and you only do this once. What that command does, why it
-> is safe, and how to handle the "could not set file security" error when upgrading are
+> It opens normally after that, and you only do this once. What that command does and why it
+> is safe are
 > all covered at **[loongport.dev/en/download](https://loongport.dev/en/download)**.
 
 ## How it works
@@ -195,7 +195,7 @@ Four things worth knowing:
 
 ## Updating
 
-**The installer (msi) and the macOS build check for updates on their own**: a few
+**The Windows Setup and the macOS build check for updates on their own**: a few
 seconds after launch they ask once in the background, and a newer version shows up
 under Settings → About — one click downloads, installs and restarts. A failed check
 never bothers you (being offline or unable to reach GitHub is common enough), and you
@@ -283,10 +283,8 @@ nothing useful on Windows:
 # macOS
 pnpm tauri build --bundles app
 
-# Windows — both flags are required. Bare `pnpm tauri build` fails at the MSI link
-# step (WiX ICE38) because of this repo's per-user WiX template, and `bundle.targets`
-# is "all", so it would also try to fetch the NSIS toolchain.
-pnpm tauri build --target x86_64-pc-windows-msvc --bundles msi
+# Windows x64 NSIS Setup (the in-app updater uses the same installer type)
+pnpm tauri build --target x86_64-pc-windows-msvc --bundles nsis
 ```
 
 On macOS, a build produced on your own machine carries no quarantine flag, so

--- a/src-tauri/nsis/installer-hooks.nsh
+++ b/src-tauri/nsis/installer-hooks.nsh
@@ -1,0 +1,49 @@
+; LoongPort 从 per-user WiX/MSI 迁移到 NSIS 的一次性兼容层。
+;
+; Tauri 自带的 NSIS 模板会检测旧 WiX 安装，但只枚举 HKLM 的 Uninstall 键；
+; LoongPort 的历史 MSI 使用 InstallScope="perUser"，产品登记在 HKCU，因此会被漏掉。
+; 这里不用 DisplayName 模糊匹配，而用历史 MSI 的稳定 UpgradeCode 精确枚举相关产品。
+;
+; UpgradeCode 来自 wix/per-user-main.wxs 的 {{upgrade_code}} 在正式构建中的展开值。
+; 它是已发布 MSI 的持久身份，不能修改或删除；否则老用户无法自动迁移。
+!define LOONGPORT_WIX_UPGRADE_CODE "{f6ae9451-300e-59b9-9081-beb400b6cde1}"
+
+LangString LoongPortMsiMigrationPrompt ${LANG_ENGLISH} \
+  "An older MSI installation of LoongPort was found. It must be uninstalled before Setup can continue. Your accounts and settings will be kept. Continue?"
+LangString LoongPortMsiMigrationPrompt ${LANG_SIMPCHINESE} \
+  "检测到旧版 LoongPort MSI。继续安装前需要先卸载旧版；账号和配置会保留。是否继续？"
+LangString LoongPortMsiMigrationPrompt ${LANG_TRADCHINESE} \
+  "偵測到舊版 LoongPort MSI。繼續安裝前需要先解除安裝舊版；帳號與設定會保留。是否繼續？"
+LangString LoongPortMsiMigrationPrompt ${LANG_JAPANESE} \
+  "旧版 LoongPort MSI が見つかりました。セットアップを続行する前にアンインストールします。アカウントと設定は保持されます。続行しますか？"
+
+LangString LoongPortMsiMigrationFailed ${LANG_ENGLISH} \
+  "The older LoongPort MSI could not be uninstalled (error $R1). Setup will stop without changing your data. Uninstall LoongPort from Windows Settings, then run Setup again."
+LangString LoongPortMsiMigrationFailed ${LANG_SIMPCHINESE} \
+  "旧版 LoongPort MSI 卸载失败（错误 $R1）。安装已停止，用户数据未改动。请先在 Windows 设置中卸载 LoongPort，再重新运行安装程序。"
+LangString LoongPortMsiMigrationFailed ${LANG_TRADCHINESE} \
+  "舊版 LoongPort MSI 解除安裝失敗（錯誤 $R1）。安裝已停止，使用者資料未變更。請先在 Windows 設定中解除安裝 LoongPort，再重新執行安裝程式。"
+LangString LoongPortMsiMigrationFailed ${LANG_JAPANESE} \
+  "旧版 LoongPort MSI のアンインストールに失敗しました（エラー $R1）。データを変更せずセットアップを中止します。Windows の設定から LoongPort をアンインストールして、もう一度実行してください。"
+
+!macro NSIS_HOOK_PREINSTALL
+  ; MsiEnumRelatedProducts 同时覆盖 per-user / per-machine 注册上下文，比遍历 HKCU/HKLM
+  ; 并比较显示名称更精确。返回 0 = 找到，1608 = 没有更多相关产品。
+  System::Call 'msi::MsiEnumRelatedProductsW(w "${LOONGPORT_WIX_UPGRADE_CODE}", i 0, i 0, w .R0) i .R1'
+  ${If} $R1 = 0
+    ; 应用内更新已经由用户点过“更新”，且 updater 会传 /UPDATE；不要再弹第二次。
+    ; 手动双击 Setup 时则明确告知这次一次性迁移。
+    ${If} $UpdateMode != 1
+      MessageBox MB_ICONINFORMATION|MB_OKCANCEL "$(LoongPortMsiMigrationPrompt)" IDOK +2
+      Abort
+    ${EndIf}
+
+    DetailPrint "Removing legacy LoongPort MSI $R0"
+    ExecWait '"$SYSDIR\msiexec.exe" /x $R0 /passive /norestart' $R1
+    ${If} $R1 != 0
+      MessageBox MB_ICONSTOP|MB_OK "$(LoongPortMsiMigrationFailed)"
+      SetErrorLevel $R1
+      Abort
+    ${EndIf}
+  ${EndIf}
+!macroend

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,7 +36,8 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "publisher": "SailingLoong",
+    "targets": ["nsis"],
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
@@ -46,6 +47,10 @@
       "icons/icon.ico"
     ],
     "windows": {
+      "nsis": {
+        "installerHooks": "nsis/installer-hooks.nsh",
+        "languages": ["English", "SimpChinese", "TradChinese", "Japanese"]
+      },
       "wix": {
         "template": "wix/per-user-main.wxs"
       }

--- a/tests/lib/windowsInstallerContract.test.ts
+++ b/tests/lib/windowsInstallerContract.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string) =>
+  readFileSync(resolve(process.cwd(), path), "utf8");
+
+/**
+ * Windows 普通安装与应用内更新必须使用同一种 NSIS 产物。
+ *
+ * latest.json 每个 Windows 架构只能放一个 URL；如果 build 改成 NSIS 而清单仍筛 MSI，
+ * 发布会静默失去 Windows 自动更新。反过来，清单继续指向 MSI 就会让每次自动升级重新
+ * 进入 Config.Msi rollback 路径，恢复 Error 1926。
+ */
+describe("Windows NSIS 安装与自动更新契约", () => {
+  it("Tauri 默认 bundle 是 NSIS，并挂载旧 MSI 迁移 hook", () => {
+    const config = JSON.parse(read("src-tauri/tauri.conf.json"));
+    expect(config.bundle.targets).toEqual(["nsis"]);
+    // Tauri 模板会先用 ProductName + Publisher 模糊命中 WiX，然后执行
+    // 不带静默参数的 UninstallString。与历史 MSI 的 loongport 区分开，
+    // 才会让下面按 UpgradeCode 精确识别的 hook 接管迁移。
+    expect(config.bundle.publisher).toBe("SailingLoong");
+    expect(config.bundle.windows.nsis.installerHooks).toBe(
+      "nsis/installer-hooks.nsh",
+    );
+  });
+
+  it("迁移按已发布 MSI 的 UpgradeCode 精确识别，而不是按显示名模糊删除", () => {
+    const hooks = read("src-tauri/nsis/installer-hooks.nsh");
+    expect(hooks).toContain("{f6ae9451-300e-59b9-9081-beb400b6cde1}");
+    expect(hooks).toContain("MsiEnumRelatedProductsW");
+    expect(hooks).toContain("msiexec.exe");
+    expect(hooks).toContain("/x $R0 /passive /norestart");
+    expect(hooks).toContain("$UpdateMode != 1");
+  });
+
+  it("正式发布、产物收集与 latest.json 全部只认 NSIS Setup", () => {
+    const workflow = read(".github/workflows/release.yml");
+    expect(workflow).toContain("--bundles nsis");
+    expect(workflow).toContain("bundle/nsis");
+    expect(workflow).toContain("-Windows$assetSuffix-Setup.exe");
+    expect(workflow).toContain("*-Windows-Setup.exe)");
+    expect(workflow).toContain("*-Windows-arm64-Setup.exe)");
+    expect(workflow).not.toContain("--bundles msi");
+  });
+
+  it("手动 Windows workflow 也出 Setup，但不要求 release 签名密钥", () => {
+    const workflow = read(".github/workflows/windows-build.yml");
+    expect(workflow).toContain("--bundles nsis");
+    expect(workflow).toContain('"createUpdaterArtifacts":false');
+    expect(workflow).toContain("bundle/nsis/*-setup.exe");
+    expect(workflow).not.toContain("--bundles msi");
+  });
+});


### PR DESCRIPTION
## What changed

- make NSIS Setup.exe the default Windows installer and updater artifact
- migrate legacy MSI installations by exact UpgradeCode before NSIS installation
- update release asset collection, `latest.json` assembly, manual Windows builds, and documentation
- add a contract test covering installer, migration, and release workflow consistency

## Why

MSI repair/upgrade writes rollback data under `Config.Msi`, which can be blocked by endpoint security software and make automatic upgrades fail. After a one-time MSI-to-NSIS migration, subsequent updates remain on the NSIS path.

## Verification

- Windows x64 NSIS release build completed successfully
- MSI → NSIS updater-mode migration exited 0; legacy MSI registration removed; user-data marker preserved
- NSIS → NSIS updater-mode reinstall exited 0; registration and user data preserved
- Windows installer contract tests: 4/4 passed
- TypeScript, Prettier, YAML parsing, and `git diff --check` passed
