### PR TITLE
fix(settings): enable Codex enhancements by default

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -447,19 +447,13 @@ pub struct AppSettings {
     /// 让官方 Codex provider 也跑在共享的 `custom` model_provider id 下，从而与第三方
     /// provider 共用一个会话历史桶。
     ///
-    /// **LoongPort 保持默认关**，有意为之：
+    /// **LoongPort 默认开**，让后续创建的官方与第三方会话出现在同一历史列表中；用户仍可
+    /// 手动关闭。存量官方会话迁移由 `unify_codex_migrate_existing` 单独记录用户意愿，默认开启
+    /// 本开关不会自动迁移历史。
     ///
-    /// - **切换路径上它对 LoongPort 是 no-op**：注入被 `category == Some("official")` 门控，
-    ///   而 sub2api 分组是第三方；且它们的 config 模板本身就写 `model_provider = "custom"`，
-    ///   已经在同一个桶里了 —— 分组之间的历史合并**天然成立，不需要这个开关**。
-    /// - **但开着它并非无害**：存量迁移那条路（`codex_history_migration`）的门控**不看
-    ///   provider category**，只看 live config.toml 的 `model_provider` 是否等于 `custom` ——
-    ///   而 LoongPort 切任一分组后恰好满足。于是它会真的去改写 ChatGPT 桌面版的历史会话
-    ///   （`sessions/*.jsonl` 与 `state_5.sqlite`），而**漏掉 ChatGPT.app 自己的
-    ///   `~/.codex/sqlite/codex-dev.db`**，在两套元数据之间留下永久不一致。
-    ///
-    /// 用户想让官方订阅的会话与分组会话并列时可以自己打开（UI 里会先弹知情同意）。
-    #[serde(default)]
+    /// 与 `preserve_codex_official_auth_on_switch` 一样，字段级 serde default 负责已有配置缺键
+    /// 的场景，`Default` impl 负责新装机，两处必须保持一致。
+    #[serde(default = "default_true")]
     pub unify_codex_session_history: bool,
     /// User opted in (via the enable dialog checkbox) to migrate existing
     /// official sessions ("openai" bucket) into the shared bucket. Persisted so
@@ -606,7 +600,7 @@ impl Default for AppSettings {
             show_profile_switcher: true,
             // 见字段上的说明：这条保的是 ChatGPT 桌面版的登录凭据，LoongPort 必须默认开。
             preserve_codex_official_auth_on_switch: true,
-            unify_codex_session_history: false,
+            unify_codex_session_history: true,
             unify_codex_migrate_existing: None,
             failover_confirmed: None,
             first_run_notice_confirmed: None,
@@ -1264,15 +1258,18 @@ mod tests {
     }
 
     #[test]
-    fn unify_codex_session_history_stays_off_by_default() {
-        // 保持关：分组之间的历史合并靠 config 模板里的 model_provider="custom" 天然成立，
-        // 而开着它会让存量迁移去改写 ChatGPT 桌面版的历史会话（且漏掉它自己那个
-        // codex-dev.db，留下永久不一致）。改成默认 true 前先读该字段的文档。
-        assert!(!AppSettings::default().unify_codex_session_history);
+    fn unify_codex_session_history_defaults_on_in_both_paths() {
+        assert!(AppSettings::default().unify_codex_session_history);
+
         let from_partial: AppSettings = serde_json::from_str("{}").expect("空对象应能解析");
-        assert!(!from_partial.unify_codex_session_history);
-        // 破坏性的存量迁移意愿必须保持「未表态」，不能被默认成同意。
+        assert!(from_partial.unify_codex_session_history);
+        // 存量迁移仍必须由用户单独选择，不能随开关默认开启。
         assert!(from_partial.unify_codex_migrate_existing.is_none());
+
+        let explicit_off: AppSettings =
+            serde_json::from_str(r#"{"unifyCodexSessionHistory":false}"#)
+                .expect("显式 false 应能解析");
+        assert!(!explicit_off.unify_codex_session_history);
     }
 
     #[test]

--- a/src/components/settings/CodexAuthSettings.tsx
+++ b/src/components/settings/CodexAuthSettings.tsx
@@ -99,7 +99,7 @@ export function CodexAuthSettings({
         icon={<KeyRound className="h-4 w-4 text-emerald-500" />}
         title={t("settings.preserveCodexOfficialAuthOnSwitch")}
         description={t("settings.preserveCodexOfficialAuthOnSwitchDescription")}
-        checked={settings.preserveCodexOfficialAuthOnSwitch ?? false}
+        checked={settings.preserveCodexOfficialAuthOnSwitch}
         onCheckedChange={(value) =>
           onChange({ preserveCodexOfficialAuthOnSwitch: value })
         }
@@ -109,7 +109,7 @@ export function CodexAuthSettings({
         icon={<History className="h-4 w-4 text-sky-500" />}
         title={t("settings.unifyCodexSessionHistory")}
         description={t("settings.unifyCodexSessionHistoryDescription")}
-        checked={settings.unifyCodexSessionHistory ?? false}
+        checked={settings.unifyCodexSessionHistory}
         onCheckedChange={handleUnifyHistoryChange}
       />
 

--- a/src/hooks/useSettingsForm.ts
+++ b/src/hooks/useSettingsForm.ts
@@ -5,8 +5,24 @@ import type { Settings } from "@/types";
 
 type Language = "zh" | "zh-TW" | "en" | "ja";
 
-export type SettingsFormState = Omit<Settings, "language"> & {
-  language: Language;
+type CodexAppEnhancementSettings = Required<
+  Pick<
+    Settings,
+    "preserveCodexOfficialAuthOnSwitch" | "unifyCodexSessionHistory"
+  >
+>;
+
+export type SettingsFormState = Omit<
+  Settings,
+  "language" | "preserveCodexOfficialAuthOnSwitch" | "unifyCodexSessionHistory"
+> &
+  CodexAppEnhancementSettings & {
+    language: Language;
+  };
+
+const DEFAULT_CODEX_APP_ENHANCEMENTS: CodexAppEnhancementSettings = {
+  preserveCodexOfficialAuthOnSwitch: true,
+  unifyCodexSessionHistory: true,
 };
 
 const normalizeLanguage = (lang?: string | null): Language => {
@@ -117,8 +133,11 @@ export function useSettingsForm(): UseSettingsFormResult {
       silentStartup: data.silentStartup ?? false,
       skipClaudeOnboarding: data.skipClaudeOnboarding ?? false,
       preserveCodexOfficialAuthOnSwitch:
-        data.preserveCodexOfficialAuthOnSwitch ?? false,
-      unifyCodexSessionHistory: data.unifyCodexSessionHistory ?? false,
+        data.preserveCodexOfficialAuthOnSwitch ??
+        DEFAULT_CODEX_APP_ENHANCEMENTS.preserveCodexOfficialAuthOnSwitch,
+      unifyCodexSessionHistory:
+        data.unifyCodexSessionHistory ??
+        DEFAULT_CODEX_APP_ENHANCEMENTS.unifyCodexSessionHistory,
       claudeConfigDir: sanitizeDir(data.claudeConfigDir),
       codexConfigDir: sanitizeDir(data.codexConfigDir),
       geminiConfigDir: sanitizeDir(data.geminiConfigDir),
@@ -144,8 +163,7 @@ export function useSettingsForm(): UseSettingsFormResult {
             useAppWindowControls: false,
             enableClaudePluginIntegration: false,
             skipClaudeOnboarding: false,
-            preserveCodexOfficialAuthOnSwitch: false,
-            unifyCodexSessionHistory: false,
+            ...DEFAULT_CODEX_APP_ENHANCEMENTS,
             language: readPersistedLanguage(),
           } as SettingsFormState);
 
@@ -184,8 +202,11 @@ export function useSettingsForm(): UseSettingsFormResult {
         silentStartup: serverData.silentStartup ?? false,
         skipClaudeOnboarding: serverData.skipClaudeOnboarding ?? false,
         preserveCodexOfficialAuthOnSwitch:
-          serverData.preserveCodexOfficialAuthOnSwitch ?? false,
-        unifyCodexSessionHistory: serverData.unifyCodexSessionHistory ?? false,
+          serverData.preserveCodexOfficialAuthOnSwitch ??
+          DEFAULT_CODEX_APP_ENHANCEMENTS.preserveCodexOfficialAuthOnSwitch,
+        unifyCodexSessionHistory:
+          serverData.unifyCodexSessionHistory ??
+          DEFAULT_CODEX_APP_ENHANCEMENTS.unifyCodexSessionHistory,
         claudeConfigDir: sanitizeDir(serverData.claudeConfigDir),
         codexConfigDir: sanitizeDir(serverData.codexConfigDir),
         geminiConfigDir: sanitizeDir(serverData.geminiConfigDir),

--- a/tests/hooks/useDirectorySettings.test.tsx
+++ b/tests/hooks/useDirectorySettings.test.tsx
@@ -46,6 +46,8 @@ const createSettings = (
   showInTray: true,
   minimizeToTrayOnClose: true,
   enableClaudePluginIntegration: false,
+  preserveCodexOfficialAuthOnSwitch: true,
+  unifyCodexSessionHistory: true,
   claudeConfigDir: "/claude/custom",
   codexConfigDir: "/codex/custom",
   grokConfigDir: "/grok/custom",

--- a/tests/hooks/useSettingsForm.test.tsx
+++ b/tests/hooks/useSettingsForm.test.tsx
@@ -51,6 +51,8 @@ describe("useSettingsForm Hook", () => {
     expect(settings.showInTray).toBe(true);
     expect(settings.minimizeToTrayOnClose).toBe(true);
     expect(settings.enableClaudePluginIntegration).toBe(false);
+    expect(settings.preserveCodexOfficialAuthOnSwitch).toBe(true);
+    expect(settings.unifyCodexSessionHistory).toBe(true);
     expect(settings.claudeConfigDir).toBe("/Users/demo");
     expect(settings.codexConfigDir).toBeUndefined();
     expect(settings.language).toBe("en");
@@ -79,6 +81,30 @@ describe("useSettingsForm Hook", () => {
 
     expect(result.current.initialLanguage).toBe("ja");
     expect(changeLanguageSpy).toHaveBeenCalledWith("ja");
+  });
+
+  it("should preserve explicitly disabled Codex app enhancements", async () => {
+    useSettingsQueryMock.mockReturnValue({
+      data: {
+        showInTray: true,
+        minimizeToTrayOnClose: true,
+        preserveCodexOfficialAuthOnSwitch: false,
+        unifyCodexSessionHistory: false,
+        language: "zh",
+      },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useSettingsForm());
+
+    await waitFor(() => {
+      expect(result.current.settings).not.toBeNull();
+    });
+
+    expect(result.current.settings?.preserveCodexOfficialAuthOnSwitch).toBe(
+      false,
+    );
+    expect(result.current.settings?.unifyCodexSessionHistory).toBe(false);
   });
 
   it("should support traditional chinese language preference aliases", async () => {
@@ -131,6 +157,10 @@ describe("useSettingsForm Hook", () => {
     });
 
     expect(result.current.settings?.showInTray).toBe(false);
+    expect(result.current.settings?.preserveCodexOfficialAuthOnSwitch).toBe(
+      true,
+    );
+    expect(result.current.settings?.unifyCodexSessionHistory).toBe(true);
 
     changeLanguageSpy.mockClear();
     act(() => {
@@ -178,6 +208,8 @@ describe("useSettingsForm Hook", () => {
     expect(settings.showInTray).toBe(false);
     expect(settings.minimizeToTrayOnClose).toBe(false);
     expect(settings.enableClaudePluginIntegration).toBe(true);
+    expect(settings.preserveCodexOfficialAuthOnSwitch).toBe(true);
+    expect(settings.unifyCodexSessionHistory).toBe(true);
     expect(settings.claudeConfigDir).toBe("/reset");
     expect(settings.codexConfigDir).toBeUndefined();
     expect(settings.language).toBe("zh");


### PR DESCRIPTION
## Summary / 概述

- 默认开启“非接管切换时保留官方登录”和“统一 Codex 会话历史”
- 统一前端缺字段时的默认值，避免表单回落为关闭
- 保留用户显式关闭选择；既有会话迁移仍需用户单独确认

## Related Issue / 关联 Issue

无。

## Screenshots / 截图

不适用，仅修改现有开关默认状态。

## Verification / 验证

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `pnpm exec tsc --noEmit`
- `pnpm format:check`
- `pnpm vitest run tests/hooks/useSettingsForm.test.tsx tests/hooks/useDirectorySettings.test.tsx`（16 tests passed）

本地全量 Vitest 在未修改的 Radix UI 测试中出现超时；远程必需检查继续作为自动合并门槛。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] No user-facing text changed / 未修改用户可见文本