### PR TITLE
fix(ui): keep dialogs above app chrome

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -12,37 +12,38 @@ const DialogPortal = DialogPrimitive.Portal;
 
 const DialogClose = DialogPrimitive.Close;
 
+// Modal layers start above the app header (50) and custom window drag region (70).
+const DIALOG_Z_INDEX_CLASS = {
+  base: "z-[80]",
+  nested: "z-[90]",
+  alert: "z-[100]",
+  top: "z-[110]",
+} as const;
+
+type DialogZIndex = keyof typeof DIALOG_Z_INDEX_CLASS;
+
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay> & {
-    zIndex?: "base" | "nested" | "alert" | "top";
+    zIndex?: DialogZIndex;
   }
->(({ className, zIndex = "base", ...props }, ref) => {
-  const zIndexMap = {
-    base: "z-40",
-    nested: "z-50",
-    alert: "z-[60]",
-    top: "z-[110]",
-  };
-
-  return (
-    <DialogPrimitive.Overlay
-      ref={ref}
-      className={cn(
-        "fixed inset-0 bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-        zIndexMap[zIndex],
-        className,
-      )}
-      {...props}
-    />
-  );
-});
+>(({ className, zIndex = "base", ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      DIALOG_Z_INDEX_CLASS[zIndex],
+      className,
+    )}
+    {...props}
+  />
+));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
-    zIndex?: "base" | "nested" | "alert" | "top";
+    zIndex?: DialogZIndex;
     variant?: "default" | "fullscreen";
     overlayClassName?: string;
     /**
@@ -84,13 +85,6 @@ const DialogContent = React.forwardRef<
     // 实测踩过（4 个测试文件同时红）。这是本目录第一个用 hook 的组件，
     // 破例的理由就是它：mock 提供 `useTranslation`，不提供那个初始化导出。
     const { t } = useTranslation();
-    const zIndexMap = {
-      base: "z-40",
-      nested: "z-50",
-      alert: "z-[60]",
-      top: "z-[110]",
-    };
-
     const variantClass = {
       default:
         "fixed left-1/2 top-1/2 flex flex-col w-full max-w-lg max-h-[90vh] translate-x-[-50%] translate-y-[-50%] border border-border-default bg-background text-foreground shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
@@ -103,7 +97,7 @@ const DialogContent = React.forwardRef<
         <DialogOverlay zIndex={zIndex} className={overlayClassName} />
         <DialogPrimitive.Content
           ref={ref}
-          className={cn(variantClass, zIndexMap[zIndex], className)}
+          className={cn(variantClass, DIALOG_Z_INDEX_CLASS[zIndex], className)}
           onInteractOutside={(e) => {
             // 防止点击遮罩层关闭对话框
             e.preventDefault();

--- a/tests/components/Dialog.test.tsx
+++ b/tests/components/Dialog.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+describe("Dialog", () => {
+  it("renders the default modal layer above the application chrome", () => {
+    render(
+      <Dialog open>
+        <DialogContent overlayClassName="test-dialog-overlay">
+          <DialogTitle>Test dialog</DialogTitle>
+          <DialogDescription>Test description</DialogDescription>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    expect(screen.getByRole("dialog")).toHaveClass("z-[80]");
+    expect(document.querySelector(".test-dialog-overlay")).toHaveClass(
+      "z-[80]",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- raise the shared dialog layer above the app header and window drag region
- keep overlay and content on one shared z-index mapping
- add a regression test for the default modal layer

## Validation

- pnpm vitest run --maxWorkers=1 (114 files, 708 tests)
- pnpm typecheck
- pnpm format:check
- cargo test
- cargo clippy --all-targets -- -D warnings
- cargo fmt --check
- browser verification of the header beneath the modal overlay