### PR TITLE
fix: sync imagegen MCP across app lifecycle

### DIFF
--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -37,8 +37,8 @@ use crate::app_config::AppType;
 use crate::error::AppError;
 use crate::events::{emit_provider_switched, PURCHASE_CLOSED};
 use crate::provider::Provider;
-use crate::relay::{api, chatgpt_app, creds, login, provision, purchase};
-use crate::services::{McpService, ProviderService};
+use crate::relay::{api, chatgpt_app, creds, imagegen_mcp, login, provision, purchase};
+use crate::services::ProviderService;
 use crate::store::AppState;
 
 /// 默认中转站域名。域名输入框的底纹词，用户直接点确定就用它。
@@ -1079,7 +1079,7 @@ async fn do_provision(
     //
     // 失败只 warn：档位已经存对了，不该因为一个 MCP 记录写不下去就把「获取密钥」
     // 整个报成失败（用户会以为连密钥都没拿到）。
-    if let Err(e) = sync_imagegen_mcp(&state) {
+    if let Err(e) = imagegen_mcp::sync_registration(&state) {
         log::warn!("同步生图工具记录失败（生图可能暂时用不了）: {e}");
     }
 
@@ -2052,7 +2052,7 @@ fn remove_site_impl(state: &AppState, id: i64) -> Result<(), AppError> {
     //
     // 失败只 warn：站点记录马上就删了，不该因为一个 MCP 记录撤不掉而让「删站点」失败
     // （与上面那段清理档位同一条原则）。
-    if let Err(e) = sync_imagegen_mcp(state) {
+    if let Err(e) = imagegen_mcp::sync_registration(state) {
         log::warn!("删除站点 {site_origin} 后同步生图工具记录失败: {e}");
     }
 
@@ -2470,123 +2470,10 @@ fn with_conn<T>(
 // 生图工具（MCP）
 // ============================================================================
 
-/// 生图 MCP 在 `mcp_servers` 表里的 id。
-///
-/// ## 为什么是**一条固定记录**而不是「一个档位一条」
-///
-/// 「用哪个档位生图」= 生图栏（`codex-image`）的当前项，MCP 进程**每次生图时现读**
-/// （见 `imagegen_mcp::current_image_tier_id`）。所以这条 MCP 记录的内容与档位无关，
-/// 只回答「这个宿主要不要有生图工具」—— 换档位不必改它。
-///
-/// 那正是「切生图档位不用重启 codex」的来源：codex 只在启动时读它的 `config.toml`，
-/// 若档位 id 写在这条记录里，用户每换一次都得新开终端。
-///
-/// ⚠️ 这个 id 会成为 `[mcp_servers.<id>]` 的表名，**跨出了进程边界** ——
-/// 改它等于让已装用户的旧配置成为孤儿（库里删不到、CLI 里还留着一条起不来的 server）。
-const IMAGEGEN_MCP_ID: &str = "loongport-imagegen";
-
-/// 启动 MCP server 模式的命令行开关。**与 `main.rs` 里那个判断必须一致**。
-///
-/// 两处各写一遍字面量迟早分叉（改了一处另一处没跟上 ⇒ 写出去的配置启动不了 server，
-/// 而症状是宿主那边"启动超时"，看不出是拼写问题）。所以这里是唯一定义，
-/// `main.rs` 用 `cc_switch_lib::IMAGEGEN_MCP_FLAG` 引它。
-pub const IMAGEGEN_MCP_FLAG: &str = "--mcp-image-gen";
-
-/// 生图工具的安装 / 撤销，跟着「生图栏里有没有档位」自动走。
-///
-/// ## 为什么不再有「启用生图」这个显式动作
-///
-/// 上一版有一对命令（`relay_set_image_tier` / `relay_current_image_tier`）在
-/// `settings` 表里维护「用哪个档位生图」。分栏之后那套是纯粹的重复：
-/// 「当前是哪一档」由 `providers.is_current` 表达，而它**每个 app_type 一栏** ——
-/// 生图栏天然就有自己的一份，用户点「切换」走的就是与聊天档位同一条路
-/// （`relay_switch_tier`）。
-///
-/// 所以现在只剩一个问题：**这个宿主要不要有生图工具**。答案由生图栏里有没有档位决定，
-/// 在 provision 收尾时对齐一次（见 [`sync_imagegen_mcp`]）。用户不必学第二套操作。
-/// 确保生图 MCP 记录在库里（进而被同步进各 CLI 的配置）。
-///
-/// ## 为什么写 `mcp_servers` 表而不是直接改 CLI 的配置文件
-///
-/// 那张表是 MCP 的 SSOT，各 CLI 的 `config.toml` / `mcp.json` 只是它的投影
-/// （`codex_config.rs` 的 `strip_codex_mcp_servers_from_settings` 那段注释钉过这条）。
-/// 自己去写配置文件会被下一次同步覆盖，而且绕过了「切档位时重投影」那套逻辑。
-///
-/// **幂等**：装的那一支走 `upsert_server`（覆盖同 id），撤的那一支走 `delete_server`
-/// （不存在时返回 `Ok(false)`）。所以每次 provision 收尾都能无条件调它。
-///
-/// ## 「有没有生图档位」是唯一判据
-///
-/// 用户那个站可能压根没有生图分组（实测 bestapi.store 就没有）—— 那时生图栏是空的，
-/// 这里把 MCP 记录撤掉 ⇒ **CLI 的配置里一个字都不多**，完全无感。
-/// 有生图分组的用户则自动获得那个工具，不必学一个额外的「启用生图」动作。
-///
-/// ⚠️ **不看「有没有选当前项」** —— 那会让「装工具」依赖一个用户可能还没做的选择，
-/// 而工具在没选档位时本来就会给出一句可操作的提示（`NO_IMAGE_TIER_HINT`）。
-/// 反过来（有档位却没工具）才是真的坏：用户说「画一只猫」，模型答「我没有这个工具」。
-fn sync_imagegen_mcp(state: &AppState) -> Result<(), AppError> {
-    let has_image_tiers = ProviderService::list(state, AppType::CodexImage)
-        .map(|list| list.values().any(is_managed))
-        .unwrap_or(false);
-
-    if !has_image_tiers {
-        // 撤掉。**不因为它本来就不在而算失败** —— `delete_server` 返回 `Ok(false)`。
-        let removed = McpService::delete_server(state, IMAGEGEN_MCP_ID)?;
-        if removed {
-            log::info!("生图栏里没有档位了，撤掉生图 MCP 记录");
-        }
-        return Ok(());
-    }
-
-    install_imagegen_mcp(state)
-}
-
-/// 把生图 MCP 记录写进库（幂等）。
-fn install_imagegen_mcp(state: &AppState) -> Result<(), AppError> {
-    // 当前可执行文件的绝对路径。macOS 上这是 `.app/Contents/MacOS/<bin>`，
-    // 正是 CLI 该去启动的东西。
-    let exe = std::env::current_exe()
-        .map_err(|e| AppError::Message(format!("获取可执行文件路径失败: {e}")))?;
-    let exe_str = exe
-        .to_str()
-        .ok_or_else(|| AppError::Message("可执行文件路径不是有效的 UTF-8".into()))?;
-
-    // ⚠️ **args 里不带档位 id** —— 见 `IMAGEGEN_MCP_ID` 的文档：带了就等于每次换档位都
-    // 改 CLI 配置文件，而 codex 只在启动时读它。
-    let spec = serde_json::json!({
-        "type": "stdio",
-        "command": exe_str,
-        "args": [IMAGEGEN_MCP_FLAG],
-    });
-
-    // 装到 codex + claude + gemini：这三个都支持 stdio MCP，而「要生图」与用户在哪个
-    // CLI 里干活无关。不装 opencode / hermes —— 那两个的配置形状要另外验，没验过的不写。
-    let apps = crate::app_config::McpApps {
-        codex: true,
-        claude: true,
-        gemini: true,
-        ..Default::default()
-    };
-
-    McpService::upsert_server(
-        state,
-        crate::app_config::McpServer {
-            id: IMAGEGEN_MCP_ID.to_string(),
-            name: "LoongPort 生图".to_string(),
-            server: spec,
-            apps,
-            // ⚠️ **描述里不提某个档位名** —— 这条记录与档位无关（换档位不改它），
-            // 写了档位名就得在每次切换时刷新它，而那正是「不必重启 CLI」要避免的事。
-            description: Some(
-                "用 LoongPort「生图」标签页里当前那个档位生图（gpt-image 系列）。\
-                 由 LoongPort 自动维护，密钥不写进 CLI 配置 —— 换档位也不必重启 CLI。"
-                    .to_string(),
-            ),
-            homepage: None,
-            docs: None,
-            tags: vec!["loongport".into(), "image".into()],
-        },
-    )
+/// 重新对齐生图 MCP。进入生图页时调用，用来修复应用运行期间被外部改掉的投影。
+#[tauri::command]
+pub fn relay_sync_imagegen_mcp(state: State<'_, AppState>) -> Result<(), AppError> {
+    imagegen_mcp::sync_registration(&state)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -360,10 +360,10 @@ pub fn run_imagegen_mcp() -> Result<(), String> {
 
 /// 启动 MCP server 模式的命令行开关，给 `main.rs` 用。
 ///
-/// **唯一定义在 [`commands::IMAGEGEN_MCP_FLAG`]** —— 写配置的那一侧（装工具时填进
+/// **唯一定义在 [`relay::imagegen_mcp::IMAGEGEN_MCP_FLAG`]** —— 写配置的那一侧（装工具时填进
 /// `args`）与读参数的这一侧（`main.rs` 的分流判断）必须是同一个字符串，
 /// 两处各写一遍字面量迟早分叉，而症状是宿主那边"启动超时"，看不出是拼写问题。
-pub use commands::IMAGEGEN_MCP_FLAG;
+pub use relay::imagegen_mcp::IMAGEGEN_MCP_FLAG;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -922,6 +922,12 @@ pub fn run() {
                 }
                 Ok(_) => log::debug!("○ No Hermes provider changes from live config"),
                 Err(e) => log::warn!("✗ Failed to import Hermes providers: {e}"),
+            }
+
+            // 生图 MCP 是「生图栏里是否有托管档位」的派生状态。启动时无条件对齐一次，
+            // 覆盖升级后已有档位但从未再次 provision、以及应用升级后可执行路径变化的情况。
+            if let Err(e) = crate::relay::imagegen_mcp::sync_registration(&app_state) {
+                log::warn!("启动时同步生图 MCP 失败（进入生图页时会重试）: {e}");
             }
 
             // 2. OMO 配置导入（当数据库中无 OMO provider 时，从本地文件导入）
@@ -1523,6 +1529,7 @@ pub fn run() {
             commands::relay_list_tier_rates,
             commands::relay_reorder,
             commands::relay_reset_tier_config,
+            commands::relay_sync_imagegen_mcp,
             commands::relay_switch_tier,
             commands::relay_list_sites,
             commands::relay_remove_site,

--- a/src-tauri/src/relay/imagegen_mcp.rs
+++ b/src-tauri/src/relay/imagegen_mcp.rs
@@ -32,7 +32,7 @@
 //! | 独立 Rust sidecar | 每平台多一份二进制，macOS 上要多签名 + 公证一个 |
 //! | **本模块** | **零新增**：已经签好的那个二进制自己就是 server |
 //!
-//! 所以入口是 `LoongPort --mcp-image-gen --tier <provider_id>`，
+//! 所以入口是 `LoongPort --mcp-image-gen`，
 //! 在 [`crate::run`] **之前**分流（见那里的说明：走进去会被 single-instance 插件
 //! 当成第二个实例而唤起主窗口）。
 //!
@@ -51,6 +51,69 @@ use std::path::PathBuf;
 
 use rusqlite::OptionalExtension;
 use serde_json::{json, Value};
+
+use crate::app_config::{AppType, McpApps, McpServer};
+use crate::error::AppError;
+use crate::services::{McpService, ProviderService};
+use crate::store::AppState;
+
+/// 生图 MCP 在统一 MCP 数据源里的稳定 id。
+pub const IMAGEGEN_MCP_ID: &str = "loongport-imagegen";
+
+/// 启动 MCP server 模式的命令行开关。
+pub const IMAGEGEN_MCP_FLAG: &str = "--mcp-image-gen";
+
+/// 让生图 MCP 注册状态与生图档位保持一致，并投影到支持它的 CLI。
+///
+/// 这是生图 MCP 生命周期的唯一入口。provision、删站、应用启动与进入生图页都调用它；
+/// 函数本身幂等，因此这些入口可以按各自生命周期无条件对齐。
+pub fn sync_registration(state: &AppState) -> Result<(), AppError> {
+    let has_image_tiers = ProviderService::list(state, AppType::CodexImage)?
+        .values()
+        .any(|provider| crate::relay::is_managed(&provider.id));
+
+    if !has_image_tiers {
+        let removed = McpService::delete_server(state, IMAGEGEN_MCP_ID)?;
+        if removed {
+            log::info!("生图栏里没有档位了，撤掉生图 MCP 记录");
+        }
+        return Ok(());
+    }
+
+    let exe = std::env::current_exe()
+        .map_err(|e| AppError::Message(format!("获取可执行文件路径失败: {e}")))?;
+    let exe_str = exe
+        .to_str()
+        .ok_or_else(|| AppError::Message("可执行文件路径不是有效的 UTF-8".into()))?;
+
+    McpService::upsert_server(state, registration_server(exe_str))
+}
+
+fn registration_server(exe: &str) -> McpServer {
+    McpServer {
+        id: IMAGEGEN_MCP_ID.to_string(),
+        name: "LoongPort 生图".to_string(),
+        server: json!({
+            "type": "stdio",
+            "command": exe,
+            "args": [IMAGEGEN_MCP_FLAG],
+        }),
+        apps: McpApps {
+            codex: true,
+            claude: true,
+            gemini: true,
+            ..Default::default()
+        },
+        description: Some(
+            "用 LoongPort「生图」标签页里当前那个档位生图（gpt-image 系列）。\
+             由 LoongPort 自动维护，密钥不写进 CLI 配置 —— 换档位也不必重启 CLI。"
+                .to_string(),
+        ),
+        homepage: None,
+        docs: None,
+        tags: vec!["loongport".into(), "image".into()],
+    }
+}
 
 /// 本模块的诊断输出：**写 stderr**。
 ///
@@ -750,6 +813,23 @@ pub fn serve() -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn registration_targets_supported_hosts_without_binding_a_tier() {
+        let server = registration_server("/Applications/LoongPort.app/Contents/MacOS/LoongPort");
+
+        assert_eq!(server.id, IMAGEGEN_MCP_ID);
+        assert!(server.apps.codex && server.apps.claude && server.apps.gemini);
+        assert!(!server.apps.opencode && !server.apps.hermes);
+        assert_eq!(
+            server.server,
+            json!({
+                "type": "stdio",
+                "command": "/Applications/LoongPort.app/Contents/MacOS/LoongPort",
+                "args": [IMAGEGEN_MCP_FLAG],
+            })
+        );
+    }
 
     /// ⚠️ **这个 crate 的 logger 写 stdout，而 stdout 是 MCP 的协议通道。**
     ///

--- a/src-tauri/src/services/mcp.rs
+++ b/src-tauri/src/services/mcp.rs
@@ -94,11 +94,22 @@ impl McpService {
 
     /// 将 MCP 服务器同步到所有启用的应用
     fn sync_server_to_apps(_state: &AppState, server: &McpServer) -> Result<(), AppError> {
+        let mut failures = Vec::new();
         for app in server.apps.enabled_apps() {
-            Self::sync_server_to_app_no_config(server, &app)?;
+            if let Err(err) = Self::sync_server_to_app_no_config(server, &app) {
+                log::warn!("同步 MCP '{}' 到 {app:?} 失败: {err}", server.id);
+                failures.push(format!("{}: {err}", app.as_str()));
+            }
         }
 
-        Ok(())
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(AppError::Message(format!(
+                "部分应用 MCP 同步失败: {}",
+                failures.join("; ")
+            )))
+        }
     }
 
     /// 将 MCP 服务器同步到指定应用

--- a/src-tauri/tests/mcp_commands.rs
+++ b/src-tauri/tests/mcp_commands.rs
@@ -4,9 +4,10 @@ use std::fs;
 use serde_json::json;
 
 use cc_switch_lib::{
-    get_claude_mcp_path, get_claude_mcp_status, get_claude_settings_path, get_grok_config_path,
-    import_default_config_test_hook, read_claude_mcp_config, update_settings, AppError,
-    AppSettings, AppType, McpApps, McpServer, McpService, MultiAppConfig, ProviderService,
+    get_claude_mcp_path, get_claude_mcp_status, get_claude_settings_path, get_codex_config_path,
+    get_grok_config_path, import_default_config_test_hook, read_claude_mcp_config, update_settings,
+    AppError, AppSettings, AppType, McpApps, McpServer, McpService, MultiAppConfig,
+    ProviderService,
 };
 
 #[path = "support.rs"]
@@ -518,6 +519,45 @@ fn import_from_all_apps_reports_broken_app_but_imports_the_rest() {
     assert!(
         entry.apps.claude,
         "imported server should have Claude app enabled"
+    );
+}
+
+#[test]
+fn upsert_reports_broken_claude_but_still_projects_to_codex() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+
+    fs::write(get_claude_mcp_path(), "{broken json").expect("seed broken Claude config");
+    let codex_dir = home.join(".codex");
+    fs::create_dir_all(&codex_dir).expect("create Codex config dir");
+    fs::write(get_codex_config_path(), "").expect("seed Codex config");
+
+    let state = create_test_state().expect("create test state");
+    let error = McpService::upsert_server(
+        &state,
+        McpServer {
+            id: "imagegen".to_string(),
+            name: "Imagegen".to_string(),
+            server: json!({ "type": "stdio", "command": "imagegen" }),
+            apps: McpApps {
+                claude: true,
+                codex: true,
+                ..Default::default()
+            },
+            description: None,
+            homepage: None,
+            docs: None,
+            tags: Vec::new(),
+        },
+    )
+    .expect_err("the broken Claude projection must still be reported");
+
+    assert!(error.to_string().contains("claude"));
+    let codex = fs::read_to_string(get_codex_config_path()).expect("read Codex config");
+    assert!(
+        codex.contains("mcp_servers.imagegen"),
+        "Claude failure must not short-circuit the Codex projection: {codex}"
     );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ import {
 } from "lucide-react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { Provider, VisibleApps } from "@/types";
-import { ALL_APPS_VISIBLE } from "@/config/appConfig";
+import { ALL_APPS_VISIBLE, APP_IDS } from "@/config/appConfig";
 import type { EnvConflict } from "@/types/env";
 import { proxyKeys, useProvidersQuery, useSettingsQuery } from "@/lib/query";
 import {
@@ -134,20 +134,9 @@ const HEADER_HEIGHT = 64; // px
 
 // 两个 localStorage key 的定义在 `@/config/constants` —— 别在这里重新写字面量。
 // 写入端在 `AppSwitcher.tsx`，那次分叉就是因为它们各写一份（见常量那边的文档）。
-const VALID_APPS: AppId[] = [
-  "claude",
-  "claude-desktop",
-  "codex",
-  "gemini",
-  "grokbuild",
-  "opencode",
-  "openclaw",
-  "hermes",
-];
-
 const getInitialApp = (): AppId => {
   const saved = localStorage.getItem(LAST_APP_STORAGE_KEY) as AppId | null;
-  if (saved && VALID_APPS.includes(saved)) {
+  if (saved && APP_IDS.includes(saved)) {
     return saved;
   }
   return "claude";
@@ -206,23 +195,21 @@ function App() {
   const visibleApps: VisibleApps =
     settingsData?.visibleApps ?? ALL_APPS_VISIBLE;
 
-  const getFirstVisibleApp = (): AppId => {
-    if (visibleApps.claude) return "claude";
-    if (visibleApps["claude-desktop"]) return "claude-desktop";
-    if (visibleApps.codex) return "codex";
-    if (visibleApps.gemini) return "gemini";
-    if (visibleApps.grokbuild) return "grokbuild";
-    if (visibleApps.opencode) return "opencode";
-    if (visibleApps.openclaw) return "openclaw";
-    if (visibleApps.hermes) return "hermes";
-    return "claude"; // fallback
-  };
+  const firstVisibleApp = APP_IDS.find((app) => visibleApps[app]) ?? "claude";
 
   useEffect(() => {
     if (!visibleApps[activeApp]) {
-      setActiveApp(getFirstVisibleApp());
+      setActiveApp(firstVisibleApp);
     }
-  }, [visibleApps, activeApp]);
+  }, [visibleApps, activeApp, firstVisibleApp]);
+
+  useEffect(() => {
+    if (activeApp !== "codex-image") return;
+
+    void invoke("relay_sync_imagegen_mcp").catch((error) => {
+      console.error("[App] Failed to sync image generation MCP", error);
+    });
+  }, [activeApp]);
 
   // Fallback from sessions view when switching to an app without session support
   useEffect(() => {

--- a/tests/integration/App.test.tsx
+++ b/tests/integration/App.test.tsx
@@ -2,7 +2,9 @@ import { Suspense, type ComponentType } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { http, HttpResponse } from "msw";
 import { providersApi } from "@/lib/api/providers";
+import { LAST_APP_STORAGE_KEY } from "@/config/constants";
 import {
   resetProviderState,
   setCurrentProviderId,
@@ -10,6 +12,7 @@ import {
   setProviders,
 } from "../msw/state";
 import { emitTauriEvent } from "../msw/tauriMocks";
+import { server } from "../msw/server";
 
 const toastSuccessMock = vi.fn();
 const toastErrorMock = vi.fn();
@@ -123,6 +126,9 @@ vi.mock("@/components/AppSwitcher", () => ({
       <span>{activeApp}</span>
       <button onClick={() => onSwitch("claude")}>switch-claude</button>
       <button onClick={() => onSwitch("codex")}>switch-codex</button>
+      <button onClick={() => onSwitch("codex-image")}>
+        switch-codex-image
+      </button>
       <button onClick={() => onSwitch("openclaw")}>switch-openclaw</button>
     </div>
   ),
@@ -167,6 +173,44 @@ describe("App integration with MSW", () => {
     //
     // key 必须与 App.tsx 的 VIEW_STORAGE_KEY 一致（那边加了 loongport- 前缀防止读到上游遗留值）。
     localStorage.setItem("loongport-last-view", "providers");
+    localStorage.setItem(LAST_APP_STORAGE_KEY, "claude");
+  });
+
+  it("restores the image page and reconciles its MCP registration on startup", async () => {
+    let syncCalls = 0;
+    server.use(
+      http.post("http://tauri.local/relay_sync_imagegen_mcp", () => {
+        syncCalls += 1;
+        return HttpResponse.json(null);
+      }),
+    );
+    localStorage.setItem(LAST_APP_STORAGE_KEY, "codex-image");
+
+    const { default: App } = await import("@/App");
+    renderApp(App);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("app-switcher")).toHaveTextContent(
+        "codex-image",
+      );
+      expect(syncCalls).toBe(1);
+    });
+  });
+
+  it("reconciles the image MCP registration when switching to the image page", async () => {
+    let syncCalls = 0;
+    server.use(
+      http.post("http://tauri.local/relay_sync_imagegen_mcp", () => {
+        syncCalls += 1;
+        return HttpResponse.json(null);
+      }),
+    );
+
+    const { default: App } = await import("@/App");
+    renderApp(App);
+    fireEvent.click(await screen.findByText("switch-codex-image"));
+
+    await waitFor(() => expect(syncCalls).toBe(1));
   });
 
   it("covers basic provider flows via real hooks", async () => {


### PR DESCRIPTION
## Summary / 概述

- Reconcile the managed image-generation MCP registration during app startup and when entering the Codex image page.
- Restore `codex-image` from the shared application ID source instead of a stale local list.
- Continue projecting MCP configuration to Codex when another client configuration is malformed.
- Add Rust and frontend regression coverage for startup restoration, page switching, and cross-client failure isolation.

## Related Issue / 关联 Issue

N/A

## Screenshots / 截图

Not applicable; behavior-only lifecycle fix.

## Checklist / 检查清单

- [x] `pnpm typecheck` equivalent (`npx tsc --noEmit`) passes
- [x] `pnpm format:check` equivalent Prettier check passes
- [x] `cargo test` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] `npx vitest run` passes
- [x] No user-facing text or i18n changes