### PR TITLE
fix(relay): preserve managed credentials across edits

### DIFF
--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -104,7 +104,7 @@ fn update_provider_internal(
     state: &AppState,
     app_type: AppType,
     original_id: Option<&str>,
-    provider: Provider,
+    mut provider: Provider,
 ) -> Result<bool, AppError> {
     // ## 托管档位**可以**改内容，但**不许改 id**
     //
@@ -135,20 +135,50 @@ fn update_provider_internal(
     // 正确判据是**这个托管 id 得对应一条已经存在的托管记录**：
     // 就地编辑（id 早在库里）放行，凭空造一个新的托管 id 拒掉。
     // 这同时覆盖了上面两种改名 —— 不必再单独判「改没改名」。
-    if crate::relay::is_managed(&provider.id)
-        && state
+    let existing_managed = if crate::relay::is_managed(&provider.id) {
+        match state
             .db
             .get_provider_by_id(&provider.id, app_type.as_str())?
-            .is_none()
-    {
-        return Err(AppError::Message(
-            "不能把供应商改成 LoongPort 托管档位的 id —— 那个 id 由 LoongPort 生成".to_string(),
-        ));
-    }
+        {
+            Some(existing) => Some(existing),
+            None => {
+                return Err(AppError::Message(
+                    "不能把供应商改成 LoongPort 托管档位的 id —— 那个 id 由 LoongPort 生成"
+                        .to_string(),
+                ));
+            }
+        }
+    } else {
+        None
+    };
     // 反向：把**已存在的**托管记录改成别的 id（脱管）。这条仍按老判据拦。
     if let Some(old) = original_id.filter(|old| *old != provider.id) {
         crate::relay::reject_if_managed(old)?;
     }
+
+    // 托管档位的站点归属与 sk 由 LoongPort 管，不属于用户可编辑配置。
+    //
+    // 倍率查询会从 `website_url` 定位 `/v1/sub2api/billing`，再从
+    // `settings_config` 提取 sk。若直接保存编辑器提交的整份 Provider，用户只改模型
+    // 也可能因表单 round-trip 丢掉认证 section，结果是倍率/连通检测一起静默失效。
+    // 这里保留这两个 owner 字段，其余配置仍照用户提交的保存。
+    if let Some(existing) = existing_managed {
+        provider.website_url = existing.website_url;
+        if let Some(api_key) =
+            crate::relay::provision::extract_api_key(&existing.settings_config, &app_type)
+        {
+            if !crate::relay::provision::ensure_api_key(
+                &mut provider.settings_config,
+                &app_type,
+                &api_key,
+            ) {
+                return Err(AppError::Config(
+                    "托管档位的配置必须是对象，无法保留由 LoongPort 管理的密钥".to_string(),
+                ));
+            }
+        }
+    }
+
     let provider_id = provider.id.clone();
     // `app_type` 下一步会被 move 进 update，先扣出字符串给 set_user_edited 用。
     let app_type_name = app_type.as_str().to_string();
@@ -395,6 +425,68 @@ mod managed_guard_tests {
                 "originalId 省略时被误当成改名拦下了。实际: {text}"
             );
         }
+    }
+
+    #[test]
+    fn managed_tier_edit_preserves_relay_origin_and_api_key() {
+        let id = managed_id();
+        let state = empty_state();
+        let site_origin = "https://bestapi.store";
+        let existing_settings = crate::relay::provision::settings_config_for(
+            &AppType::Codex,
+            "sk-managed",
+            "provision 生成的名字",
+            "https://bestapi.store/v1",
+            "gpt-5.6-sol",
+        )
+        .expect("codex 托管档位必须有配置形状");
+        let existing = Provider::with_id(
+            id.clone(),
+            "provision 生成的名字".to_string(),
+            existing_settings.clone(),
+            Some(site_origin.to_string()),
+        );
+        state
+            .db
+            .save_provider(AppType::Codex.as_str(), &existing)
+            .expect("预置托管档位");
+
+        // 模拟编辑器的整份 Provider 回写：用户改了配置，同时 payload 里的站点与 sk
+        // 也被改掉。后两项是 LoongPort 的 owner 字段，不能随表单落库。
+        let mut edited_settings = existing_settings;
+        let config = edited_settings["config"]
+            .as_str()
+            .expect("codex 配置应是 TOML 字符串");
+        edited_settings["config"] =
+            serde_json::json!(format!("{config}\nmodel_reasoning_effort = \"low\"\n"));
+        edited_settings["auth"]["OPENAI_API_KEY"] = serde_json::json!("sk-user-overwrite");
+        let edited = Provider::with_id(
+            id.clone(),
+            "用户改的名字".to_string(),
+            edited_settings,
+            Some("https://wrong.example/v1".to_string()),
+        );
+
+        update_provider_internal(&state, AppType::Codex, Some(id.as_str()), edited)
+            .expect("编辑托管档位应成功");
+
+        let saved = state
+            .db
+            .get_provider_by_id(&id, AppType::Codex.as_str())
+            .expect("读取保存结果")
+            .expect("托管档位仍应存在");
+        assert_eq!(saved.website_url.as_deref(), Some(site_origin));
+        assert_eq!(
+            crate::relay::provision::extract_api_key(&saved.settings_config, &AppType::Codex)
+                .as_deref(),
+            Some("sk-managed")
+        );
+        assert!(
+            saved.settings_config["config"]
+                .as_str()
+                .is_some_and(|config| config.contains("model_reasoning_effort = \"low\"")),
+            "除 LoongPort 管理的站点与 sk 外，用户编辑必须保留"
+        );
     }
 
     /// ⭐ **编辑一个「当前」生图档位并保存必须成功。**

--- a/src-tauri/src/relay/provision.rs
+++ b/src-tauri/src/relay/provision.rs
@@ -1010,12 +1010,12 @@ pub fn is_image_model(model: &str) -> bool {
 /// 写进去的和读出来的不是同一个字段）。
 ///
 /// 返回 `None` = 这个 CLI 还没接。
-fn api_key_location(app_type: &AppType) -> Option<(&'static str, &'static str)> {
+fn api_key_locations(app_type: &AppType) -> Option<&'static [(&'static str, &'static str)]> {
     match app_type {
         // 生图栏与 codex 同形（见 `settings_config_for`），sk 在同一个位置。
         // 漏了它的后果是**静默的**：`_ => None` 会让 `is_user_edited` 对每条生图档位
         // 都返回「判不了」，`extract_api_key` 也读不出 sk ⇒ 生图工具起不来。
-        AppType::Codex | AppType::CodexImage => Some(("auth", "OPENAI_API_KEY")),
+        AppType::Codex | AppType::CodexImage => Some(&[("auth", "OPENAI_API_KEY")]),
         // ⚠️ **ClaudeDesktop 与 Claude 同形，两个都要在这里**（2026-08-05 补）。
         //
         // 它们走同一个 `deeplink::build_claude_settings`（`provider.rs:165` 的
@@ -1024,8 +1024,11 @@ fn api_key_location(app_type: &AppType) -> Option<(&'static str, &'static str)> 
         // 下面那个 `_ => None`，后果与漏掉生图栏那条完全一样、而且**同样是静默的**：
         // `is_user_edited` 恒为「判不了」⇒ 界面上永远不显示「已手动维护」标记；
         // `extract_api_key` 读不出 sk ⇒ 「恢复默认配置」直接报错。
-        AppType::Claude | AppType::ClaudeDesktop => Some(("env", "ANTHROPIC_AUTH_TOKEN")),
-        AppType::Gemini => Some(("env", "GEMINI_API_KEY")),
+        AppType::Claude | AppType::ClaudeDesktop => Some(&[
+            ("env", "ANTHROPIC_AUTH_TOKEN"),
+            ("env", "ANTHROPIC_API_KEY"),
+        ]),
+        AppType::Gemini => Some(&[("env", "GEMINI_API_KEY")]),
         // ⚠️ hermes / openclaw / opencode **还没接**，见代码仓 `TODO.md`：
         // 它们的 sk 在**顶层**（hermes 是 `api_key`、openclaw 是 `apiKey`）或
         // 嵌在别的结构里（opencode 是 `options.apiKey`），而本函数的
@@ -1041,13 +1044,16 @@ fn api_key_location(app_type: &AppType) -> Option<(&'static str, &'static str)> 
 /// 返回 `None` 表示配置形状里找不到 sk（被改坏了 / 这个 CLI 还没接）——
 /// 调用方应当报错而不是继续，生成一份没有 sk 的配置是条必定 401 的记录。
 pub fn extract_api_key(settings_config: &serde_json::Value, app_type: &AppType) -> Option<String> {
-    let (section, field) = api_key_location(app_type)?;
-    settings_config
-        .get(section)?
-        .get(field)?
-        .as_str()
-        .filter(|s| !s.is_empty())
-        .map(str::to_string)
+    api_key_locations(app_type)?
+        .iter()
+        .find_map(|(section, field)| {
+            settings_config
+                .get(*section)?
+                .get(*field)?
+                .as_str()
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+        })
 }
 
 /// 把新 sk 塞进一份**已存在的** `settings_config`，其余部分原样保留。
@@ -1082,16 +1088,67 @@ pub fn patch_api_key(
     app_type: &AppType,
     api_key: &str,
 ) -> bool {
-    let Some((section, field)) = api_key_location(app_type) else {
+    let Some(locations) = api_key_locations(app_type) else {
         return false;
     };
 
-    // 只在那个 section 本来就是对象时改 —— 不存在就说明形状不对，让调用方全量重写，
-    // 别在这里凭空造一个 section（那会拼出一份半新半旧的配置）。
+    // 所有已经存在的候选字段都改成同一把 key。Claude 配置若意外同时含两种字段，
+    // 只改一个会让运行时与倍率查询各读到不同的凭据。
+    let mut patched = false;
+    for (section, field) in locations {
+        let Some(map) = settings_config
+            .get_mut(*section)
+            .and_then(serde_json::Value::as_object_mut)
+        else {
+            continue;
+        };
+        if map.contains_key(*field) {
+            map.insert((*field).to_string(), serde_json::json!(api_key));
+            patched = true;
+        }
+    }
+    if patched {
+        return true;
+    }
+
+    // section 存在但 key 被用户删掉时，补回默认字段，避免下一次倍率查询丢凭据。
+    let (section, field) = locations[0];
     let Some(map) = settings_config
         .get_mut(section)
         .and_then(serde_json::Value::as_object_mut)
     else {
+        return false;
+    };
+    map.insert(field.to_string(), serde_json::json!(api_key));
+    true
+}
+
+/// 确保手工编辑后的托管档位仍带有由 LoongPort 管理的 sk。
+///
+/// 与 [`patch_api_key`] 的区别是：编辑器可能把整个认证 section 删掉；此时仍应把
+/// 托管凭据补回去，而不是让倍率/连通检测静默失效。若根配置不是对象，返回 `false`
+/// 交给调用方报出明确错误。
+pub fn ensure_api_key(
+    settings_config: &mut serde_json::Value,
+    app_type: &AppType,
+    api_key: &str,
+) -> bool {
+    if patch_api_key(settings_config, app_type, api_key) {
+        return true;
+    }
+
+    let Some((section, field)) =
+        api_key_locations(app_type).and_then(|locations| locations.first().copied())
+    else {
+        return false;
+    };
+    let Some(root) = settings_config.as_object_mut() else {
+        return false;
+    };
+    let section = root
+        .entry(section.to_string())
+        .or_insert_with(|| serde_json::json!({}));
+    let Some(map) = section.as_object_mut() else {
         return false;
     };
     map.insert(field.to_string(), serde_json::json!(api_key));
@@ -1940,6 +1997,41 @@ mod tests {
         // 重复 provision 走全量覆盖会把它们冲掉，而用户点「获取密钥」通常只想刷新列表。
         assert_eq!(sc["config"], "model = \"用户改过的模型\"\n自定义 = 1");
         assert_eq!(sc["auth"]["用户加的字段"], "保留我");
+    }
+
+    #[test]
+    fn claude_api_key_field_is_supported_by_read_and_patch() {
+        let mut sc = serde_json::json!({
+            "env": {
+                "ANTHROPIC_API_KEY": "sk-old",
+                "ANTHROPIC_MODEL": "用户改过的模型"
+            }
+        });
+
+        assert_eq!(
+            extract_api_key(&sc, &AppType::Claude).as_deref(),
+            Some("sk-old")
+        );
+        assert!(patch_api_key(&mut sc, &AppType::Claude, "sk-new"));
+        assert_eq!(sc["env"]["ANTHROPIC_API_KEY"], "sk-new");
+        assert!(sc["env"].get("ANTHROPIC_AUTH_TOKEN").is_none());
+        assert_eq!(sc["env"]["ANTHROPIC_MODEL"], "用户改过的模型");
+
+        sc["env"]["ANTHROPIC_AUTH_TOKEN"] = serde_json::json!("sk-stale");
+        assert!(patch_api_key(&mut sc, &AppType::Claude, "sk-unified"));
+        assert_eq!(sc["env"]["ANTHROPIC_AUTH_TOKEN"], "sk-unified");
+        assert_eq!(sc["env"]["ANTHROPIC_API_KEY"], "sk-unified");
+    }
+
+    #[test]
+    fn ensure_api_key_recreates_a_missing_auth_section() {
+        let mut sc = serde_json::json!({
+            "config": "model = \"用户改过的模型\""
+        });
+
+        assert!(ensure_api_key(&mut sc, &AppType::Codex, "sk-managed"));
+        assert_eq!(sc["auth"]["OPENAI_API_KEY"], "sk-managed");
+        assert_eq!(sc["config"], "model = \"用户改过的模型\"");
     }
 
     /// Claude Code 的默认配置带 `language: chinese`（维护者要求所有 LoongPort 生成的


### PR DESCRIPTION
## Summary / 概述

Fix managed provider edits so user-maintained model configuration no longer overwrites the LoongPort-owned relay origin or API key.

- Preserve the persisted website_url and managed API key at the provider update boundary.
- Support both Claude API-key fields and keep existing candidates synchronized.
- Recreate a missing managed auth section without replacing other user edits.
- Add regression tests covering the edit round trip and credential repair.

## Related Issue / 关联 Issue

No linked issue.

## Screenshots / 截图

Not applicable because this changes backend behavior only.

## Checklist / 检查清单

- [x] npx tsc --noEmit passes / 通过 TypeScript 类型检查
- [x] pnpm format:check passes / 通过代码格式检查
- [x] cargo clippy --all-targets -- -D warnings passes / 通过 Clippy 检查
- [x] No user-facing text changed / 无需更新国际化文件
- [x] cargo test passes
- [x] npx vitest run passes with 711 tests