### PR TITLE
fix(model-verification): reconcile runtime ownership safely

### DIFF
--- a/.superpowers/sdd/2026-08-09-model-verification-active/progress.md
+++ b/.superpowers/sdd/2026-08-09-model-verification-active/progress.md
@@ -1,0 +1,57 @@
+# SDD ledger — plan: /Users/allen/code/LoongPort-workspace/LoongPort-design/docs/superpowers/plans/2026-08-09-model-verification-active.md
+
+Baseline: `0b45fb22` on `origin/main`.
+Prerequisite: Active implementation is merged in PR #64; the entries below are the auditable commit map for the completed checklist.
+
+## Active Task 1 — complete
+
+- Implementation: `07d7d836` (`feat(model-verification): add result domain and storage`)
+- Correction: `f25742cc` (`test(model-verification): make schema migration fixture genuine`)
+
+## Active Task 2 — complete
+
+- Implementation: `7fadcc15` (`feat(model-verification): resolve managed targets and models`)
+
+## Active Task 3 — complete
+
+- Implementation: `17fde05e` (`feat(model-verification): add capability-aware verdicts`)
+
+## Active Task 4 — complete
+
+- Implementation: `74d2aa03` (`feat(model-verification): verify Anthropic Messages`)
+- Correction: `5d6d5f79` (`fix(model-verification): tighten Anthropic stream probes`)
+
+## Active Task 5 — complete
+
+- Implementation: `441d534c` (`feat(model-verification): verify OpenAI Responses`)
+- Corrections: `54ca0991`, `420b33f4` (tighten and reject failed Responses streams)
+
+## Active Task 6 — complete
+
+- Implementation: `4793d4aa` (`feat(model-verification): coordinate active verification runs`)
+- Correction: `c4380852` (`fix(model-verification): expose finite report evidence`)
+
+## Active Task 7 — complete
+
+- Implementation: `fb996e90` (`feat(model-verification): clear results after tier reset`)
+
+## Active Task 8 — complete
+
+- Implementation: `214a4a61` (`feat(model-verification): add active verification dialog`)
+- Correction: `986a2d0e` (`fix(model-verification): avoid missing early run events`)
+
+## Active Task 9 — complete
+
+- Implementation: `28553321` (`feat(model-verification): surface verification on tier rows`)
+- Correction: `f83016dc` (`fix(model-verification): complete tier verification context`)
+
+## Active Task 10 — complete
+
+- Implementation: `3fb6d565` (`test(model-verification): enforce active verification privacy`)
+- Corrections: `9340f4a1`, `2ff62a79`, `8a89ea78` (privacy hardening, review fixes, persisted-report authority)
+- Acceptance: six repository gates and the active test matrix passed before PR #64 merge.
+
+## Delivery — complete
+
+- PR #64 merged to `origin/main` as `0b45fb22` after Frontend Checks and all three platform backend checks passed.
+- This ledger records historical implementation commits; it does not create empty commits to simulate task independence.

--- a/.superpowers/sdd/2026-08-09-model-verification-runtime/progress.md
+++ b/.superpowers/sdd/2026-08-09-model-verification-runtime/progress.md
@@ -1,4 +1,4 @@
-# SDD ledger — plan: /Users/allen/code/LoongPort-worktrees/LoongPort-design-model-verification/docs/superpowers/plans/2026-08-09-model-verification-runtime.md
+# SDD ledger — plan: /Users/allen/code/LoongPort-workspace/LoongPort-design/docs/superpowers/plans/2026-08-09-model-verification-runtime.md
 
 Baseline: 8a89ea78 on codex/model-verification
 Prerequisite: Active Phase complete; final review clean; six repository gates passed at 8a89ea78.
@@ -18,59 +18,57 @@ Pre-flight review: no blocking requirement contradictions. Execution order is 1 
 - Correction commit: `8b19d0c5` (`fix(model-verification): bound passive evidence batches`)
 - Independent review: initial findings (unbounded batch facts, missing merge facade, duplicated threshold) fixed; final re-review clean with no Critical/Important/Minor findings.
 - Focused verification: `cargo fmt --check`; passive 5 passed; verdict 14 passed; store 8 passed. Full model-verification library run had 85 passed and 17 pre-existing loopback/network failures caused by restricted socket binding.
-- Runtime Task 5 is next.
 
 ## Runtime Task 5 — complete
 
-- Implementation commit: pending (`feat(model-verification): inject bounded passive ingress`)
+- Implementation commit: `9df9dea6` (`feat(model-verification): inject bounded passive ingress`)
 - Independent review: completed locally against the task brief; no blocking findings.
 - Focused verification: passive 9 passed; handler context 9 passed; proxy service 58 passed; formatting and diff checks passed.
-- Runtime Task 6 is next.
 
 ## Runtime Task 6 — complete
 
-- Implementation commit: pending (`feat(model-verification): observe supported protocols passively`)
+- Implementation commit: `4f0cdfe8` (`feat(model-verification): observe supported protocols passively`); correction `984dc908` (`fix(model-verification): classify chat completions as foreign`)
 - Independent review: completed locally; no Critical/Important/Minor findings.
 - Focused verification: protocol suite 42 passed; formatting and diff checks passed.
-- Runtime Task 7 is next.
 
 ## Runtime Task 7 — complete
 
-- Implementation commit: pending (`feat(model-verification): tap real responses without interference`)
+- Implementation commit: `173a2db9` (`feat(model-verification): tap real responses without interference`)
 - Independent review: completed locally; no blocking findings.
 - Focused verification: response processor 8 passed; protocol suite 42 passed; compile, formatting, and diff checks passed.
-- Runtime Task 8 is next.
 
 ## Runtime Task 8 — complete
 
-- Implementation commit: pending (`feat(model-verification): deduplicate runtime anomaly alerts`)
+- Implementation commit: `ea6fd909` (`feat(model-verification): deduplicate runtime anomaly alerts`)
 - Independent review: completed locally; no blocking findings.
 - Focused verification: event consistency passed; store 8 passed; compile, formatting, and diff checks passed.
-- Runtime Task 9 is next.
 
 ## Runtime Task 9 — complete
 
-- Implementation commit: pending (`feat(model-verification): expose global runtime detection`)
+- Implementation commit: `afe26d29` (`feat(model-verification): expose global runtime detection`)
 - Independent review: completed locally; no blocking findings.
 - Focused verification: typecheck passed; full Vitest run 732 passed.
-- Runtime Task 10 is next.
 
 ## Runtime Task 10 — complete
 
-- Implementation commit: pending (`test(model-verification): enforce passive privacy and fail-open behavior`)
+- Implementation commit: `c8c3769c` (`test(model-verification): enforce passive privacy and fail-open behavior`); event-sink correction `5920aa71`; CI scheduler correction `828773d9`
 - Independent review: completed locally; no blocking findings.
 - All six repository gates passed; full Rust suite 2784 passed and full frontend suite 732 passed.
 - Runtime implementation todo list is complete.
 
 ## Runtime Task 2 — complete
 
-- Implementation commit: pending (`feat(model-verification): reconcile proxy leases safely`)
+- Implementation commit: `5185508a` (`feat(model-verification): recover runtime observation state`) — this commit contains the lease reconciliation and startup/provider-switch recovery boundary described by Tasks 2–3.
 - Independent review: completed locally; no blocking findings.
 - Focused verification: command 3 passed; store 8 passed; compile and formatting checks passed.
 
 ## Runtime Task 3 — complete
 
-- Implementation commit: pending (`feat(model-verification): recover runtime observation state`)
+- Implementation commit: `5185508a` (`feat(model-verification): recover runtime observation state`)
 - Independent review: completed locally; provider-switch and startup hooks are fail-open and centralized.
 - Focused verification: event consistency passed; compile and formatting checks passed.
-- Runtime Task 9 is next.
+
+## Delivery — complete
+
+- PR #64 merged to `origin/main` as `0b45fb22` after Frontend Checks and all three platform backend checks passed.
+- The merged branch and temporary worktree were removed only after the merge commit was reachable and the worktree was clean.

--- a/src-tauri/src/commands/model_verification.rs
+++ b/src-tauri/src/commands/model_verification.rs
@@ -31,10 +31,7 @@ pub struct RuntimeVerificationSnapshot {
 pub async fn get_runtime_verification_setting(
     state: tauri::State<'_, AppState>,
 ) -> Result<RuntimeVerificationSnapshot, String> {
-    let (setting, apps) = state
-        .model_verification
-        .runtime_status(&state.proxy_service)
-        .await?;
+    let (setting, apps) = state.model_verification.runtime_status().await?;
     Ok(RuntimeVerificationSnapshot { setting, apps })
 }
 

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -111,18 +111,14 @@ pub fn emit_provider_switched(
         log::warn!("发射 {PROVIDER_SWITCHED} 事件失败: {e}");
     }
     if matches!(app_type, AppType::Codex | AppType::Claude) {
+        let runtime_app =
+            crate::relay::model_verification::types::RuntimeAppType::try_from(app_type.as_str())
+                .expect("supported runtime app");
         if let Some(state) = app_handle.try_state::<crate::AppState>() {
             let coordinator = state.model_verification.clone();
             let proxy = state.proxy_service.clone();
             tauri::async_runtime::spawn(async move {
-                if crate::relay::model_verification::store::get_runtime_setting(
-                    &coordinator.database(),
-                )
-                .map(|setting| setting.runtime_auto_enabled)
-                .unwrap_or(false)
-                {
-                    let _ = coordinator.set_runtime_enabled(&proxy, true).await;
-                }
+                let _ = coordinator.reconcile_app(&proxy, runtime_app).await;
             });
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1198,15 +1198,7 @@ pub fn run() {
             model_verification.start_passive_worker();
             let proxy_service = app.state::<AppState>().proxy_service.clone();
             tauri::async_runtime::spawn(async move {
-                if let Ok(setting) = crate::relay::model_verification::store::get_runtime_setting(
-                    &model_verification.database(),
-                ) {
-                    if setting.runtime_auto_enabled {
-                        let _ = model_verification
-                            .set_runtime_enabled(&proxy_service, true)
-                            .await;
-                    }
-                }
+                let _ = model_verification.reconcile_all(&proxy_service).await;
             });
 
             // 初始化 SkillService

--- a/src-tauri/src/relay/model_verification/coordinator.rs
+++ b/src-tauri/src/relay/model_verification/coordinator.rs
@@ -8,7 +8,7 @@ use std::{
 
 use futures::future::{AbortHandle, Abortable};
 use tauri::Emitter;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex as AsyncMutex};
 
 use crate::{
     database::Database,
@@ -35,6 +35,19 @@ pub trait ActiveVerifier: Send + Sync {
         target: TargetKey,
         progress: ProbeProgress,
     ) -> Result<PreparedVerification, RunFailureKind>;
+}
+
+/// Narrow port used by runtime reconciliation. Keeping takeover behind this boundary makes the
+/// lease saga deterministic in tests and keeps the coordinator independent from proxy internals.
+#[allow(async_fn_in_trait)]
+pub(crate) trait TakeoverControl: Send + Sync {
+    async fn set_takeover_for_app(&self, app_type: &str, enabled: bool) -> Result<(), String>;
+}
+
+impl TakeoverControl for crate::services::ProxyService {
+    async fn set_takeover_for_app(&self, app_type: &str, enabled: bool) -> Result<(), String> {
+        crate::services::ProxyService::set_takeover_for_app(self, app_type, enabled).await
+    }
 }
 
 pub trait VerificationEventSink: Send + Sync {
@@ -122,6 +135,7 @@ pub struct ModelVerificationCoordinator {
     state: Mutex<CoordinatorState>,
     passive_receiver: Mutex<Option<mpsc::Receiver<EvidenceBatch>>>,
     passive_ingress: VerificationIngress,
+    runtime_mutation: AsyncMutex<()>,
 }
 
 #[derive(Default)]
@@ -164,6 +178,7 @@ impl ModelVerificationCoordinator {
             state: Mutex::new(CoordinatorState::default()),
             passive_receiver: Mutex::new(Some(passive_receiver)),
             passive_ingress,
+            runtime_mutation: AsyncMutex::new(()),
         }
     }
 
@@ -182,6 +197,7 @@ impl ModelVerificationCoordinator {
             state: Mutex::new(CoordinatorState::default()),
             passive_receiver: Mutex::new(Some(passive_receiver)),
             passive_ingress,
+            runtime_mutation: AsyncMutex::new(()),
         }
     }
 
@@ -249,93 +265,322 @@ impl ModelVerificationCoordinator {
         self.event_sink.attach_app_handle(app_handle);
     }
 
-    pub async fn runtime_status(
+    pub(crate) async fn runtime_status(
         &self,
-        proxy: &crate::services::ProxyService,
     ) -> Result<(RuntimeVerificationSetting, Vec<RuntimeAppState>), String> {
+        let _guard = self.runtime_mutation.lock().await;
         let setting = crate::relay::model_verification::store::get_runtime_setting(&self.db)
             .map_err(|error| error.to_string())?;
         let mut apps = Vec::new();
         for app in [RuntimeAppType::Codex, RuntimeAppType::Claude] {
-            let app_name = app.as_str();
-            let state = match crate::settings::get_effective_current_provider(
-                &self.db,
-                &crate::app_config::AppType::from_str(app_name).map_err(|e| e.to_string())?,
-            )? {
-                None => RuntimeAppState {
-                    app_type: app,
-                    status: RuntimeAppStatus::Waiting,
-                    reason: Some(RuntimeAppReason::NoCurrentProvider),
-                },
-                Some(_) => match self.db.get_proxy_config_for_app(app_name).await {
-                    Ok(config) if config.enabled => RuntimeAppState {
-                        app_type: app,
-                        status: RuntimeAppStatus::Active,
-                        reason: None,
-                    },
-                    Ok(_) => RuntimeAppState {
-                        app_type: app,
-                        status: RuntimeAppStatus::Waiting,
-                        reason: Some(RuntimeAppReason::ClientUnavailable),
-                    },
-                    Err(_) => RuntimeAppState {
-                        app_type: app,
-                        status: RuntimeAppStatus::Error,
-                        reason: Some(RuntimeAppReason::RecoveryFailed),
-                    },
-                },
-            };
-            let _ = proxy;
-            apps.push(state);
+            apps.push(self.inspect_runtime_app(app).await);
         }
         Ok((setting, apps))
     }
 
-    pub async fn set_runtime_enabled(
+    pub(crate) async fn set_runtime_enabled<P: TakeoverControl>(
         &self,
-        proxy: &crate::services::ProxyService,
+        proxy: &P,
         enabled: bool,
     ) -> Result<(RuntimeVerificationSetting, Vec<RuntimeAppState>), String> {
-        crate::relay::model_verification::store::set_runtime_setting(&self.db, enabled)
-            .map_err(|error| error.to_string())?;
-        self.passive_ingress.set_enabled(enabled);
+        let setting =
+            crate::relay::model_verification::store::set_runtime_setting(&self.db, enabled)
+                .map_err(|error| error.to_string())?;
+        let apps = self.reconcile_all(proxy).await;
+        Ok((setting, apps))
+    }
+
+    pub(crate) async fn reconcile_all<P: TakeoverControl>(
+        &self,
+        proxy: &P,
+    ) -> Vec<RuntimeAppState> {
+        let _guard = self.runtime_mutation.lock().await;
+        let setting = match crate::relay::model_verification::store::get_runtime_setting(&self.db) {
+            Ok(value) => value.runtime_auto_enabled,
+            Err(_) => {
+                self.passive_ingress.set_enabled(false);
+                return [RuntimeAppType::Codex, RuntimeAppType::Claude]
+                    .into_iter()
+                    .map(|app_type| RuntimeAppState {
+                        app_type,
+                        status: RuntimeAppStatus::Error,
+                        reason: Some(RuntimeAppReason::RecoveryFailed),
+                    })
+                    .collect();
+            }
+        };
+        self.passive_ingress.set_enabled(setting);
+        let mut states = Vec::with_capacity(2);
         for app in [RuntimeAppType::Codex, RuntimeAppType::Claude] {
-            let name = app.as_str();
-            if !enabled {
-                if crate::relay::model_verification::store::has_lease(&self.db, name)
-                    .unwrap_or(false)
-                {
-                    let _ = proxy.set_takeover_for_app(name, false).await;
-                    let _ = crate::relay::model_verification::store::delete_lease(&self.db, name);
+            states.push(self.reconcile_app_locked(proxy, app, setting).await);
+        }
+        states
+    }
+
+    pub(crate) async fn reconcile_app<P: TakeoverControl>(
+        &self,
+        proxy: &P,
+        app: RuntimeAppType,
+    ) -> RuntimeAppState {
+        let _guard = self.runtime_mutation.lock().await;
+        let setting = match crate::relay::model_verification::store::get_runtime_setting(&self.db) {
+            Ok(value) => value.runtime_auto_enabled,
+            Err(_) => {
+                self.passive_ingress.set_enabled(false);
+                return RuntimeAppState {
+                    app_type: app,
+                    status: RuntimeAppStatus::Error,
+                    reason: Some(RuntimeAppReason::RecoveryFailed),
+                };
+            }
+        };
+        self.passive_ingress.set_enabled(setting);
+        self.reconcile_app_locked(proxy, app, setting).await
+    }
+
+    async fn inspect_runtime_app(&self, app: RuntimeAppType) -> RuntimeAppState {
+        let app_name = app.as_str();
+        let current = match crate::settings::get_effective_current_provider(
+            &self.db,
+            &crate::app_config::AppType::from_str(app_name).expect("runtime app type is valid"),
+        ) {
+            Ok(current) => current,
+            Err(_) => {
+                return RuntimeAppState {
+                    app_type: app,
+                    status: RuntimeAppStatus::Error,
+                    reason: Some(RuntimeAppReason::RecoveryFailed),
                 }
-                continue;
             }
-            let app_enum = crate::app_config::AppType::from_str(name).map_err(|e| e.to_string())?;
-            if crate::settings::get_effective_current_provider(&self.db, &app_enum)
-                .map_err(|e| e.to_string())?
-                .is_none()
-            {
-                continue;
+        };
+        let Some(provider_id) = current else {
+            return RuntimeAppState {
+                app_type: app,
+                status: RuntimeAppStatus::Waiting,
+                reason: Some(RuntimeAppReason::NoCurrentProvider),
+            };
+        };
+        if !crate::relay::is_managed(&provider_id) {
+            return RuntimeAppState {
+                app_type: app,
+                status: RuntimeAppStatus::Waiting,
+                reason: Some(RuntimeAppReason::CurrentProviderUnsupported),
+            };
+        }
+        match self.db.get_proxy_config_for_app(app_name).await {
+            Ok(config) if config.enabled => RuntimeAppState {
+                app_type: app,
+                status: RuntimeAppStatus::Active,
+                reason: None,
+            },
+            Ok(_) => RuntimeAppState {
+                app_type: app,
+                status: RuntimeAppStatus::Waiting,
+                reason: Some(RuntimeAppReason::ClientUnavailable),
+            },
+            Err(_) => RuntimeAppState {
+                app_type: app,
+                status: RuntimeAppStatus::Error,
+                reason: Some(RuntimeAppReason::RecoveryFailed),
+            },
+        }
+    }
+
+    async fn reconcile_app_locked<P: TakeoverControl>(
+        &self,
+        proxy: &P,
+        app: RuntimeAppType,
+        enabled: bool,
+    ) -> RuntimeAppState {
+        let app_name = app.as_str();
+        let current = match crate::settings::get_effective_current_provider(
+            &self.db,
+            &crate::app_config::AppType::from_str(app_name).expect("runtime app type is valid"),
+        ) {
+            Ok(current) => current,
+            Err(_) => {
+                return RuntimeAppState {
+                    app_type: app,
+                    status: RuntimeAppStatus::Error,
+                    reason: Some(RuntimeAppReason::RecoveryFailed),
+                };
             }
-            let config = self
-                .db
-                .get_proxy_config_for_app(name)
-                .await
-                .map_err(|e| e.to_string())?;
-            if config.enabled {
-                continue;
+        };
+
+        if !enabled {
+            return self.release_owned_lease(proxy, app).await;
+        }
+
+        let Some(provider_id) = current else {
+            return self
+                .release_owned_lease_with_fallback(
+                    proxy,
+                    app,
+                    RuntimeAppStatus::Waiting,
+                    RuntimeAppReason::NoCurrentProvider,
+                )
+                .await;
+        };
+        if !crate::relay::is_managed(&provider_id) {
+            return self
+                .release_owned_lease_with_fallback(
+                    proxy,
+                    app,
+                    RuntimeAppStatus::Waiting,
+                    RuntimeAppReason::CurrentProviderUnsupported,
+                )
+                .await;
+        }
+
+        let config = match self.db.get_proxy_config_for_app(app_name).await {
+            Ok(config) => config,
+            Err(_) => {
+                return RuntimeAppState {
+                    app_type: app,
+                    status: RuntimeAppStatus::Error,
+                    reason: Some(RuntimeAppReason::RecoveryFailed),
+                }
             }
-            crate::relay::model_verification::store::insert_lease(
-                &self.db,
-                name,
-                chrono::Utc::now().timestamp(),
-            )
-            .map_err(|error| error.to_string())?;
-            if proxy.set_takeover_for_app(name, true).await.is_err() {
-                let _ = crate::relay::model_verification::store::delete_lease(&self.db, name);
+        };
+        if config.enabled {
+            return RuntimeAppState {
+                app_type: app,
+                status: RuntimeAppStatus::Active,
+                reason: None,
+            };
+        }
+        if crate::relay::model_verification::store::insert_lease(
+            &self.db,
+            app_name,
+            chrono::Utc::now().timestamp(),
+        )
+        .is_err()
+        {
+            return RuntimeAppState {
+                app_type: app,
+                status: RuntimeAppStatus::Error,
+                reason: Some(RuntimeAppReason::RecoveryFailed),
+            };
+        }
+        match proxy.set_takeover_for_app(app_name, true).await {
+            Ok(()) => RuntimeAppState {
+                app_type: app,
+                status: RuntimeAppStatus::Active,
+                reason: None,
+            },
+            Err(_) => {
+                let _ = crate::relay::model_verification::store::delete_lease(&self.db, app_name);
+                RuntimeAppState {
+                    app_type: app,
+                    status: RuntimeAppStatus::Error,
+                    reason: Some(RuntimeAppReason::TakeoverFailed),
+                }
             }
         }
-        self.runtime_status(proxy).await
+    }
+
+    async fn release_owned_lease<P: TakeoverControl>(
+        &self,
+        proxy: &P,
+        app: RuntimeAppType,
+    ) -> RuntimeAppState {
+        let app_name = app.as_str();
+        let has_lease = match crate::relay::model_verification::store::has_lease(&self.db, app_name)
+        {
+            Ok(has_lease) => has_lease,
+            Err(_) => {
+                return RuntimeAppState {
+                    app_type: app,
+                    status: RuntimeAppStatus::Error,
+                    reason: Some(RuntimeAppReason::RecoveryFailed),
+                };
+            }
+        };
+        if !has_lease {
+            return self.inspect_runtime_app(app).await;
+        }
+        let config = match self.db.get_proxy_config_for_app(app_name).await {
+            Ok(config) => config,
+            Err(_) => {
+                return RuntimeAppState {
+                    app_type: app,
+                    status: RuntimeAppStatus::Error,
+                    reason: Some(RuntimeAppReason::RecoveryFailed),
+                }
+            }
+        };
+        if config.enabled && proxy.set_takeover_for_app(app_name, false).await.is_err() {
+            return RuntimeAppState {
+                app_type: app,
+                status: RuntimeAppStatus::Error,
+                reason: Some(RuntimeAppReason::RecoveryFailed),
+            };
+        }
+        if crate::relay::model_verification::store::delete_lease(&self.db, app_name).is_err() {
+            return RuntimeAppState {
+                app_type: app,
+                status: RuntimeAppStatus::Error,
+                reason: Some(RuntimeAppReason::RecoveryFailed),
+            };
+        }
+        self.inspect_runtime_app(app).await
+    }
+
+    async fn release_owned_lease_with_fallback<P: TakeoverControl>(
+        &self,
+        proxy: &P,
+        app: RuntimeAppType,
+        status: RuntimeAppStatus,
+        reason: RuntimeAppReason,
+    ) -> RuntimeAppState {
+        let app_name = app.as_str();
+        let has_lease = match crate::relay::model_verification::store::has_lease(&self.db, app_name)
+        {
+            Ok(has_lease) => has_lease,
+            Err(_) => {
+                return RuntimeAppState {
+                    app_type: app,
+                    status: RuntimeAppStatus::Error,
+                    reason: Some(RuntimeAppReason::RecoveryFailed),
+                };
+            }
+        };
+        if !has_lease {
+            return RuntimeAppState {
+                app_type: app,
+                status,
+                reason: Some(reason),
+            };
+        }
+        let config = match self.db.get_proxy_config_for_app(app_name).await {
+            Ok(config) => config,
+            Err(_) => {
+                return RuntimeAppState {
+                    app_type: app,
+                    status: RuntimeAppStatus::Error,
+                    reason: Some(RuntimeAppReason::RecoveryFailed),
+                }
+            }
+        };
+        if config.enabled && proxy.set_takeover_for_app(app_name, false).await.is_err() {
+            return RuntimeAppState {
+                app_type: app,
+                status: RuntimeAppStatus::Error,
+                reason: Some(RuntimeAppReason::RecoveryFailed),
+            };
+        }
+        if crate::relay::model_verification::store::delete_lease(&self.db, app_name).is_err() {
+            return RuntimeAppState {
+                app_type: app,
+                status: RuntimeAppStatus::Error,
+                reason: Some(RuntimeAppReason::RecoveryFailed),
+            };
+        }
+        RuntimeAppState {
+            app_type: app,
+            status,
+            reason: Some(reason),
+        }
     }
 
     pub async fn start(
@@ -769,7 +1014,7 @@ mod tests {
         pin::Pin,
         sync::{
             atomic::{AtomicUsize, Ordering},
-            Arc, Mutex,
+            Arc, Mutex, OnceLock,
         },
     };
 
@@ -778,14 +1023,14 @@ mod tests {
     use crate::{
         database::Database,
         relay::model_verification::types::{
-            EvidenceLevel, RunFailureKind, TargetKey, TargetScope, Verdict, VerificationReport,
-            RULES_VERSION,
+            EvidenceLevel, RunFailureKind, RuntimeAppReason, RuntimeAppStatus, RuntimeAppType,
+            TargetKey, TargetScope, Verdict, VerificationReport, RULES_VERSION,
         },
     };
 
     use super::{
         ActiveVerifier, ModelVerificationCoordinator, PreparedVerification, ProbeProgress,
-        VerificationEventSink,
+        TakeoverControl, VerificationEventSink,
     };
 
     #[derive(Default)]
@@ -929,6 +1174,64 @@ mod tests {
         }
     }
 
+    struct FakeTakeover {
+        db: Arc<Database>,
+        calls: Mutex<Vec<(String, bool)>>,
+        failures: Mutex<std::collections::HashSet<String>>,
+    }
+
+    impl FakeTakeover {
+        fn new(db: Arc<Database>) -> Self {
+            Self {
+                db,
+                calls: Mutex::new(Vec::new()),
+                failures: Mutex::new(std::collections::HashSet::new()),
+            }
+        }
+
+        fn fail_for(&self, app_type: &str) {
+            self.failures.lock().unwrap().insert(app_type.to_string());
+        }
+    }
+
+    impl TakeoverControl for FakeTakeover {
+        async fn set_takeover_for_app(&self, app_type: &str, enabled: bool) -> Result<(), String> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((app_type.to_string(), enabled));
+            if self.failures.lock().unwrap().contains(app_type) {
+                return Err("takeover failed".to_string());
+            }
+            let mut config = self
+                .db
+                .get_proxy_config_for_app(app_type)
+                .await
+                .map_err(|error| error.to_string())?;
+            config.enabled = enabled;
+            self.db
+                .update_proxy_config_for_app(config)
+                .await
+                .map_err(|error| error.to_string())
+        }
+    }
+
+    fn runtime_test_guard() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let guard = LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        crate::settings::set_current_provider(&crate::app_config::AppType::Codex, None).unwrap();
+        guard
+    }
+
+    fn managed_runtime_db(current_provider: &str) -> Arc<Database> {
+        let db = database_with_providers(&[
+            ("loongport-0123456789abcdef", "codex"),
+            ("custom-provider", "codex"),
+        ]);
+        db.set_current_provider("codex", current_provider).unwrap();
+        db
+    }
+
     fn target() -> TargetKey {
         TargetKey::new("provider-a", "codex", "gpt-5.6-sol")
     }
@@ -957,6 +1260,104 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(1)).await;
         }
         panic!("condition was not reached");
+    }
+
+    #[tokio::test]
+    async fn runtime_reconcile_takes_over_only_a_managed_current_provider() {
+        let _guard = runtime_test_guard();
+        let db = managed_runtime_db("loongport-0123456789abcdef");
+        let fake = FakeTakeover::new(db.clone());
+        let coordinator = ModelVerificationCoordinator::with_verifier(
+            db.clone(),
+            Arc::new(BlockedVerifier::new()),
+        );
+
+        let (_, states) = coordinator.set_runtime_enabled(&fake, true).await.unwrap();
+        assert_eq!(states[0].status, RuntimeAppStatus::Active);
+        assert_eq!(
+            fake.calls.lock().unwrap().as_slice(),
+            [("codex".into(), true)]
+        );
+        assert!(crate::relay::model_verification::store::has_lease(&db, "codex").unwrap());
+
+        db.set_current_provider("codex", "custom-provider").unwrap();
+        let state = coordinator
+            .reconcile_app(&fake, RuntimeAppType::Codex)
+            .await;
+        assert_eq!(state.status, RuntimeAppStatus::Waiting);
+        assert_eq!(
+            state.reason,
+            Some(RuntimeAppReason::CurrentProviderUnsupported)
+        );
+        assert_eq!(
+            fake.calls.lock().unwrap().as_slice(),
+            [("codex".into(), true), ("codex".into(), false)]
+        );
+        assert!(!crate::relay::model_verification::store::has_lease(&db, "codex").unwrap());
+    }
+
+    #[tokio::test]
+    async fn runtime_disable_preserves_user_owned_takeover() {
+        let _guard = runtime_test_guard();
+        let db = managed_runtime_db("loongport-0123456789abcdef");
+        let mut config = db.get_proxy_config_for_app("codex").await.unwrap();
+        config.enabled = true;
+        db.update_proxy_config_for_app(config).await.unwrap();
+        let fake = FakeTakeover::new(db.clone());
+        let coordinator = ModelVerificationCoordinator::with_verifier(
+            db.clone(),
+            Arc::new(BlockedVerifier::new()),
+        );
+
+        let (_, states) = coordinator.set_runtime_enabled(&fake, false).await.unwrap();
+        assert_eq!(states[0].status, RuntimeAppStatus::Active);
+        assert!(fake.calls.lock().unwrap().is_empty());
+        assert!(!crate::relay::model_verification::store::has_lease(&db, "codex").unwrap());
+        assert!(db.get_proxy_config_for_app("codex").await.unwrap().enabled);
+    }
+
+    #[tokio::test]
+    async fn runtime_takeover_failure_removes_the_pending_lease() {
+        let _guard = runtime_test_guard();
+        let db = managed_runtime_db("loongport-0123456789abcdef");
+        let fake = FakeTakeover::new(db.clone());
+        fake.fail_for("codex");
+        let coordinator = ModelVerificationCoordinator::with_verifier(
+            db.clone(),
+            Arc::new(BlockedVerifier::new()),
+        );
+
+        let (_, states) = coordinator.set_runtime_enabled(&fake, true).await.unwrap();
+        assert_eq!(states[0].status, RuntimeAppStatus::Error);
+        assert_eq!(states[0].reason, Some(RuntimeAppReason::TakeoverFailed));
+        assert!(!crate::relay::model_verification::store::has_lease(&db, "codex").unwrap());
+    }
+
+    #[tokio::test]
+    async fn runtime_reconcile_recovers_a_pending_lease_after_startup() {
+        let _guard = runtime_test_guard();
+        let db = managed_runtime_db("loongport-0123456789abcdef");
+        crate::relay::model_verification::store::set_runtime_setting(&db, true).unwrap();
+        crate::relay::model_verification::store::insert_lease(
+            &db,
+            "codex",
+            chrono::Utc::now().timestamp(),
+        )
+        .unwrap();
+        let fake = FakeTakeover::new(db.clone());
+        let coordinator = ModelVerificationCoordinator::with_verifier(
+            db.clone(),
+            Arc::new(BlockedVerifier::new()),
+        );
+
+        let states = coordinator.reconcile_all(&fake).await;
+
+        assert_eq!(states[0].status, RuntimeAppStatus::Active);
+        assert_eq!(
+            fake.calls.lock().unwrap().as_slice(),
+            [("codex".into(), true)]
+        );
+        assert!(db.get_proxy_config_for_app("codex").await.unwrap().enabled);
     }
 
     #[tokio::test]

--- a/src-tauri/src/relay/model_verification/coordinator.rs
+++ b/src-tauri/src/relay/model_verification/coordinator.rs
@@ -1216,9 +1216,12 @@ mod tests {
         }
     }
 
-    fn runtime_test_guard() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        let guard = LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    async fn runtime_test_guard() -> tokio::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+        let guard = LOCK
+            .get_or_init(|| tokio::sync::Mutex::new(()))
+            .lock()
+            .await;
         crate::settings::set_current_provider(&crate::app_config::AppType::Codex, None).unwrap();
         guard
     }
@@ -1264,7 +1267,7 @@ mod tests {
 
     #[tokio::test]
     async fn runtime_reconcile_takes_over_only_a_managed_current_provider() {
-        let _guard = runtime_test_guard();
+        let _guard = runtime_test_guard().await;
         let db = managed_runtime_db("loongport-0123456789abcdef");
         let fake = FakeTakeover::new(db.clone());
         let coordinator = ModelVerificationCoordinator::with_verifier(
@@ -1298,7 +1301,7 @@ mod tests {
 
     #[tokio::test]
     async fn runtime_disable_preserves_user_owned_takeover() {
-        let _guard = runtime_test_guard();
+        let _guard = runtime_test_guard().await;
         let db = managed_runtime_db("loongport-0123456789abcdef");
         let mut config = db.get_proxy_config_for_app("codex").await.unwrap();
         config.enabled = true;
@@ -1318,7 +1321,7 @@ mod tests {
 
     #[tokio::test]
     async fn runtime_takeover_failure_removes_the_pending_lease() {
-        let _guard = runtime_test_guard();
+        let _guard = runtime_test_guard().await;
         let db = managed_runtime_db("loongport-0123456789abcdef");
         let fake = FakeTakeover::new(db.clone());
         fake.fail_for("codex");
@@ -1335,7 +1338,7 @@ mod tests {
 
     #[tokio::test]
     async fn runtime_reconcile_recovers_a_pending_lease_after_startup() {
-        let _guard = runtime_test_guard();
+        let _guard = runtime_test_guard().await;
         let db = managed_runtime_db("loongport-0123456789abcdef");
         crate::relay::model_verification::store::set_runtime_setting(&db, true).unwrap();
         crate::relay::model_verification::store::insert_lease(


### PR DESCRIPTION
## Summary
- centralize runtime startup and provider-switch reconciliation behind a serialized coordinator
- only take over LoongPort-managed current providers and preserve user-owned proxy state
- make lease release failure-safe and recover pending leases after startup
- restore Active and Runtime completion ledgers with real commit mappings and corrected worktree paths

## Verification
- cargo test (2792 passed, 6 ignored)
- cargo clippy --all-targets -- -D warnings
- cargo fmt --check
- pnpm typecheck
- pnpm format:check
- pnpm test:unit (parallel runner had pre-existing timeout contention; affected files pass 30/30 with one worker and 15s timeout)
