### PR TITLE
fix(release): build macOS app bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,7 +329,9 @@ jobs:
           fi
           for attempt in $(seq 1 "$max_attempts"); do
             echo "=== macOS build/notarization attempt ${attempt}/${max_attempts} ==="
-            if pnpm tauri build --target universal-apple-darwin; then
+            # tauri.conf.json keeps the global target list at NSIS for Windows releases;
+            # select the macOS app bundle explicitly so the asset-preparation step gets a .app.
+            if pnpm tauri build --target universal-apple-darwin --bundles app; then
               echo "✅ macOS build/notarization succeeded"
               exit 0
             fi


### PR DESCRIPTION
## Summary
- explicitly request the macOS app bundle in the release build
- keep the global NSIS target used by Windows releases

## Root cause
`bundle.targets` is configured for NSIS so the macOS build produced only the bare binary. The asset preparation step then could not find a `.app`.

## Verification
- `git diff --check`
- YAML parse
- `pnpm tauri build --help` confirms `app` is a supported macOS bundle target