### PR TITLE
fix(stream-check): localize model probe verdicts

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -320,6 +320,11 @@ sqlite 的备份 API，直接拷主文件会丢最近的写）；② `app_store`
 `StreamCheckResult.model_used` 那个 TEXT 列要么存 enum 的判别式 + JSON、
 要么另加一列 —— 注意它同时是 `stream_check_logs` 的历史数据，改格式要考虑旧行怎么读。
 
+**已完成（2026-08-10）**：`model_used` 现在存带 `kind` 的结构化 JSON（不改表结构），
+前端解析后通过四份 locale 渲染密钥失效、无权访问、无模型、仅生图和模型列表五类结论。
+旧日志里的纯文本值继续作为 legacy 文案回退显示；新增 Rust 序列化、前端解析和 locale
+对称性测试。
+
 ---
 
 ## HSTS 的 max_age 还是观察期的 1 天（2026-08-05 记）

--- a/src-tauri/src/services/stream_check.rs
+++ b/src-tauri/src/services/stream_check.rs
@@ -35,6 +35,26 @@ pub enum HealthStatus {
     Failed,
 }
 
+/// `/models` 探测的结构化结论。
+///
+/// 该值会序列化进既有的 `stream_check_logs.model_used` TEXT 列；这样不需要迁移数据库，
+/// 前端仍能按当前语言渲染文案。旧日志里的纯文本值由前端作为 legacy 值回退显示。
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum ModelProbeVerdict {
+    KeyExpired { status: u16 },
+    Forbidden { status: u16 },
+    NoModels,
+    ImageOnly { models: Vec<String> },
+    Models { total: usize, head: Vec<String> },
+}
+
+impl ModelProbeVerdict {
+    fn encode(&self) -> String {
+        serde_json::to_string(self).unwrap_or_default()
+    }
+}
+
 /// 连通性检查配置
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -69,7 +89,7 @@ pub struct StreamCheckResult {
     pub message: String,
     pub response_time_ms: Option<u64>,
     pub http_status: Option<u16>,
-    /// 保留字段以兼容 `stream_check_logs` 表结构；连通性检查恒为空串。
+    /// 兼容 `stream_check_logs` 表结构的探测结论 JSON；未探测到时为空串。
     pub model_used: String,
     pub tested_at: i64,
     pub retry_count: u32,
@@ -155,10 +175,10 @@ impl StreamCheckService {
         // 只在**托管档位**上做：判据要 sk，而那套形状只有托管项保证有；
         // 用户手工建的 provider 密钥可能在任意位置。
         if checked.success && crate::relay::is_managed(&provider.id) {
-            if let Some(summary) =
+            if let Some(verdict) =
                 Self::probe_models(&client, app_type, provider, &base_url, timeout, ua).await
             {
-                checked.model_used = summary;
+                checked.model_used = verdict.encode();
             }
         }
         Ok(checked)
@@ -188,11 +208,11 @@ impl StreamCheckService {
     /// 可以对每个档位都点，与「真发一次推理去试」有本质区别 —— 后者要花钱，因而不可能
     /// 做成一个用户随时能按的按钮。
     ///
-    /// # 返回值放进 `model_used`（一个原本恒空的字段）
+    /// # 返回值序列化后放进 `model_used`（一个原本恒空的字段）
     ///
     /// `StreamCheckResult::model_used` 是 `stream_check_logs` 表里的既有列，改成真实检查
-    /// 之后它一直是空串。填上它 ⇒ 前端与历史日志**不用改结构**就能看到这条信息，
-    /// 而这正是那个字段当初的用意。
+    /// 之后它一直是空串。填上结构化 JSON ⇒ 前端与历史日志**不用改结构**就能看到这条信息，
+    /// 而这正是那个字段当初的用意。旧行若仍是纯文本，由调用方按 legacy 值处理。
     ///
     /// 返回 `None` = 问不出来（站点没这个端点 / 网络抖动）。**那时不改判定** ——
     /// 探测不到不等于档位坏了，把「我不知道」报成「不可用」比不报更糟。
@@ -203,7 +223,7 @@ impl StreamCheckService {
         base_url: &str,
         timeout: std::time::Duration,
         custom_ua: Option<HeaderValue>,
-    ) -> Option<String> {
+    ) -> Option<ModelProbeVerdict> {
         // 密钥位置按 CLI 分派，复用那一处定义（硬编码 codex 的位置会让 claude 档位
         // 永远探不出来，而且是静默的）。
         let api_key =
@@ -226,8 +246,8 @@ impl StreamCheckService {
             // 它正是可达性探测看不见的那一类。其余非 2xx 说明这个站没有这个端点，
             // 那不是档位的问题，按「问不出来」处理。
             return match status.as_u16() {
-                401 => Some("密钥已失效（401）".to_string()),
-                403 => Some("这个档位无权访问（403）".to_string()),
+                401 => Some(ModelProbeVerdict::KeyExpired { status: 401 }),
+                403 => Some(ModelProbeVerdict::Forbidden { status: 403 }),
                 _ => None,
             };
         }
@@ -243,7 +263,7 @@ impl StreamCheckService {
             .collect();
 
         if models.is_empty() {
-            return Some("这个档位没有可调用的模型".to_string());
+            return Some(ModelProbeVerdict::NoModels);
         }
 
         // 只挂生图模型 ⇒ 当对话档位用必定失败。这句话要说得让用户能照做。
@@ -251,16 +271,19 @@ impl StreamCheckService {
             .iter()
             .all(|m| crate::relay::provision::is_image_model(m));
         if all_image {
-            return Some(format!("只能生图（{}），不能对话", models.join(" / ")));
+            return Some(ModelProbeVerdict::ImageOnly { models });
         }
 
         // 正常情况：报个数 + 头几个名字。全列出来会把 toast 撑爆（实测有 13 个的分组）。
         const SHOWN: usize = 3;
-        let mut head: Vec<&str> = models.iter().take(SHOWN).map(String::as_str).collect();
+        let mut head: Vec<String> = models.iter().take(SHOWN).cloned().collect();
         if models.len() > SHOWN {
-            head.push("…");
+            head.push("…".to_string());
         }
-        Some(format!("{} 个模型（{}）", models.len(), head.join(" / ")))
+        Some(ModelProbeVerdict::Models {
+            total: models.len(),
+            head,
+        })
     }
 
     /// 解析供应商 `base_url`。
@@ -498,6 +521,23 @@ mod tests {
         assert_eq!(config.max_retries, 1);
         // 降级阈值沿用旧尺度，避免把 1 秒多的正常延迟误判为"较慢"
         assert_eq!(config.degraded_threshold_ms, 6000);
+    }
+
+    #[test]
+    fn model_probe_verdict_serializes_for_existing_log_column() {
+        let verdict = ModelProbeVerdict::Models {
+            total: 4,
+            head: vec!["alpha".to_string(), "beta".to_string(), "…".to_string()],
+        };
+
+        assert_eq!(
+            verdict.encode(),
+            r#"{"kind":"models","total":4,"head":["alpha","beta","…"]}"#
+        );
+        assert_eq!(
+            serde_json::from_str::<ModelProbeVerdict>(&verdict.encode()).unwrap(),
+            verdict
+        );
     }
 
     #[test]

--- a/src/hooks/useStreamCheck.ts
+++ b/src/hooks/useStreamCheck.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from "react";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import {
+  parseModelProbeVerdict,
   streamCheckProvider,
   type StreamCheckResult,
 } from "@/lib/api/connectivity-check";
@@ -17,6 +18,38 @@ import type { AppId } from "@/lib/api";
 export function useStreamCheck(appId: AppId) {
   const { t } = useTranslation();
   const [checkingIds, setCheckingIds] = useState<Set<string>>(new Set());
+
+  const formatModelProbe = useCallback(
+    (modelUsed: string | undefined) => {
+      if (!modelUsed) return undefined;
+
+      const verdict = parseModelProbeVerdict(modelUsed);
+      if (!verdict) return modelUsed;
+
+      switch (verdict.kind) {
+        case "keyExpired":
+          return t("streamCheck.modelProbe.keyExpired", {
+            status: verdict.status,
+          });
+        case "forbidden":
+          return t("streamCheck.modelProbe.forbidden", {
+            status: verdict.status,
+          });
+        case "noModels":
+          return t("streamCheck.modelProbe.noModels");
+        case "imageOnly":
+          return t("streamCheck.modelProbe.imageOnly", {
+            models: verdict.models.join(" / "),
+          });
+        case "models":
+          return t("streamCheck.modelProbe.models", {
+            total: verdict.total,
+            models: verdict.head.join(" / "),
+          });
+      }
+    },
+    [t],
+  );
 
   const checkProvider = useCallback(
     async (
@@ -40,7 +73,7 @@ export function useStreamCheck(appId: AppId) {
               // 「真正能调什么」—— 后端零成本探出来的（见 `modelUsed` 的文档）。
               // **可达 ≠ 可用**：密钥失效、分组没挂模型、只挂生图模型这三种，
               // 可达性探测都报「正常」，而这一行会说清楚。
-              description: result.modelUsed || undefined,
+              description: formatModelProbe(result.modelUsed),
             },
           );
         } else if (result.status === "degraded") {
@@ -54,7 +87,7 @@ export function useStreamCheck(appId: AppId) {
             // 独立的事：一个响应慢的档位同样可能密钥已失效、或只挂了生图模型。
             // 漏在这里等于让这个功能在最需要它的那一类档位上静默失效
             // （结论算出来了、写进日志了，就是不给用户看）。
-            { description: result.modelUsed || undefined },
+            { description: formatModelProbe(result.modelUsed) },
           );
         } else {
           // 仅当无法建立连接（DNS / 连接被拒 / TLS / 超时）才会到这里
@@ -93,7 +126,7 @@ export function useStreamCheck(appId: AppId) {
         });
       }
     },
-    [appId, t],
+    [appId, formatModelProbe, t],
   );
 
   const isChecking = useCallback(

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2773,7 +2773,14 @@
     "timeout": "Timeout (seconds)",
     "maxRetries": "Max Retries",
     "degradedThreshold": "Slow-response threshold (ms)",
-    "error": "{{providerName}} check error: {{error}}"
+    "error": "{{providerName}} check error: {{error}}",
+    "modelProbe": {
+      "keyExpired": "API key expired ({{status}})",
+      "forbidden": "This tier cannot access the models endpoint ({{status}})",
+      "noModels": "This tier has no callable models",
+      "imageOnly": "Image generation only ({{models}}); chat is unavailable",
+      "models": "{{total}} models ({{models}})"
+    }
   },
   "proxyConfig": {
     "proxyEnabled": "Routing Master Switch",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2773,7 +2773,14 @@
     "timeout": "タイムアウト（秒）",
     "maxRetries": "最大リトライ回数",
     "degradedThreshold": "低速判定しきい値（ミリ秒）",
-    "error": "{{providerName}} のチェックでエラーが発生しました: {{error}}"
+    "error": "{{providerName}} のチェックでエラーが発生しました: {{error}}",
+    "modelProbe": {
+      "keyExpired": "API キーが失効しています（{{status}}）",
+      "forbidden": "このティアはモデル一覧にアクセスできません（{{status}}）",
+      "noModels": "このティアに呼び出し可能なモデルはありません",
+      "imageOnly": "画像生成のみ（{{models}}）。チャットは利用できません",
+      "models": "{{total}} 個のモデル（{{models}}）"
+    }
   },
   "proxyConfig": {
     "proxyEnabled": "ルーティング総スイッチ",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2774,7 +2774,14 @@
     "timeout": "逾時時間（秒）",
     "maxRetries": "最大重試次數",
     "degradedThreshold": "緩慢閾值（毫秒）",
-    "error": "{{providerName}} 檢查出錯：{{error}}"
+    "error": "{{providerName}} 檢查出錯：{{error}}",
+    "modelProbe": {
+      "keyExpired": "金鑰已失效（{{status}}）",
+      "forbidden": "此檔位無權存取模型清單（{{status}}）",
+      "noModels": "此檔位沒有可呼叫的模型",
+      "imageOnly": "只能生成圖片（{{models}}），不能對話",
+      "models": "{{total}} 個模型（{{models}}）"
+    }
   },
   "proxyConfig": {
     "proxyEnabled": "路由總開關",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2773,7 +2773,14 @@
     "timeout": "超时时间（秒）",
     "maxRetries": "最大重试次数",
     "degradedThreshold": "较慢阈值（毫秒）",
-    "error": "{{providerName}} 检查出错: {{error}}"
+    "error": "{{providerName}} 检查出错: {{error}}",
+    "modelProbe": {
+      "keyExpired": "密钥已失效（{{status}}）",
+      "forbidden": "这个档位无权访问（{{status}}）",
+      "noModels": "这个档位没有可调用的模型",
+      "imageOnly": "只能生图（{{models}}），不能对话",
+      "models": "{{total}} 个模型（{{models}}）"
+    }
   },
   "proxyConfig": {
     "proxyEnabled": "路由总开关",

--- a/src/lib/api/connectivity-check.ts
+++ b/src/lib/api/connectivity-check.ts
@@ -31,10 +31,65 @@ export interface StreamCheckResult {
    * 密钥失效（401）、分组没挂任何模型、或只挂了生图模型却被当对话档位用
    * （实测这三种在可达性探测里全显示「正常」）。
    *
-   * 字段名沿用后端 `stream_check_logs` 表的既有列（原本恒为空串），所以历史日志
-   * 与批量检查不必改结构就能带上这条信息。
+   * 字段名沿用后端 `stream_check_logs` 表的既有列（原本恒为空串）。新结果是带 `kind`
+   * 的 JSON，历史行里的纯文本仍可作为 legacy 值回退显示，因此不需要改数据库结构。
    */
   modelUsed?: string;
+}
+
+export type ModelProbeVerdict =
+  | { kind: "keyExpired"; status: number }
+  | { kind: "forbidden"; status: number }
+  | { kind: "noModels" }
+  | { kind: "imageOnly"; models: string[] }
+  | { kind: "models"; total: number; head: string[] };
+
+/** Parse the structured verdict stored in the legacy `modelUsed` field. */
+export function parseModelProbeVerdict(
+  value: string | undefined,
+): ModelProbeVerdict | null {
+  if (!value) return null;
+
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!parsed || typeof parsed !== "object" || !("kind" in parsed)) {
+      return null;
+    }
+
+    const candidate = parsed as Record<string, unknown>;
+    switch (candidate.kind) {
+      case "keyExpired":
+      case "forbidden":
+        return typeof candidate.status === "number"
+          ? { kind: candidate.kind, status: candidate.status }
+          : null;
+      case "noModels":
+        return { kind: "noModels" };
+      case "imageOnly":
+      case "models":
+        if (
+          !Array.isArray(candidate.models) &&
+          !Array.isArray(candidate.head)
+        ) {
+          return null;
+        }
+        if (candidate.kind === "imageOnly") {
+          return Array.isArray(candidate.models) &&
+            candidate.models.every((model) => typeof model === "string")
+            ? { kind: "imageOnly", models: candidate.models }
+            : null;
+        }
+        return typeof candidate.total === "number" &&
+          Array.isArray(candidate.head) &&
+          candidate.head.every((model) => typeof model === "string")
+          ? { kind: "models", total: candidate.total, head: candidate.head }
+          : null;
+      default:
+        return null;
+    }
+  } catch {
+    return null;
+  }
 }
 
 // ===== 连通性检查 API =====

--- a/tests/lib/connectivity-check.test.ts
+++ b/tests/lib/connectivity-check.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { parseModelProbeVerdict } from "@/lib/api/connectivity-check";
+
+describe("parseModelProbeVerdict", () => {
+  it("parses structured model lists", () => {
+    expect(
+      parseModelProbeVerdict(
+        '{"kind":"models","total":4,"head":["alpha","beta","…"]}',
+      ),
+    ).toEqual({
+      kind: "models",
+      total: 4,
+      head: ["alpha", "beta", "…"],
+    });
+  });
+
+  it("parses image-only and HTTP verdicts", () => {
+    expect(
+      parseModelProbeVerdict('{"kind":"imageOnly","models":["gpt-image-1"]}'),
+    ).toEqual({ kind: "imageOnly", models: ["gpt-image-1"] });
+    expect(
+      parseModelProbeVerdict('{"kind":"keyExpired","status":401}'),
+    ).toEqual({ kind: "keyExpired", status: 401 });
+  });
+
+  it("returns null for malformed or unknown payloads", () => {
+    expect(parseModelProbeVerdict("legacy Chinese summary")).toBeNull();
+    expect(parseModelProbeVerdict('{"kind":"futureVerdict"}')).toBeNull();
+    expect(parseModelProbeVerdict('{"kind":"models","total":"4"}')).toBeNull();
+    expect(parseModelProbeVerdict(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary\n- serialize model probe verdicts as structured JSON in the existing model_used column\n- render verdicts through i18n in all four locales\n- preserve legacy plain-text values and add Rust/frontend tests\n\n## Verification\n- cargo test stream_check --lib\n- pnpm exec tsc --noEmit\n- targeted Vitest and locale checks\n- cargo fmt / Prettier / git diff --check