### PR TITLE
fix(model-verification): expose actionable status

### DIFF
--- a/src-tauri/src/relay/model_verification/active.rs
+++ b/src-tauri/src/relay/model_verification/active.rs
@@ -70,7 +70,7 @@ impl ActiveVerifier for BalancedActiveVerifier {
                 }
                 _ => unreachable!("supported app type checked before preparing the run"),
             }
-            .map_err(map_protocol_failure)?;
+            .map_err(|failure| map_protocol_failure(&target, &app_type, failure))?;
             let (verdict, evidence_level) = verdict::evaluate(app_type, &profile, &facts);
             Ok(VerificationReport {
                 target,
@@ -88,12 +88,24 @@ impl ActiveVerifier for BalancedActiveVerifier {
     }
 }
 
-fn map_protocol_failure(failure: RunFailure) -> RunFailureKind {
+fn map_protocol_failure(
+    target: &TargetKey,
+    app_type: &AppType,
+    failure: RunFailure,
+) -> RunFailureKind {
     match failure {
         RunFailure::Authentication => RunFailureKind::Authentication,
         RunFailure::RateLimited => RunFailureKind::RateLimited,
         RunFailure::InsufficientBalance => RunFailureKind::InsufficientBalance,
-        RunFailure::Upstream => RunFailureKind::Upstream,
+        RunFailure::Upstream { status } => {
+            log::warn!(
+                "[model-verification] upstream failure: provider_id={:?} app_type={} model={:?} status={status}",
+                target.provider_id,
+                app_type.as_str(),
+                target.model,
+            );
+            RunFailureKind::Upstream
+        }
         RunFailure::Network => RunFailureKind::Network,
         RunFailure::Timeout => RunFailureKind::Timeout,
         RunFailure::ModelUnavailable => RunFailureKind::ModelUnavailable,

--- a/src-tauri/src/relay/model_verification/protocols/anthropic.rs
+++ b/src-tauri/src/relay/model_verification/protocols/anthropic.rs
@@ -738,7 +738,7 @@ mod tests {
             (
                 StatusCode::BAD_GATEWAY,
                 "SENTINEL_502",
-                RunFailure::Upstream,
+                RunFailure::Upstream { status: 502 },
             ),
         ] {
             let app =

--- a/src-tauri/src/relay/model_verification/protocols/mod.rs
+++ b/src-tauri/src/relay/model_verification/protocols/mod.rs
@@ -101,7 +101,11 @@ pub(crate) enum RunFailure {
     Authentication,
     RateLimited,
     InsufficientBalance,
-    Upstream,
+    /// An upstream 5xx response. The status is retained for diagnostics, but the response body
+    /// deliberately never crosses this protocol boundary.
+    Upstream {
+        status: u16,
+    },
     Network,
     Timeout,
     ModelUnavailable,
@@ -200,7 +204,9 @@ pub(crate) fn classify_http_failure(status: StatusCode, body: &[u8]) -> RunFailu
             RunFailure::InsufficientBalance
         }
         StatusCode::NOT_FOUND => RunFailure::ModelUnavailable,
-        status if status.is_server_error() => RunFailure::Upstream,
+        status if status.is_server_error() => RunFailure::Upstream {
+            status: status.as_u16(),
+        },
         _ => RunFailure::InvalidResponse,
     }
 }

--- a/src-tauri/src/relay/model_verification/protocols/openai_responses.rs
+++ b/src-tauri/src/relay/model_verification/protocols/openai_responses.rs
@@ -1212,7 +1212,7 @@ mod openai_responses_tests {
             (
                 StatusCode::BAD_GATEWAY,
                 "SENTINEL_502",
-                RunFailure::Upstream,
+                RunFailure::Upstream { status: 502 },
             ),
         ] {
             let endpoint = spawn_server(

--- a/src/components/relay/RelayRow.tsx
+++ b/src/components/relay/RelayRow.tsx
@@ -3,6 +3,7 @@ import {
   Activity,
   AlertCircle,
   Check,
+  CheckCircle2,
   ChevronDown,
   ChevronRight,
   Fingerprint,
@@ -662,6 +663,7 @@ function TierItem({
     verificationVerdict === "anomaly" || verificationVerdict === "suspicious"
       ? verificationVerdict
       : undefined;
+  const verificationPassed = verificationVerdict === "trusted";
 
   // ⚠️ **`=== true` 而不是 `??` 或直接判真值** —— `userEdited` 是三态：
   // `true`（改过）/ `false`（没改）/ `null`（**判不了**，读不出密钥或这个 CLI
@@ -728,6 +730,15 @@ function TierItem({
               {t(
                 `loongport.modelVerification.tierVerdict.${verificationProblem}`,
               )}
+            </span>
+          )}
+          {verificationPassed && (
+            <span
+              className="inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium text-emerald-600 ring-1 ring-inset ring-emerald-500/30 dark:text-emerald-400"
+              title={t("loongport.modelVerification.tierVerdict.trustedHint")}
+            >
+              <CheckCircle2 className="h-2.5 w-2.5" />
+              {t("loongport.modelVerification.tierVerdict.trusted")}
             </span>
           )}
         </div>

--- a/src/components/relay/RelaySection.tsx
+++ b/src/components/relay/RelaySection.tsx
@@ -108,7 +108,7 @@ let autoPromptedThisProcess = false;
 
 type TierVerificationVerdict = Extract<
   VerificationVerdict,
-  "suspicious" | "anomaly"
+  "trusted" | "suspicious" | "anomaly"
 >;
 
 function verificationReportKey({
@@ -131,6 +131,11 @@ function reduceTierVerificationVerdicts(
       verdicts[report.target.providerId] !== "anomaly"
     ) {
       verdicts[report.target.providerId] = "suspicious";
+    } else if (
+      report.verdict === "trusted" &&
+      verdicts[report.target.providerId] === undefined
+    ) {
+      verdicts[report.target.providerId] = "trusted";
     }
   }
   return verdicts;

--- a/src/components/relay/__tests__/RelayRow.modelVerification.test.tsx
+++ b/src/components/relay/__tests__/RelayRow.modelVerification.test.tsx
@@ -8,8 +8,11 @@ vi.mock("react-i18next", () => ({
       (
         ({
           "loongport.modelVerification.title": "模型验证",
+          "loongport.modelVerification.tierVerdict.trusted": "模型已验证",
           "loongport.modelVerification.tierVerdict.suspicious": "模型存疑",
           "loongport.modelVerification.tierVerdict.anomaly": "模型异常",
+          "loongport.modelVerification.tierVerdict.trustedHint":
+            "模型验证通过，请点击「模型验证」查看详情",
           "loongport.modelVerification.tierVerdict.suspiciousHint":
             "模型验证结果存疑，请点击「模型验证」查看详情",
           "loongport.modelVerification.tierVerdict.anomalyHint":
@@ -150,15 +153,24 @@ describe("RelayRow model verification", () => {
     ).toBeInTheDocument();
   });
 
-  it.each(["trusted", "inconclusive"] as const)(
-    "does not render a problem label for %s",
-    (verificationVerdict) => {
-      renderRow({ verificationVerdictForTier: () => verificationVerdict });
+  it("shows a success-colored label for a verified model", () => {
+    renderRow({ verificationVerdictForTier: () => "trusted" });
 
-      expect(screen.queryByText("模型存疑")).not.toBeInTheDocument();
-      expect(screen.queryByText("模型异常")).not.toBeInTheDocument();
-    },
-  );
+    const label = screen.getByText("模型已验证").closest("span");
+    expect(label).toHaveClass("text-emerald-600");
+    expect(
+      screen.getByTitle("模型验证通过，请点击「模型验证」查看详情"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("模型存疑")).not.toBeInTheDocument();
+  });
+
+  it("does not render a tier label for an inconclusive result", () => {
+    renderRow({ verificationVerdictForTier: () => "inconclusive" });
+
+    expect(screen.queryByText("模型已验证")).not.toBeInTheDocument();
+    expect(screen.queryByText("模型存疑")).not.toBeInTheDocument();
+    expect(screen.queryByText("模型异常")).not.toBeInTheDocument();
+  });
 });
 
 function relayWithTier(tierOverrides: Partial<typeof tier>) {

--- a/src/components/relay/__tests__/RelaySection.modelVerification.test.tsx
+++ b/src/components/relay/__tests__/RelaySection.modelVerification.test.tsx
@@ -237,6 +237,32 @@ describe("RelaySection model verification ownership", () => {
     await screen.findByRole("combobox");
   });
 
+  it("keeps a trusted tier visible until a more severe report supersedes it", async () => {
+    api.listResults.mockResolvedValueOnce([
+      report("provider-a", "trusted", "verified-model"),
+    ]);
+
+    render(<RelaySection appId="codex" />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("verdict-provider-a")).toHaveTextContent(
+        "trusted",
+      ),
+    );
+
+    api.listResults.mockResolvedValueOnce([
+      report("provider-a", "trusted", "verified-model"),
+      report("provider-a", "suspicious", "suspicious-model"),
+    ]);
+    fireEvent.click(screen.getByRole("button", { name: "refresh" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("verdict-provider-a")).toHaveTextContent(
+        "suspicious",
+      ),
+    );
+  });
+
   it("clears a reset badge only after the matching backend change event", async () => {
     render(<RelaySection appId="codex" />);
     await waitFor(() =>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3228,8 +3228,10 @@
         "status": { "active": "Active", "waiting": "Waiting", "error": "Error" }
       },
       "tierVerdict": {
+        "trusted": "Model verified",
         "suspicious": "Model suspicious",
         "anomaly": "Model anomaly",
+        "trustedHint": "Model verification passed. Select Verify model for details.",
         "suspiciousHint": "Verification found suspicious behavior. Select Verify model for details.",
         "anomalyHint": "Verification found an anomaly. Select Verify model for details."
       },

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3228,8 +3228,10 @@
         "status": { "active": "有効", "waiting": "待機中", "error": "エラー" }
       },
       "tierVerdict": {
+        "trusted": "モデル検証済み",
         "suspicious": "モデルに疑い",
         "anomaly": "モデル異常",
+        "trustedHint": "モデル検証に合格しました。モデルを検証で詳細を確認してください。",
         "suspiciousHint": "検証で疑わしい挙動が見つかりました。モデルを検証で詳細を確認してください。",
         "anomalyHint": "検証で異常が見つかりました。モデルを検証で詳細を確認してください。"
       },

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3225,8 +3225,10 @@
         "status": { "active": "已啟用", "waiting": "等待中", "error": "錯誤" }
       },
       "tierVerdict": {
+        "trusted": "模型已驗證",
         "suspicious": "模型存疑",
         "anomaly": "模型異常",
+        "trustedHint": "模型驗證通過，請點擊「模型驗證」查看詳情",
         "suspiciousHint": "模型驗證結果存疑，請點擊「模型驗證」查看詳情",
         "anomalyHint": "模型驗證發現異常，請點擊「模型驗證」查看詳情"
       },

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -3224,8 +3224,10 @@
         "status": { "active": "已启用", "waiting": "等待中", "error": "异常" }
       },
       "tierVerdict": {
+        "trusted": "模型已验证",
         "suspicious": "模型存疑",
         "anomaly": "模型异常",
+        "trustedHint": "模型验证通过，请点击「模型验证」查看详情",
         "suspiciousHint": "模型验证结果存疑，请点击「模型验证」查看详情",
         "anomalyHint": "模型验证发现异常，请点击「模型验证」查看详情"
       },


### PR DESCRIPTION
## Summary / 概述

- retain upstream HTTP status codes for model-verification diagnostics without logging bodies, URLs, or credentials
- show a green “模型已验证” tier tag for trusted reports while keeping suspicious and anomaly states authoritative
- update all four locales and focused regression tests

## Related Issue / 关联 Issue

N/A

## Screenshots / 截图

Not included; the change reuses the existing compact tier tag style.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy --all-targets -- -D warnings` passes / 通过 Clippy 检查
- [x] Updated i18n files if user-facing text changed / 已更新国际化文件

## Verification

- `cargo test model_verification --lib` (125 passed)
- `pnpm vitest run` (742 passed)
- full `cargo test`: 2807 passed; one existing proxy integration test could not bind port 15721 because the installed LoongPort app was running on that port