### PR TITLE
feat: show recent model verification results

### DIFF
--- a/src-tauri/src/commands/model_verification.rs
+++ b/src-tauri/src/commands/model_verification.rs
@@ -3,7 +3,7 @@ use crate::{
         target,
         types::{
             RunFailureKind, RuntimeAppState, RuntimeVerificationSetting, StartRunResponse,
-            TargetKey, VerificationReport,
+            TargetKey, TargetScope, VerificationHistoryEntry, VerificationReport,
         },
     },
     AppState,
@@ -94,6 +94,17 @@ fn get_model_verification_results_impl(
     provider_ids: Vec<String>,
 ) -> Result<Vec<VerificationReport>, RunFailureKind> {
     state.model_verification.list_results(&provider_ids)
+}
+
+#[tauri::command]
+pub fn get_model_verification_history(
+    state: tauri::State<'_, AppState>,
+    provider_id: String,
+    app_type: String,
+) -> Result<Vec<VerificationHistoryEntry>, RunFailureKind> {
+    state
+        .model_verification
+        .list_history(&TargetScope::new(provider_id, app_type))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/database/loongport_schema.rs
+++ b/src-tauri/src/database/loongport_schema.rs
@@ -48,7 +48,7 @@ use crate::error::AppError;
 /// LoongPort 自己的 schema 版本。加迁移时 +1。
 ///
 /// **与 `SCHEMA_VERSION`（上游那个）无关**，两者各自独立计数。
-pub(crate) const LOONGPORT_SCHEMA_VERSION: i32 = 6;
+pub(crate) const LOONGPORT_SCHEMA_VERSION: i32 = 7;
 
 /// 存版本号的表。**只有一行**（`id = 1`）。
 ///
@@ -155,6 +155,13 @@ pub(crate) fn apply(conn: &Connection) -> Result<(), AppError> {
                 log::info!("LoongPort 数据迁移 v5 → v6（运行时验证设置与代理租约）");
                 crate::relay::model_verification::store::create_runtime_tables(conn)?;
                 set_version(conn, 6)?;
+            }
+            // v6 → v7：每个分组最近五条脱敏模型验证结果。
+            // 旧表是当前状态快照，不是历史事件，不将它伪装成首条历史。
+            6 => {
+                log::info!("LoongPort 数据迁移 v6 → v7（模型验证历史）");
+                crate::relay::model_verification::history::create_table(conn)?;
+                set_version(conn, 7)?;
             }
             other => {
                 return Err(AppError::Database(format!(
@@ -524,7 +531,7 @@ mod tests {
     }
 
     #[test]
-    fn v4_to_v6_creates_runtime_tables_without_touching_user_version() {
+    fn v4_to_latest_creates_model_verification_tables_without_touching_user_version() {
         let conn = mem();
         legacy_providers_table(&conn);
         conn.execute("PRAGMA user_version = 16", [])
@@ -564,6 +571,16 @@ mod tests {
                 |row| row.get(0),
             )
             .expect("查询运行时验证租约表");
+        let history_table_exists: bool = conn
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM sqlite_master
+                    WHERE type = 'table' AND name = 'model_verification_history'
+                )",
+                [],
+                |row| row.get(0),
+            )
+            .expect("查询模型验证历史表");
         let user_version: i32 = conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .expect("读取上游版本");
@@ -571,12 +588,13 @@ mod tests {
         assert!(result_table_exists, "v4 → v5 必须创建模型验证结果表");
         assert!(settings_table_exists, "v5 → v6 必须创建运行时验证设置表");
         assert!(leases_table_exists, "v5 → v6 必须创建运行时验证租约表");
+        assert!(history_table_exists, "v6 → v7 必须创建模型验证历史表");
         assert_eq!(user_version, 16, "LoongPort 迁移不许修改上游版本号");
-        assert_eq!(current_version(&conn).unwrap(), 6);
+        assert_eq!(current_version(&conn).unwrap(), 7);
     }
 
     #[test]
-    fn v5_to_v6_is_idempotent_and_seeds_setting() {
+    fn v5_to_latest_is_idempotent_and_seeds_setting() {
         let conn = mem();
         ensure_version_table(&conn).expect("建版本表");
         set_version(&conn, 5).expect("设为 v5");
@@ -593,7 +611,52 @@ mod tests {
             )
             .expect("读取默认设置");
         assert_eq!(setting, (0, 1));
-        assert_eq!(current_version(&conn).unwrap(), 6);
+        assert_eq!(current_version(&conn).unwrap(), 7);
+    }
+
+    #[test]
+    fn v6_to_v7_keeps_current_results_but_starts_history_empty() {
+        let conn = mem();
+        legacy_providers_table(&conn);
+        conn.execute(
+            "INSERT INTO providers (id, app_type) VALUES ('provider-a', 'codex')",
+            [],
+        )
+        .expect("插入旧档位");
+        crate::relay::model_verification::store::create_results_table(&conn).expect("创建旧结果表");
+        conn.execute(
+            "INSERT INTO model_verification_results (
+                provider_id, app_type, model, verdict, evidence_level,
+                rules_version, updated_at
+             ) VALUES (
+                'provider-a', 'codex', 'gpt-test', 'inconclusive',
+                'insufficient', 1, 123
+             )",
+            [],
+        )
+        .expect("插入旧结果快照");
+        ensure_version_table(&conn).expect("建版本表");
+        set_version(&conn, 6).expect("设为 v6");
+
+        apply(&conn).expect("迁移到 v7");
+
+        let current_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM model_verification_results",
+                [],
+                |row| row.get(0),
+            )
+            .expect("统计当前结果");
+        let history_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM model_verification_history",
+                [],
+                |row| row.get(0),
+            )
+            .expect("统计验证历史");
+
+        assert_eq!(current_count, 1, "当前结果仍是运行状态，不应丢弃");
+        assert_eq!(history_count, 0, "旧快照不能伪造为历史事件");
     }
 
     fn insert_codex_tier(conn: &Connection, id: &str, name: &str, model: &str) {

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -46,6 +46,7 @@ impl Database {
         .map_err(|e| AppError::Database(e.to_string()))?;
 
         crate::relay::model_verification::store::create_results_table(conn)?;
+        crate::relay::model_verification::history::create_table(conn)?;
         crate::relay::model_verification::store::create_runtime_tables(conn)?;
 
         // 2. Provider Endpoints 表

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1555,6 +1555,7 @@ pub fn run() {
             commands::start_model_verification,
             commands::cancel_model_verification,
             commands::get_model_verification_results,
+            commands::get_model_verification_history,
             // LoongPort 官网直连账号（vendor）
             commands::vendor_list_accounts,
             commands::vendor_open_login,

--- a/src-tauri/src/relay/model_verification/coordinator.rs
+++ b/src-tauri/src/relay/model_verification/coordinator.rs
@@ -667,6 +667,17 @@ impl ModelVerificationCoordinator {
             .map_err(|_| RunFailureKind::InvalidResponse)
     }
 
+    pub fn list_history(
+        &self,
+        scope: &TargetScope,
+    ) -> Result<
+        Vec<crate::relay::model_verification::types::VerificationHistoryEntry>,
+        RunFailureKind,
+    > {
+        crate::relay::model_verification::history::list(&self.db, scope)
+            .map_err(|_| RunFailureKind::InvalidResponse)
+    }
+
     pub fn cancel(&self, run_id: &str) -> Result<(), RunFailureKind> {
         let _mutation = self
             .mutation

--- a/src-tauri/src/relay/model_verification/history.rs
+++ b/src-tauri/src/relay/model_verification/history.rs
@@ -1,0 +1,149 @@
+use rusqlite::{params, Connection};
+
+use crate::{
+    database::{lock_conn, Database},
+    error::AppError,
+    relay::model_verification::types::{
+        TargetKey, TargetScope, VerificationHistoryEntry, VerificationReport, VerificationSource,
+    },
+};
+
+const TABLE: &str = "model_verification_history";
+const LIMIT: i64 = 5;
+
+pub(crate) fn create_table(conn: &Connection) -> Result<(), AppError> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS model_verification_history (
+            id INTEGER PRIMARY KEY,
+            provider_id TEXT NOT NULL,
+            app_type TEXT NOT NULL,
+            model TEXT NOT NULL,
+            source TEXT NOT NULL CHECK (source IN ('active', 'runtime')),
+            verdict TEXT NOT NULL,
+            evidence_level TEXT NOT NULL,
+            facts_json TEXT NOT NULL,
+            rules_version INTEGER NOT NULL,
+            checked_at INTEGER NOT NULL,
+            FOREIGN KEY (provider_id, app_type) REFERENCES providers(id, app_type) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_model_verification_history_scope_order
+        ON model_verification_history (provider_id, app_type, checked_at DESC, id DESC);",
+    )
+    .map_err(|error| AppError::Database(format!("创建 {TABLE} 表失败: {error}")))?;
+    Ok(())
+}
+
+pub fn list(db: &Database, scope: &TargetScope) -> Result<Vec<VerificationHistoryEntry>, AppError> {
+    let conn = lock_conn!(db.conn);
+    let mut statement = conn
+        .prepare(
+            "SELECT provider_id, app_type, model, source, verdict, evidence_level,
+                    facts_json, rules_version, checked_at
+             FROM model_verification_history
+             WHERE provider_id = ?1 AND app_type = ?2
+             ORDER BY checked_at DESC, id DESC
+             LIMIT ?3",
+        )
+        .map_err(|error| AppError::Database(format!("查询模型验证历史失败: {error}")))?;
+    let rows = statement
+        .query_map(params![scope.provider_id, scope.app_type, LIMIT], |row| {
+            Ok((
+                TargetKey::new(
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ),
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, String>(5)?,
+                row.get::<_, String>(6)?,
+                row.get::<_, i32>(7)?,
+                row.get::<_, i64>(8)?,
+            ))
+        })
+        .map_err(|error| AppError::Database(format!("读取模型验证历史失败: {error}")))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| AppError::Database(format!("解析模型验证历史失败: {error}")))?;
+
+    rows.into_iter()
+        .map(
+            |(target, source, verdict, evidence_level, facts_json, rules_version, checked_at)| {
+                let facts = serde_json::from_str(&facts_json).map_err(|error| {
+                    AppError::Config(format!("解析模型验证历史依据失败: {error}"))
+                })?;
+                Ok(VerificationHistoryEntry {
+                    source: VerificationSource::try_from(source.as_str())
+                        .map_err(|_| AppError::Config("解析模型验证来源失败".into()))?,
+                    report: VerificationReport {
+                        target,
+                        verdict: crate::relay::model_verification::types::Verdict::try_from(
+                            verdict.as_str(),
+                        )
+                        .map_err(|_| AppError::Config("解析验证结论失败".into()))?,
+                        evidence_level:
+                            crate::relay::model_verification::types::EvidenceLevel::try_from(
+                                evidence_level.as_str(),
+                            )
+                            .map_err(|_| AppError::Config("解析验证证据等级失败".into()))?,
+                        facts,
+                        rules_version,
+                        checked_at,
+                    },
+                })
+            },
+        )
+        .collect()
+}
+
+pub(super) fn insert(
+    conn: &Connection,
+    source: VerificationSource,
+    report: &VerificationReport,
+) -> Result<(), AppError> {
+    let facts_json = serde_json::to_string(&report.facts)
+        .map_err(|error| AppError::Config(format!("序列化模型验证历史依据失败: {error}")))?;
+    conn.execute(
+        "INSERT INTO model_verification_history (
+            provider_id, app_type, model, source, verdict, evidence_level,
+            facts_json, rules_version, checked_at
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        params![
+            &report.target.provider_id,
+            &report.target.app_type,
+            &report.target.model,
+            source.as_str(),
+            report.verdict.as_str(),
+            report.evidence_level.as_str(),
+            facts_json,
+            report.rules_version,
+            report.checked_at,
+        ],
+    )
+    .map_err(|error| AppError::Database(format!("保存模型验证历史失败: {error}")))?;
+    Ok(())
+}
+
+pub(super) fn prune(conn: &Connection, provider_id: &str, app_type: &str) -> Result<(), AppError> {
+    conn.execute(
+        "DELETE FROM model_verification_history
+         WHERE provider_id = ?1 AND app_type = ?2
+           AND id NOT IN (
+             SELECT id FROM model_verification_history
+             WHERE provider_id = ?1 AND app_type = ?2
+             ORDER BY checked_at DESC, id DESC
+             LIMIT ?3
+           )",
+        params![provider_id, app_type, LIMIT],
+    )
+    .map_err(|error| AppError::Database(format!("裁剪模型验证历史失败: {error}")))?;
+    Ok(())
+}
+
+pub(super) fn clear(conn: &Connection, scope: &TargetScope) -> Result<(), AppError> {
+    conn.execute(
+        "DELETE FROM model_verification_history WHERE provider_id = ?1 AND app_type = ?2",
+        params![scope.provider_id, scope.app_type],
+    )
+    .map_err(|error| AppError::Database(format!("清除模型验证历史失败: {error}")))?;
+    Ok(())
+}

--- a/src-tauri/src/relay/model_verification/mod.rs
+++ b/src-tauri/src/relay/model_verification/mod.rs
@@ -1,6 +1,7 @@
 pub mod active;
 pub mod capability_profiles;
 pub mod coordinator;
+pub(crate) mod history;
 pub mod passive;
 pub(crate) mod protocols;
 pub mod store;

--- a/src-tauri/src/relay/model_verification/passive.rs
+++ b/src-tauri/src/relay/model_verification/passive.rs
@@ -219,6 +219,10 @@ impl FiniteEvidenceFacts {
         self.0.is_empty()
     }
 
+    pub fn into_vec(self) -> Vec<EvidenceFact> {
+        self.0
+    }
+
     fn record(
         outcomes: &mut [Option<EvidenceOutcome>; EvidenceCode::CARDINALITY],
         fact: EvidenceFact,
@@ -377,6 +381,25 @@ impl PassiveAggregate {
 
     pub fn last_observed_at(&self) -> Option<i64> {
         self.last_observed_at
+    }
+
+    pub fn evidence_facts(&self) -> Vec<EvidenceFact> {
+        EvidenceCode::ALL
+            .into_iter()
+            .filter_map(|code| {
+                let outcome = if self
+                    .unresolved_fingerprints
+                    .contains(&AnomalyFingerprint::from_code(code))
+                {
+                    EvidenceOutcome::Failed
+                } else if self.pass_count(code) > 0 {
+                    EvidenceOutcome::Passed
+                } else {
+                    return None;
+                };
+                Some(EvidenceFact { code, outcome })
+            })
+            .collect()
     }
 
     #[cfg(test)]

--- a/src-tauri/src/relay/model_verification/privacy_tests.rs
+++ b/src-tauri/src/relay/model_verification/privacy_tests.rs
@@ -136,8 +136,12 @@ async fn active_protocols_keep_private_request_and_response_material_out_of_ever
         let returned = serde_json::to_string(&(start, &reports)).unwrap();
         assert_no_private_values("returned start/report", &returned, &request_private_strings);
 
-        let persisted = persisted_row(&db);
-        assert_no_private_values("SQLite result row", &persisted, &request_private_strings);
+        let persisted = persisted_rows(&db);
+        assert_no_private_values(
+            "SQLite result and history rows",
+            &persisted,
+            &request_private_strings,
+        );
 
         let emitted = serde_json::to_string(&(
             sink.progress.lock().unwrap().clone(),
@@ -531,21 +535,25 @@ async fn wait_for_change(sink: &RecordingSink) {
     .expect("active verification should finish");
 }
 
-fn persisted_row(db: &Database) -> String {
+fn persisted_rows(db: &Database) -> String {
     let conn = db.conn.lock().unwrap();
-    let mut statement = conn
-        .prepare("SELECT * FROM model_verification_results")
-        .unwrap();
-    let column_count = statement.column_count();
-    assert!(column_count > 0);
-    statement
-        .query_row([], |row| {
-            (0..column_count)
-                .map(|index| row.get_ref(index).map(|value| format!("{value:?}")))
-                .collect::<Result<Vec<_>, _>>()
-                .map(|values| values.join("|"))
+    ["model_verification_results", "model_verification_history"]
+        .into_iter()
+        .map(|table| {
+            let mut statement = conn.prepare(&format!("SELECT * FROM {table}")).unwrap();
+            let column_count = statement.column_count();
+            assert!(column_count > 0);
+            statement
+                .query_row([], |row| {
+                    (0..column_count)
+                        .map(|index| row.get_ref(index).map(|value| format!("{value:?}")))
+                        .collect::<Result<Vec<_>, _>>()
+                        .map(|values| values.join("|"))
+                })
+                .unwrap()
         })
-        .unwrap()
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn assert_no_private_values(

--- a/src-tauri/src/relay/model_verification/store.rs
+++ b/src-tauri/src/relay/model_verification/store.rs
@@ -2,12 +2,14 @@ use crate::{
     database::{lock_conn, Database},
     error::AppError,
     relay::model_verification::{
+        history,
         passive::{
-            reduce_batch, resolve_with_active, AnomalyFingerprint, EvidenceBatch, PassiveAggregate,
+            reduce_batch, resolve_with_active, AnomalyFingerprint, EvidenceBatch,
+            FiniteEvidenceFacts, PassiveAggregate,
         },
         types::{
             EvidenceLevel, ProxyLease, RuntimeAppType, RuntimeVerificationSetting, TargetKey,
-            TargetScope, Verdict, VerificationReport, RULES_VERSION,
+            TargetScope, Verdict, VerificationReport, VerificationSource, RULES_VERSION,
         },
         verdict::{self, MergedReport},
     },
@@ -200,11 +202,36 @@ mod tests {
     use super::*;
     use crate::relay::model_verification::types::{
         EvidenceCode, EvidenceFact, EvidenceLevel, EvidenceOutcome, ProxyLease, RuntimeAppReason,
-        RuntimeAppState, RuntimeAppStatus, RuntimeAppType, TargetKey, Verdict, VerificationReport,
-        RULES_VERSION,
+        RuntimeAppState, RuntimeAppStatus, RuntimeAppType, TargetKey, TargetScope, Verdict,
+        VerificationReport, VerificationSource, RULES_VERSION,
     };
 
     use crate::relay::model_verification::passive::EvidenceBatch;
+
+    fn insert_provider(db: &Database, provider_id: &str, app_type: &str) -> Result<(), AppError> {
+        let conn = lock_conn!(db.conn);
+        conn.execute(
+            "INSERT INTO providers (id, app_type, name, settings_config)
+             VALUES (?1, ?2, ?1, '{}')",
+            params![provider_id, app_type],
+        )
+        .unwrap();
+        Ok(())
+    }
+
+    fn active_report(provider_id: &str, app_type: &str, checked_at: i64) -> VerificationReport {
+        VerificationReport {
+            target: TargetKey::new(provider_id, app_type, format!("model-{checked_at}")),
+            verdict: Verdict::Trusted,
+            evidence_level: EvidenceLevel::ProtocolBehavior,
+            facts: vec![EvidenceFact {
+                code: EvidenceCode::ModelMatch,
+                outcome: EvidenceOutcome::Passed,
+            }],
+            rules_version: RULES_VERSION,
+            checked_at,
+        }
+    }
 
     #[test]
     fn runtime_setting_defaults_off() {
@@ -362,9 +389,14 @@ mod tests {
             upsert_passive(&db, &batch).unwrap().verdict,
             Verdict::Anomaly
         );
+        let passive_report = &list_for_provider_ids(&db, &["provider-a".into()])?[0];
+        assert_eq!(passive_report.verdict, Verdict::Anomaly);
         assert_eq!(
-            list_for_provider_ids(&db, &["provider-a".into()])?[0].verdict,
-            Verdict::Anomaly
+            passive_report.facts,
+            vec![EvidenceFact {
+                code: EvidenceCode::ForeignProtocol,
+                outcome: EvidenceOutcome::Failed,
+            }]
         );
         let active = VerificationReport {
             target,
@@ -396,13 +428,97 @@ mod tests {
         );
         Ok(())
     }
+
+    #[test]
+    fn history_is_newest_first_bounded_per_scope_and_cleared_with_results() -> Result<(), AppError>
+    {
+        let db = Database::memory().unwrap();
+        insert_provider(&db, "provider-a", "codex")?;
+        insert_provider(&db, "provider-b", "codex")?;
+        for checked_at in 1..=6 {
+            upsert_active(&db, &active_report("provider-a", "codex", checked_at))?;
+        }
+        upsert_active(&db, &active_report("provider-b", "codex", 99))?;
+
+        let scope = TargetScope::new("provider-a", "codex");
+        let history = history::list(&db, &scope)?;
+        assert_eq!(history.len(), 5);
+        assert_eq!(
+            history
+                .iter()
+                .map(|entry| entry.report.checked_at)
+                .collect::<Vec<_>>(),
+            vec![6, 5, 4, 3, 2]
+        );
+        assert!(history
+            .iter()
+            .all(|entry| entry.source == VerificationSource::Active));
+        assert_eq!(
+            history::list(&db, &TargetScope::new("provider-b", "codex"))?.len(),
+            1
+        );
+
+        clear_scope(&db, &scope)?;
+        assert!(history::list(&db, &scope)?.is_empty());
+        assert_eq!(
+            history::list(&db, &TargetScope::new("provider-b", "codex"))?.len(),
+            1
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn passive_history_retains_only_sanitized_merged_evidence() -> Result<(), AppError> {
+        let db = Database::memory().unwrap();
+        insert_provider(&db, "provider-a", "codex")?;
+        let target = TargetKey::new("provider-a", "codex", "gpt-5.6-sol");
+        upsert_passive(
+            &db,
+            &EvidenceBatch::new(
+                target.clone(),
+                0,
+                true,
+                [EvidenceFact {
+                    code: EvidenceCode::StreamLifecycle,
+                    outcome: EvidenceOutcome::Failed,
+                }],
+                100,
+            ),
+        )?;
+
+        let history = history::list(&db, &TargetScope::new("provider-a", "codex"))?;
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].source, VerificationSource::Runtime);
+        assert_eq!(
+            history[0].report,
+            VerificationReport {
+                target,
+                verdict: Verdict::Anomaly,
+                evidence_level: EvidenceLevel::Insufficient,
+                facts: vec![EvidenceFact {
+                    code: EvidenceCode::StreamLifecycle,
+                    outcome: EvidenceOutcome::Failed,
+                }],
+                rules_version: RULES_VERSION,
+                checked_at: 100,
+            }
+        );
+        assert_eq!(
+            serde_json::to_value(&history).unwrap()[0]["source"],
+            serde_json::json!("runtime")
+        );
+        Ok(())
+    }
 }
 
 pub fn upsert_active(db: &Database, report: &VerificationReport) -> Result<(), AppError> {
     let active_report_json = serde_json::to_string(report)
         .map_err(|error| AppError::Config(format!("序列化验证报告失败: {error}")))?;
-    let conn = lock_conn!(db.conn);
-    let (mut passive, notified) = load_passive_state(&conn, &report.target)?;
+    let mut conn = lock_conn!(db.conn);
+    let transaction = conn
+        .transaction()
+        .map_err(|error| AppError::Database(format!("开始保存模型验证结果失败: {error}")))?;
+    let (mut passive, notified) = load_passive_state(&transaction, &report.target)?;
     let cleared = passive
         .as_mut()
         .map(|aggregate| resolve_with_active(aggregate, report))
@@ -413,9 +529,18 @@ pub fn upsert_active(db: &Database, report: &VerificationReport) -> Result<(), A
         .collect();
     let merged = verdict::merge(Some(report), passive.as_ref());
     let passive_aggregate_json = serialize_optional(&passive)?;
+    let history_report = merged_report(
+        report.target.clone(),
+        Some(report),
+        passive.as_ref(),
+        merged,
+        report.rules_version,
+        report.checked_at,
+    );
 
-    conn.execute(
-        "INSERT INTO model_verification_results (
+    transaction
+        .execute(
+            "INSERT INTO model_verification_results (
             provider_id, app_type, model, active_report_json, passive_aggregate_json,
             verdict, evidence_level, rules_version, active_checked_at, updated_at,
             notified_fingerprints_json
@@ -429,21 +554,30 @@ pub fn upsert_active(db: &Database, report: &VerificationReport) -> Result<(), A
             active_checked_at = excluded.active_checked_at,
             updated_at = excluded.updated_at,
             notified_fingerprints_json = excluded.notified_fingerprints_json",
-        params![
-            &report.target.provider_id,
-            &report.target.app_type,
-            &report.target.model,
-            active_report_json,
-            passive_aggregate_json,
-            verdict_name(merged.verdict),
-            evidence_level_name(merged.evidence_level),
-            report.rules_version,
-            report.checked_at,
-            report.checked_at,
-            serialize_fingerprints(&notified)?,
-        ],
-    )
-    .map_err(|error| AppError::Database(format!("保存模型验证结果失败: {error}")))?;
+            params![
+                &report.target.provider_id,
+                &report.target.app_type,
+                &report.target.model,
+                active_report_json,
+                passive_aggregate_json,
+                verdict_name(merged.verdict),
+                evidence_level_name(merged.evidence_level),
+                report.rules_version,
+                report.checked_at,
+                report.checked_at,
+                serialize_fingerprints(&notified)?,
+            ],
+        )
+        .map_err(|error| AppError::Database(format!("保存模型验证结果失败: {error}")))?;
+    history::insert(&transaction, VerificationSource::Active, &history_report)?;
+    history::prune(
+        &transaction,
+        &report.target.provider_id,
+        &report.target.app_type,
+    )?;
+    transaction
+        .commit()
+        .map_err(|error| AppError::Database(format!("提交模型验证结果失败: {error}")))?;
     Ok(())
 }
 
@@ -456,11 +590,14 @@ pub fn upsert_passive_with_notifications(
     db: &Database,
     batch: &EvidenceBatch,
 ) -> Result<(MergedReport, Vec<AnomalyFingerprint>), AppError> {
-    let conn = lock_conn!(db.conn);
-    let (existing, notified) = load_passive_state(&conn, &batch.target)?;
+    let mut conn = lock_conn!(db.conn);
+    let transaction = conn
+        .transaction()
+        .map_err(|error| AppError::Database(format!("开始保存运行时模型验证结果失败: {error}")))?;
+    let (existing, notified) = load_passive_state(&transaction, &batch.target)?;
     let mut aggregate = existing.unwrap_or_default();
     reduce_batch(&mut aggregate, batch);
-    let active = load_active_report(&conn, &batch.target)?;
+    let active = load_active_report(&transaction, &batch.target)?;
     let merged = verdict::merge(active.as_ref(), Some(&aggregate));
     let newly_claimed = aggregate
         .unresolved_fingerprints()
@@ -473,9 +610,18 @@ pub fn upsert_passive_with_notifications(
     notified.extend(newly_claimed.iter().copied());
     let passive_aggregate_json = serde_json::to_string(&aggregate)
         .map_err(|error| AppError::Config(format!("序列化被动验证聚合失败: {error}")))?;
+    let history_report = merged_report(
+        batch.target.clone(),
+        active.as_ref(),
+        Some(&aggregate),
+        merged,
+        RULES_VERSION,
+        batch.observed_at,
+    );
 
-    conn.execute(
-        "INSERT INTO model_verification_results (
+    transaction
+        .execute(
+            "INSERT INTO model_verification_results (
             provider_id, app_type, model, passive_aggregate_json, verdict, evidence_level,
             rules_version, passive_observed_at, updated_at, notified_fingerprints_json
         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
@@ -487,20 +633,29 @@ pub fn upsert_passive_with_notifications(
             passive_observed_at = excluded.passive_observed_at,
             updated_at = excluded.updated_at,
             notified_fingerprints_json = excluded.notified_fingerprints_json",
-        params![
-            &batch.target.provider_id,
-            &batch.target.app_type,
-            &batch.target.model,
-            passive_aggregate_json,
-            verdict_name(merged.verdict),
-            evidence_level_name(merged.evidence_level),
-            RULES_VERSION,
-            batch.observed_at,
-            batch.observed_at,
-            serialize_fingerprints(&notified)?,
-        ],
-    )
-    .map_err(|error| AppError::Database(format!("保存被动模型验证结果失败: {error}")))?;
+            params![
+                &batch.target.provider_id,
+                &batch.target.app_type,
+                &batch.target.model,
+                passive_aggregate_json,
+                verdict_name(merged.verdict),
+                evidence_level_name(merged.evidence_level),
+                RULES_VERSION,
+                batch.observed_at,
+                batch.observed_at,
+                serialize_fingerprints(&notified)?,
+            ],
+        )
+        .map_err(|error| AppError::Database(format!("保存被动模型验证结果失败: {error}")))?;
+    history::insert(&transaction, VerificationSource::Runtime, &history_report)?;
+    history::prune(
+        &transaction,
+        &batch.target.provider_id,
+        &batch.target.app_type,
+    )?;
+    transaction
+        .commit()
+        .map_err(|error| AppError::Database(format!("提交运行时模型验证结果失败: {error}")))?;
     Ok((merged, newly_claimed))
 }
 
@@ -570,20 +725,11 @@ fn serialize_fingerprints(fingerprints: &[AnomalyFingerprint]) -> Result<String,
 }
 
 fn verdict_name(verdict: Verdict) -> &'static str {
-    match verdict {
-        Verdict::Trusted => "trusted",
-        Verdict::Suspicious => "suspicious",
-        Verdict::Anomaly => "anomaly",
-        Verdict::Inconclusive => "inconclusive",
-    }
+    verdict.as_str()
 }
 
 fn evidence_level_name(evidence_level: EvidenceLevel) -> &'static str {
-    match evidence_level {
-        EvidenceLevel::Cryptographic => "cryptographic",
-        EvidenceLevel::ProtocolBehavior => "protocolBehavior",
-        EvidenceLevel::Insufficient => "insufficient",
-    }
+    evidence_level.as_str()
 }
 
 pub fn list_for_providers(
@@ -597,8 +743,9 @@ pub fn list_for_providers(
 
     let placeholders = vec!["?"; provider_ids.len()].join(", ");
     let sql = format!(
-        "SELECT provider_id, app_type, model, active_report_json, verdict, evidence_level,
-                rules_version, COALESCE(active_checked_at, passive_observed_at, updated_at)
+        "SELECT provider_id, app_type, model, active_report_json, passive_aggregate_json,
+                verdict, evidence_level, rules_version,
+                COALESCE(active_checked_at, passive_observed_at, updated_at)
          FROM model_verification_results
          WHERE app_type = ? AND provider_id IN ({placeholders})
          ORDER BY provider_id, model"
@@ -634,8 +781,9 @@ pub fn list_for_provider_ids(
 
     let placeholders = vec!["?"; provider_ids.len()].join(", ");
     let sql = format!(
-        "SELECT provider_id, app_type, model, active_report_json, verdict, evidence_level,
-                rules_version, COALESCE(active_checked_at, passive_observed_at, updated_at)
+        "SELECT provider_id, app_type, model, active_report_json, passive_aggregate_json,
+                verdict, evidence_level, rules_version,
+                COALESCE(active_checked_at, passive_observed_at, updated_at)
          FROM model_verification_results
          WHERE provider_id IN ({placeholders})
          ORDER BY provider_id, app_type, model"
@@ -653,7 +801,15 @@ pub fn list_for_provider_ids(
     rows.into_iter().map(result_row_into_report).collect()
 }
 
-type StoredResultRow = (TargetKey, Option<String>, String, String, i32, i64);
+type StoredResultRow = (
+    TargetKey,
+    Option<String>,
+    Option<String>,
+    String,
+    String,
+    i32,
+    i64,
+);
 
 fn result_row_to_report(row: &rusqlite::Row<'_>) -> rusqlite::Result<StoredResultRow> {
     Ok((
@@ -667,58 +823,96 @@ fn result_row_to_report(row: &rusqlite::Row<'_>) -> rusqlite::Result<StoredResul
         row.get(5)?,
         row.get(6)?,
         row.get(7)?,
+        row.get(8)?,
     ))
 }
 
 fn result_row_into_report(row: StoredResultRow) -> Result<VerificationReport, AppError> {
-    let (target, active_report_json, verdict, evidence_level, rules_version, checked_at) = row;
-    let mut report = active_report_json
+    let (
+        target,
+        active_report_json,
+        passive_aggregate_json,
+        verdict,
+        evidence_level,
+        rules_version,
+        checked_at,
+    ) = row;
+    let passive = passive_aggregate_json
+        .map(|value| {
+            serde_json::from_str::<PassiveAggregate>(&value)
+                .map_err(|error| AppError::Config(format!("解析被动验证聚合失败: {error}")))
+        })
+        .transpose()?;
+    let active = active_report_json
         .map(|value| {
             serde_json::from_str(&value)
                 .map_err(|error| AppError::Config(format!("解析主动验证报告失败: {error}")))
         })
-        .transpose()?
-        .unwrap_or(VerificationReport {
-            target: target.clone(),
-            verdict: Verdict::Inconclusive,
-            evidence_level: EvidenceLevel::Insufficient,
-            facts: Vec::new(),
-            rules_version,
-            checked_at,
-        });
-    report.target = target;
-    report.verdict = parse_verdict(&verdict)?;
-    report.evidence_level = parse_evidence_level(&evidence_level)?;
-    report.rules_version = rules_version;
-    report.checked_at = checked_at;
-    Ok(report)
+        .transpose()?;
+    Ok(merged_report(
+        target,
+        active.as_ref(),
+        passive.as_ref(),
+        MergedReport {
+            verdict: parse_verdict(&verdict)?,
+            evidence_level: parse_evidence_level(&evidence_level)?,
+        },
+        rules_version,
+        checked_at,
+    ))
+}
+
+fn merged_report(
+    target: TargetKey,
+    active: Option<&VerificationReport>,
+    passive: Option<&PassiveAggregate>,
+    merged: MergedReport,
+    rules_version: i32,
+    checked_at: i64,
+) -> VerificationReport {
+    let facts = FiniteEvidenceFacts::new(
+        active
+            .into_iter()
+            .flat_map(|report| report.facts.iter().cloned())
+            .chain(
+                passive
+                    .into_iter()
+                    .flat_map(PassiveAggregate::evidence_facts),
+            ),
+    )
+    .into_vec();
+    VerificationReport {
+        target,
+        verdict: merged.verdict,
+        evidence_level: merged.evidence_level,
+        facts,
+        rules_version,
+        checked_at,
+    }
 }
 
 fn parse_verdict(value: &str) -> Result<Verdict, AppError> {
-    match value {
-        "trusted" => Ok(Verdict::Trusted),
-        "suspicious" => Ok(Verdict::Suspicious),
-        "anomaly" => Ok(Verdict::Anomaly),
-        "inconclusive" => Ok(Verdict::Inconclusive),
-        _ => Err(AppError::Config("解析验证结论失败".into())),
-    }
+    Verdict::try_from(value).map_err(|_| AppError::Config("解析验证结论失败".into()))
 }
 
 fn parse_evidence_level(value: &str) -> Result<EvidenceLevel, AppError> {
-    match value {
-        "cryptographic" => Ok(EvidenceLevel::Cryptographic),
-        "protocolBehavior" => Ok(EvidenceLevel::ProtocolBehavior),
-        "insufficient" => Ok(EvidenceLevel::Insufficient),
-        _ => Err(AppError::Config("解析验证证据等级失败".into())),
-    }
+    EvidenceLevel::try_from(value).map_err(|_| AppError::Config("解析验证证据等级失败".into()))
 }
 
 pub fn clear_scope(db: &Database, scope: &TargetScope) -> Result<(), AppError> {
-    let conn = lock_conn!(db.conn);
-    conn.execute(
-        "DELETE FROM model_verification_results WHERE provider_id = ?1 AND app_type = ?2",
-        params![scope.provider_id, scope.app_type],
-    )
-    .map_err(|error| AppError::Database(format!("清除模型验证结果失败: {error}")))?;
+    let mut conn = lock_conn!(db.conn);
+    let transaction = conn
+        .transaction()
+        .map_err(|error| AppError::Database(format!("开始清除模型验证结果失败: {error}")))?;
+    transaction
+        .execute(
+            "DELETE FROM model_verification_results WHERE provider_id = ?1 AND app_type = ?2",
+            params![scope.provider_id, scope.app_type],
+        )
+        .map_err(|error| AppError::Database(format!("清除模型验证结果失败: {error}")))?;
+    history::clear(&transaction, scope)?;
+    transaction
+        .commit()
+        .map_err(|error| AppError::Database(format!("提交清除模型验证结果失败: {error}")))?;
     Ok(())
 }

--- a/src-tauri/src/relay/model_verification/types.rs
+++ b/src-tauri/src/relay/model_verification/types.rs
@@ -49,12 +49,60 @@ pub enum Verdict {
     Inconclusive,
 }
 
+impl Verdict {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Trusted => "trusted",
+            Self::Suspicious => "suspicious",
+            Self::Anomaly => "anomaly",
+            Self::Inconclusive => "inconclusive",
+        }
+    }
+}
+
+impl TryFrom<&str> for Verdict {
+    type Error = &'static str;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "trusted" => Ok(Self::Trusted),
+            "suspicious" => Ok(Self::Suspicious),
+            "anomaly" => Ok(Self::Anomaly),
+            "inconclusive" => Ok(Self::Inconclusive),
+            _ => Err("unsupported verification verdict"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum EvidenceLevel {
     Cryptographic,
     ProtocolBehavior,
     Insufficient,
+}
+
+impl EvidenceLevel {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Cryptographic => "cryptographic",
+            Self::ProtocolBehavior => "protocolBehavior",
+            Self::Insufficient => "insufficient",
+        }
+    }
+}
+
+impl TryFrom<&str> for EvidenceLevel {
+    type Error = &'static str;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "cryptographic" => Ok(Self::Cryptographic),
+            "protocolBehavior" => Ok(Self::ProtocolBehavior),
+            "insufficient" => Ok(Self::Insufficient),
+            _ => Err("unsupported verification evidence level"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -128,6 +176,41 @@ pub struct VerificationReport {
     pub facts: Vec<EvidenceFact>,
     pub rules_version: i32,
     pub checked_at: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum VerificationSource {
+    Active,
+    Runtime,
+}
+
+impl VerificationSource {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Runtime => "runtime",
+        }
+    }
+}
+
+impl TryFrom<&str> for VerificationSource {
+    type Error = &'static str;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "active" => Ok(Self::Active),
+            "runtime" => Ok(Self::Runtime),
+            _ => Err("unsupported verification source"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerificationHistoryEntry {
+    pub source: VerificationSource,
+    pub report: VerificationReport,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/components/relay/__tests__/RelaySection.modelVerification.test.tsx
+++ b/src/components/relay/__tests__/RelaySection.modelVerification.test.tsx
@@ -15,6 +15,7 @@ const api = vi.hoisted(() => ({
   status: vi.fn(),
   listSites: vi.fn(),
   listResults: vi.fn(),
+  listHistory: vi.fn(),
   listModels: vi.fn(),
   start: vi.fn(),
   cancel: vi.fn(),
@@ -44,6 +45,7 @@ vi.mock("@/lib/api/vendor", () => ({
 vi.mock("@/lib/api/modelVerification", () => ({
   modelVerificationApi: {
     listResults: api.listResults,
+    listHistory: api.listHistory,
     listModels: api.listModels,
     start: api.start,
     cancel: api.cancel,
@@ -207,6 +209,7 @@ describe("RelaySection model verification ownership", () => {
       report("provider-a", "suspicious", "one"),
       report("provider-a", "anomaly", "two"),
     ]);
+    api.listHistory.mockResolvedValue([]);
     api.listModels.mockResolvedValue(["gpt-5"]);
     api.start.mockResolvedValue({ runId: "run-1", state: "running" });
     api.cancel.mockResolvedValue(undefined);

--- a/src/components/relay/model-verification/ModelVerificationDialog.tsx
+++ b/src/components/relay/model-verification/ModelVerificationDialog.tsx
@@ -20,9 +20,13 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { modelVerificationApi } from "@/lib/api/modelVerification";
-import type { VerificationReport } from "@/lib/api/modelVerification";
+import type {
+  VerificationHistoryEntry,
+  VerificationReport,
+} from "@/lib/api/modelVerification";
 
 import { VerificationEvidenceList } from "./VerificationEvidenceList";
+import { VerificationHistoryList } from "./VerificationHistoryList";
 import { useModelVerificationRun } from "./useModelVerificationRun";
 
 export interface ModelVerificationDialogProps {
@@ -57,7 +61,12 @@ export function ModelVerificationDialog({
   const [runtimeState, setRuntimeState] = useState<
     "idle" | "loading" | "error"
   >("idle");
+  const [history, setHistory] = useState<VerificationHistoryEntry[]>([]);
+  const [historyState, setHistoryState] = useState<
+    "idle" | "loading" | "ready" | "error"
+  >("idle");
   const requestRef = useRef(0);
+  const historyRequestRef = useRef(0);
   const run = useModelVerificationRun({ providerId, appType });
 
   useEffect(() => {
@@ -80,6 +89,22 @@ export function ModelVerificationDialog({
       .catch(() => {
         if (request !== requestRef.current) return;
         setModelsState("error");
+      });
+  }, [appType, providerId]);
+
+  const loadHistory = useCallback(() => {
+    const request = ++historyRequestRef.current;
+    setHistoryState("loading");
+    void modelVerificationApi
+      .listHistory(providerId, appType)
+      .then((entries) => {
+        if (request !== historyRequestRef.current) return;
+        setHistory(entries);
+        setHistoryState("ready");
+      })
+      .catch(() => {
+        if (request !== historyRequestRef.current) return;
+        setHistoryState("error");
       });
   }, [appType, providerId]);
 
@@ -107,6 +132,16 @@ export function ModelVerificationDialog({
       .catch(() => setRuntimeState("error"));
     // Reload from the live backend on every open; the model catalog is not cached UI state.
   }, [loadModels, open]);
+
+  useEffect(() => {
+    if (!open) {
+      historyRequestRef.current += 1;
+      setHistory([]);
+      setHistoryState("idle");
+      return;
+    }
+    loadHistory();
+  }, [loadHistory, open, report?.checkedAt]);
 
   const showStart = !run.isRunning;
   const canStart =
@@ -295,6 +330,31 @@ export function ModelVerificationDialog({
               <VerificationEvidenceList report={report} />
             </div>
           )}
+
+          <section className="space-y-3 border-t border-border-default pt-4">
+            <h3 className="text-sm font-medium">
+              {t("loongport.modelVerification.history.title")}
+            </h3>
+            {historyState === "loading" && (
+              <p className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="size-4 animate-spin" />
+                {t("loongport.modelVerification.history.loading")}
+              </p>
+            )}
+            {historyState === "error" && (
+              <p className="text-sm text-destructive" role="alert">
+                {t("loongport.modelVerification.history.error")}
+              </p>
+            )}
+            {historyState === "ready" && history.length === 0 && (
+              <p className="text-sm text-muted-foreground">
+                {t("loongport.modelVerification.history.empty")}
+              </p>
+            )}
+            {historyState === "ready" && history.length > 0 && (
+              <VerificationHistoryList entries={history} />
+            )}
+          </section>
         </div>
 
         <DialogFooter>

--- a/src/components/relay/model-verification/VerificationHistoryList.tsx
+++ b/src/components/relay/model-verification/VerificationHistoryList.tsx
@@ -1,0 +1,70 @@
+import { useTranslation } from "react-i18next";
+
+import type {
+  VerificationHistoryEntry,
+  VerificationVerdict,
+} from "@/lib/api/modelVerification";
+import { cn } from "@/lib/utils";
+
+import { VerificationEvidenceList } from "./VerificationEvidenceList";
+
+const verdictClass: Record<VerificationVerdict, string> = {
+  trusted: "text-emerald-600 dark:text-emerald-400",
+  suspicious: "text-amber-600 dark:text-amber-400",
+  anomaly: "text-destructive",
+  inconclusive: "text-muted-foreground",
+};
+
+export function VerificationHistoryList({
+  entries,
+}: {
+  entries: VerificationHistoryEntry[];
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="divide-y divide-border-default">
+      {entries.map((entry, index) => {
+        const checkedAt = new Date(entry.report.checkedAt * 1000);
+        return (
+          <article
+            className="space-y-2 py-3 first:pt-0 last:pb-0"
+            key={`${entry.source}-${entry.report.target.model}-${entry.report.checkedAt}-${index}`}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 space-y-0.5">
+                <p className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+                  <span className="font-medium">
+                    {t(
+                      `loongport.modelVerification.history.source.${entry.source}`,
+                    )}
+                  </span>
+                  <span className="break-all text-muted-foreground">
+                    {entry.report.target.model}
+                  </span>
+                </p>
+                <time
+                  className="block text-xs text-muted-foreground"
+                  dateTime={checkedAt.toISOString()}
+                >
+                  {checkedAt.toLocaleString()}
+                </time>
+              </div>
+              <span
+                className={cn(
+                  "shrink-0 text-xs font-medium",
+                  verdictClass[entry.report.verdict],
+                )}
+              >
+                {t(
+                  `loongport.modelVerification.verdict.${entry.report.verdict}`,
+                )}
+              </span>
+            </div>
+            <VerificationEvidenceList report={entry.report} />
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/relay/model-verification/__tests__/ModelVerificationDialog.test.tsx
+++ b/src/components/relay/model-verification/__tests__/ModelVerificationDialog.test.tsx
@@ -10,6 +10,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const api = vi.hoisted(() => ({
   listModels: vi.fn(),
+  listHistory: vi.fn(),
   start: vi.fn(),
   cancel: vi.fn(),
   onProgress: vi.fn(),
@@ -37,6 +38,15 @@ vi.mock("react-i18next", () => ({
         "loongport.modelVerification.verdict.anomaly": "异常",
         "loongport.modelVerification.verdict.inconclusive": "结论不足",
         "loongport.modelVerification.failure.network": "网络连接失败",
+        "loongport.modelVerification.history.title": "最近 5 条验证记录",
+        "loongport.modelVerification.history.empty": "暂无验证记录",
+        "loongport.modelVerification.history.source.active": "主动检测",
+        "loongport.modelVerification.history.source.runtime": "使用时检测",
+        "loongport.modelVerification.evidence.fact.modelMatch": "模型身份",
+        "loongport.modelVerification.evidence.fact.streamLifecycle":
+          "流式响应生命周期",
+        "loongport.modelVerification.evidence.outcome.passed": "通过",
+        "loongport.modelVerification.evidence.outcome.failed": "未通过",
       };
       return (strings[key] ?? key).replace(/{{(\w+)}}/g, (_, name) =>
         String(options?.[name] ?? ""),
@@ -101,6 +111,7 @@ vi.mock("@/components/ui/select", async () => {
 
 import { ModelVerificationDialog } from "../ModelVerificationDialog";
 import type {
+  VerificationHistoryEntry,
   VerificationReport,
   VerificationVerdict,
 } from "@/lib/api/modelVerification";
@@ -159,6 +170,25 @@ const report = (verdict: VerificationVerdict): VerificationReport => ({
   checkedAt: 1,
 });
 
+const history: VerificationHistoryEntry[] = [
+  { source: "active", report: report("trusted") },
+  {
+    source: "runtime",
+    report: {
+      target: {
+        providerId: "provider-a",
+        appType: "codex",
+        model: "gpt-5.6-sol",
+      },
+      verdict: "anomaly",
+      evidenceLevel: "insufficient",
+      facts: [{ code: "streamLifecycle", outcome: "failed" }],
+      rulesVersion: 1,
+      checkedAt: 2,
+    },
+  },
+];
+
 async function openModelOptions() {
   await screen.findByRole("combobox");
   return screen.findByRole("option", { name: "gpt-5" });
@@ -169,6 +199,7 @@ describe("ModelVerificationDialog", () => {
     vi.clearAllMocks();
     progressListener = undefined;
     api.listModels.mockResolvedValue(["gpt-5"]);
+    api.listHistory.mockResolvedValue([]);
     api.start.mockResolvedValue({ runId: "run-1", state: "queued" });
     api.cancel.mockResolvedValue(undefined);
     api.onProgress.mockImplementation(
@@ -287,6 +318,20 @@ describe("ModelVerificationDialog", () => {
       rerender(<DialogHarness report={report(verdict)} />);
       await screen.findByText(label);
     }
+  });
+
+  it("shows the latest active and runtime verification records for this tier", async () => {
+    api.listHistory.mockResolvedValue(history);
+
+    render(<DialogHarness />);
+
+    expect(await screen.findByText("最近 5 条验证记录")).toBeInTheDocument();
+    expect(screen.getByText("主动检测")).toBeInTheDocument();
+    expect(screen.getByText("使用时检测")).toBeInTheDocument();
+    expect(screen.getByText("gpt-5.6-sol")).toBeInTheDocument();
+    expect(screen.getByText("流式响应生命周期")).toBeInTheDocument();
+    expect(screen.getByText("未通过")).toBeInTheDocument();
+    expect(api.listHistory).toHaveBeenCalledWith("provider-a", "codex");
   });
 
   it("requests a fresh model list every time the dialog reopens", async () => {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3227,6 +3227,13 @@
         "apps": { "codex": "Codex", "claude": "Claude" },
         "status": { "active": "Active", "waiting": "Waiting", "error": "Error" }
       },
+      "history": {
+        "title": "Latest 5 verification results",
+        "loading": "Loading verification results…",
+        "empty": "No verification results yet.",
+        "error": "Could not load verification results.",
+        "source": { "active": "Active check", "runtime": "Runtime check" }
+      },
       "tierVerdict": {
         "trusted": "Model verified",
         "suspicious": "Model suspicious",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3227,6 +3227,13 @@
         "apps": { "codex": "Codex", "claude": "Claude" },
         "status": { "active": "有効", "waiting": "待機中", "error": "エラー" }
       },
+      "history": {
+        "title": "直近 5 件の検証結果",
+        "loading": "検証結果を読み込んでいます…",
+        "empty": "検証結果はまだありません。",
+        "error": "検証結果を読み込めませんでした。",
+        "source": { "active": "手動検証", "runtime": "使用時の検証" }
+      },
       "tierVerdict": {
         "trusted": "モデル検証済み",
         "suspicious": "モデルに疑い",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3224,6 +3224,13 @@
         "apps": { "codex": "Codex", "claude": "Claude" },
         "status": { "active": "已啟用", "waiting": "等待中", "error": "錯誤" }
       },
+      "history": {
+        "title": "最近 5 筆驗證記錄",
+        "loading": "正在載入驗證記錄…",
+        "empty": "暫無驗證記錄",
+        "error": "驗證記錄載入失敗",
+        "source": { "active": "主動檢測", "runtime": "使用時檢測" }
+      },
       "tierVerdict": {
         "trusted": "模型已驗證",
         "suspicious": "模型存疑",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -3223,6 +3223,13 @@
         "apps": { "codex": "Codex", "claude": "Claude" },
         "status": { "active": "已启用", "waiting": "等待中", "error": "异常" }
       },
+      "history": {
+        "title": "最近 5 条验证记录",
+        "loading": "正在加载验证记录…",
+        "empty": "暂无验证记录",
+        "error": "验证记录加载失败",
+        "source": { "active": "主动检测", "runtime": "使用时检测" }
+      },
       "tierVerdict": {
         "trusted": "模型已验证",
         "suspicious": "模型存疑",

--- a/src/lib/api/modelVerification.ts
+++ b/src/lib/api/modelVerification.ts
@@ -75,6 +75,13 @@ export interface VerificationReport {
   checkedAt: number;
 }
 
+export type VerificationSource = "active" | "runtime";
+
+export interface VerificationHistoryEntry {
+  source: VerificationSource;
+  report: VerificationReport;
+}
+
 export interface StartRunResponse {
   runId: string;
   state: RunState;
@@ -126,6 +133,12 @@ export const modelVerificationApi = {
 
   listResults: (providerIds: string[]): Promise<VerificationReport[]> =>
     invoke("get_model_verification_results", { providerIds }),
+
+  listHistory: (
+    providerId: string,
+    appType: string,
+  ): Promise<VerificationHistoryEntry[]> =>
+    invoke("get_model_verification_history", { providerId, appType }),
 
   onProgress: (
     handler: (event: VerificationProgressEvent) => void,


### PR DESCRIPTION
## Summary / 概述

- persist the latest five sanitized model-verification results per tier
- reconstruct runtime-only anomaly evidence so the verification dialog shows actionable details
- show active/runtime source, model, time, verdict, and finite evidence in the existing dialog
- clear current results and history atomically when a tier is reset
- keep existing current-result snapshots in place while starting upgraded histories empty

## Related Issue / 关联 Issue

N/A

## Screenshots / 截图

Not included: the dialog depends on real Tauri invokes, so a plain renderer screenshot would not exercise the implemented path.

## Checklist / 检查清单

- [x] TypeScript type check passes (`pnpm tsc --noEmit`)
- [x] `pnpm format:check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] Frontend suite passes (120 files, 744 tests)
- [x] Updated all four i18n files
- [x] Privacy tests cover both current results and history rows

## Local Rust test note

`cargo test` reached 2810 passed / 6 ignored with one unrelated environmental failure: the installed LoongPort app already owns `127.0.0.1:15721`, while `update_current_claude_desktop_provider_syncs_profile_when_proxy_takeover_is_active` binds that fixed port. The model-verification suites and the new v6-to-v7 migration test pass.