### PR TITLE
feat(loongport): standardize product copy

### DIFF
--- a/src/components/relay/RefreshActionMenu.tsx
+++ b/src/components/relay/RefreshActionMenu.tsx
@@ -1,0 +1,59 @@
+import { Loader2, MoreHorizontal, RefreshCw } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface RefreshActionMenuProps {
+  actionLabel: string;
+  loading: boolean;
+  onAction: () => void;
+}
+
+/**
+ * 两类账号行共用的次要刷新动作入口。
+ *
+ * 圆形刷新图标无法说明它到底会重拉分组，还是只会把本地密钥重新写入配置；
+ * 统一收进「更多」菜单后，动作名称可以完整展示，也不会与真正的全局刷新混淆。
+ */
+export function RefreshActionMenu({
+  actionLabel,
+  loading,
+  onAction,
+}: RefreshActionMenuProps) {
+  const { t } = useTranslation();
+  const menuLabel = t("loongport.row.more");
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
+          disabled={loading}
+          aria-label={menuLabel}
+          title={menuLabel}
+        >
+          {loading ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <MoreHorizontal className="h-3.5 w-3.5" />
+          )}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem disabled={loading} onSelect={() => onAction()}>
+          <RefreshCw className="h-3.5 w-3.5" />
+          {actionLabel}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/relay/RelayRow.tsx
+++ b/src/components/relay/RelayRow.tsx
@@ -12,7 +12,6 @@ import {
   Pencil,
   PencilLine,
   Play,
-  RefreshCw,
   Trash2,
   Undo2,
   Wallet,
@@ -31,6 +30,7 @@ import { cn } from "@/lib/utils";
 import type { RelayRow as RelayRowData, TierInfo } from "@/lib/api/relay";
 import type { VerificationVerdict } from "@/lib/api/modelVerification";
 import { isLowBalance, LOW_BALANCE_THRESHOLD_USD } from "./lowBalance";
+import { RefreshActionMenu } from "./RefreshActionMenu";
 
 /**
  * 一行中转站 + 可折叠的档位列表。
@@ -558,34 +558,13 @@ function RowStatus({
       <span className="text-xs text-muted-foreground">
         {t("loongport.row.tierCount", { count: relay.tiers.length })}
       </span>
-      {/* 「重新拉分组」。用 ghost + 图标（不是 outline + 文字）——
-          这一行已经有档位了，它是个补充动作，不该抢「用哪个档位」的注意力。
-
-          **hover 才出**：同上一条规矩，它是动作而非信息。
-          左边那个「N 个档位」是信息，所以留在组外常驻。 */}
-      <div
-        className={cn(
-          "flex shrink-0 items-center",
-          HOVER_ACTIONS_BASE,
-          provisioning ? HOVER_ACTIONS_PINNED : ROW_HOVER_ACTIONS,
-        )}
-      >
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="h-7 gap-1 px-2"
-          disabled={provisioning}
-          onClick={onProvision}
-          title={t("loongport.row.refetchGroups")}
-        >
-          {provisioning ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          ) : (
-            <RefreshCw className="h-3.5 w-3.5" />
-          )}
-        </Button>
-      </div>
+      {/* 重拉分组不是普通的「刷新当前显示」，而是一次远端重新发现。
+          收进有明确文案的菜单，避免与顶部的全局刷新混淆。 */}
+      <RefreshActionMenu
+        actionLabel={t("loongport.row.refetchGroups")}
+        loading={provisioning}
+        onAction={onProvision}
+      />
     </div>
   );
 }

--- a/src/components/relay/VendorRow.tsx
+++ b/src/components/relay/VendorRow.tsx
@@ -6,7 +6,6 @@ import {
   Pencil,
   PencilLine,
   Play,
-  RefreshCw,
   Trash2,
   Undo2,
   Wallet,
@@ -19,6 +18,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { VendorAccountRow } from "@/lib/api/vendor";
 
+import { RefreshActionMenu } from "./RefreshActionMenu";
 import { rowKey } from "./rowKey";
 
 /**
@@ -321,7 +321,7 @@ export function VendorRow({
  *
  * | 条件 | 显示 | 为什么这个顺序 |
  * |---|---|---|
- * | `keyReady` | 使用 / 在用 + 刷新 | ⚠️ **优先于 `sessionExpired`** —— 见下 |
+ * | `keyReady` | 使用 / 在用 + 更多 | ⚠️ **优先于 `sessionExpired`** —— 见下 |
  * | `sessionExpired` | 「登录已过期」+ 重新登录 | 预填已就绪，用户只需补验证 |
  * | `!loggedIn` | 「还没登录」+ 登录 | 从没登录过 |
  * | `loggedIn` | 「获取密钥」 | 登录了但还没备好 sk |
@@ -422,32 +422,16 @@ function VendorStatus({
               )}
             </Button>
           )}
-          {/* 「重新备一次密钥」= 把本地这把 sk 重新写进六个平台的配置。
-
-              ⚠️ **它不会去官网换一把新 key**：`vendor_provision` 只在本地
-              `api_key` 为空时才联网建（见它第 2 步「本地已有明文 ⇒ 零请求」）。
-              所以用户在官网手动删/撤销了 key 之后，点这个按钮是**无效**的 ——
-              它会把同一把已失效的 sk 再写一遍。那种情况目前只能删掉这一行再重新添加
-              （没有「换一把 key」的入口，已记在 `TODO.md`）。
-
-              这个按钮真正有用的场景：配置被改坏、或某个平台的记录写失败了，
-              重新展开一次把六个平台补齐。 */}
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-7 gap-1 px-2"
-            disabled={provisioning}
-            onClick={onProvision}
-            title={t("loongport.vendor.refreshKey")}
-          >
-            {provisioning ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <RefreshCw className="h-3.5 w-3.5" />
-            )}
-          </Button>
         </div>
+
+        {/* 「重新备一次密钥」只是把本地已有的 sk 重新写入六个平台配置，
+            不会去官网换新 key。收进明确命名的菜单，避免一个裸刷新图标让用户
+            误以为它会更新密钥本身。 */}
+        <RefreshActionMenu
+          actionLabel={t("loongport.vendor.refreshKey")}
+          loading={provisioning}
+          onAction={onProvision}
+        />
       </div>
     );
   }

--- a/src/components/relay/__tests__/RefreshActions.test.tsx
+++ b/src/components/relay/__tests__/RefreshActions.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        "loongport.row.more": "更多",
+        "loongport.row.refetchGroups": "更新可用分组",
+        "loongport.vendor.refreshKey": "重新应用密钥配置",
+        "loongport.modelVerification.title": "模型验证",
+        "loongport.modelVerification.tierVerdict.trusted": "验证通过",
+        "loongport.modelVerification.tierVerdict.suspicious": "需要复核",
+        "loongport.modelVerification.tierVerdict.anomaly": "检测到异常",
+        "loongport.modelVerification.tierVerdict.trustedHint":
+          "现有证据验证通过。打开“模型验证”查看详情。",
+        "loongport.modelVerification.tierVerdict.suspiciousHint":
+          "现有结果需要人工复核。打开“模型验证”查看详情。",
+        "loongport.modelVerification.tierVerdict.anomalyHint":
+          "检测到响应不一致。打开“模型验证”查看详情。",
+        "loongport.tier.checkConnectivity": "测试连接",
+        "loongport.tier.userEdited": "手动维护",
+        "loongport.tier.userEditedHint": "此接入配置包含手动修改。",
+        "loongport.tier.rate": "{{value}} 倍",
+        "loongport.tier.rateUnknown": "倍率未知",
+        "loongport.tier.edit": "编辑配置",
+        "loongport.tier.resetConfig": "恢复默认配置",
+        "provider.enable": "启用",
+        "provider.inUse": "使用中",
+        "loongport.tier.switching": "切换中...",
+        "loongport.row.dragHandle": "拖动排序",
+        "loongport.row.collapse": "收起",
+        "loongport.row.expand": "展开",
+        "loongport.row.remove": "删除",
+        "loongport.row.removeBlockedByCurrent": "无法删除",
+        "loongport.row.notLoggedIn": "未登录",
+        "loongport.row.login": "登录",
+        "loongport.row.sessionExpired": "登录已过期",
+        "loongport.row.reLogin": "重新登录",
+        "loongport.row.noTiers": "没有可用分组",
+        "loongport.row.getKeys": "创建接入配置",
+        "loongport.row.tierCount": "{{count}} 个接入配置",
+        "loongport.vendor.sessionExpiredUsable":
+          "登录已过期，但 API 密钥仍可使用；余额暂时无法查询。点击重新登录。",
+        "loongport.vendor.noKey": "尚未配置 API 密钥",
+        "loongport.vendor.keyReady": "已创建接入配置",
+      })[key] ?? key,
+  }),
+}));
+
+import { RelayRow } from "../RelayRow";
+import { VendorRow } from "../VendorRow";
+
+const tier = {
+  providerId: "provider-a",
+  appId: "codex" as const,
+  groupName: "Pro",
+  displayName: "Pro",
+  model: "gpt-5.6-sol",
+  models: [],
+  rateMultiplier: 1,
+  isCurrent: false,
+  userEdited: false,
+  allowImageGeneration: false,
+};
+
+function renderRelayRow(onProvision = vi.fn()) {
+  const props: ComponentProps<typeof RelayRow> = {
+    relay: {
+      id: 1,
+      siteOrigin: "https://relay.example",
+      siteName: "Relay",
+      accountLabel: "account",
+      loggedIn: true,
+      sessionExpired: false,
+      tiers: [tier],
+    },
+    open: true,
+    onOpenChange: vi.fn(),
+    busy: new Set(),
+    onLogin: vi.fn(),
+    onProvision,
+    onSwitchTier: vi.fn(),
+    onSelectTierModel: vi.fn(),
+    balance: null,
+    onPurchase: vi.fn(),
+    onCheckTier: vi.fn(),
+    isCheckingTier: () => false,
+    onResetTier: vi.fn(),
+    onEditTier: vi.fn(),
+    onDelete: vi.fn(),
+    onVerifyTier: vi.fn(),
+    verificationVerdictForTier: () => undefined,
+    isVerifyingTier: () => false,
+  };
+
+  return { onProvision, ...render(<RelayRow {...props} />) };
+}
+
+function renderVendorRow(onProvision = vi.fn()) {
+  const props: ComponentProps<typeof VendorRow> = {
+    account: {
+      id: 1,
+      vendorId: "deepseek",
+      vendorName: "DeepSeek",
+      accountLabel: "account",
+      loggedIn: true,
+      sessionExpired: false,
+      keyReady: true,
+      providerId: "provider-a",
+      isCurrent: false,
+      userEdited: false,
+    },
+    busy: new Set(),
+    balance: null,
+    isCurrent: false,
+    onLogin: vi.fn(),
+    onProvision,
+    onUse: vi.fn(),
+    onDelete: vi.fn(),
+    onEdit: vi.fn(),
+    onReset: vi.fn(),
+  };
+
+  return { onProvision, ...render(<VendorRow {...props} />) };
+}
+
+describe("refresh actions", () => {
+  it("puts relay group refetch behind a clearly labeled more menu", async () => {
+    const user = userEvent.setup();
+    const { onProvision } = renderRelayRow();
+
+    expect(screen.getByRole("button", { name: "更多" })).toBeInTheDocument();
+    expect(screen.queryByTitle("更新可用分组")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "更多" }));
+    const refetch = screen.getByRole("menuitem", {
+      name: "更新可用分组",
+    });
+    expect(refetch).toBeInTheDocument();
+
+    await user.click(refetch);
+    expect(onProvision).toHaveBeenCalledTimes(1);
+  });
+
+  it("puts vendor key reprovision behind the same more menu", async () => {
+    const user = userEvent.setup();
+    const { onProvision } = renderVendorRow();
+
+    expect(screen.getByRole("button", { name: "更多" })).toBeInTheDocument();
+    expect(screen.queryByTitle("重新应用密钥配置")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "更多" }));
+    const reprovision = screen.getByRole("menuitem", {
+      name: "重新应用密钥配置",
+    });
+    expect(reprovision).toBeInTheDocument();
+
+    await user.click(reprovision);
+    expect(onProvision).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/relay/__tests__/RelayRow.modelVerification.test.tsx
+++ b/src/components/relay/__tests__/RelayRow.modelVerification.test.tsx
@@ -8,18 +8,18 @@ vi.mock("react-i18next", () => ({
       (
         ({
           "loongport.modelVerification.title": "模型验证",
-          "loongport.modelVerification.tierVerdict.trusted": "模型已验证",
-          "loongport.modelVerification.tierVerdict.suspicious": "模型存疑",
-          "loongport.modelVerification.tierVerdict.anomaly": "模型异常",
+          "loongport.modelVerification.tierVerdict.trusted": "验证通过",
+          "loongport.modelVerification.tierVerdict.suspicious": "需要复核",
+          "loongport.modelVerification.tierVerdict.anomaly": "检测到异常",
           "loongport.modelVerification.tierVerdict.trustedHint":
-            "模型验证通过，请点击「模型验证」查看详情",
+            "现有证据验证通过。打开“模型验证”查看详情。",
           "loongport.modelVerification.tierVerdict.suspiciousHint":
-            "模型验证结果存疑，请点击「模型验证」查看详情",
+            "现有结果需要人工复核。打开“模型验证”查看详情。",
           "loongport.modelVerification.tierVerdict.anomalyHint":
-            "模型验证发现异常，请点击「模型验证」查看详情",
-          "loongport.tier.checkConnectivity": "检测连通",
-          "loongport.tier.userEdited": "已手工维护",
-          "loongport.tier.userEditedHint": "手工维护说明",
+            "检测到响应不一致。打开“模型验证”查看详情。",
+          "loongport.tier.checkConnectivity": "测试连接",
+          "loongport.tier.userEdited": "手动维护",
+          "loongport.tier.userEditedHint": "此接入配置包含手动修改。",
           "loongport.tier.rate": "{{value}} 倍",
           "loongport.tier.rateUnknown": "倍率未知",
           "loongport.tier.edit": "编辑配置",
@@ -89,7 +89,7 @@ describe("RelayRow model verification", () => {
   it("shows the managed Codex action immediately after connectivity in the existing hover group", () => {
     const { onVerifyTier } = renderRow();
 
-    const connectivity = screen.getByTitle("检测连通");
+    const connectivity = screen.getByTitle("测试连接");
     const verify = screen.getByTitle("模型验证");
     expect(connectivity.nextElementSibling).toBe(verify);
     expect(verify.parentElement?.className).toContain(
@@ -125,10 +125,10 @@ describe("RelayRow model verification", () => {
       verificationVerdictForTier: () => "suspicious",
       isVerifyingTier: () => false,
     });
-    expect(screen.getByText("已手工维护")).toBeInTheDocument();
-    expect(screen.getByText("模型存疑")).toBeInTheDocument();
+    expect(screen.getByText("手动维护")).toBeInTheDocument();
+    expect(screen.getByText("需要复核")).toBeInTheDocument();
     expect(
-      screen.getByTitle("模型验证结果存疑，请点击「模型验证」查看详情"),
+      screen.getByTitle("现有结果需要人工复核。打开“模型验证”查看详情。"),
     ).toBeInTheDocument();
 
     rerender(
@@ -147,29 +147,29 @@ describe("RelayRow model verification", () => {
       expect.objectContaining({ providerId: "provider-a" }),
     );
     expect(verify.querySelector(".animate-spin")).toBeInTheDocument();
-    expect(screen.getByText("模型异常")).toBeInTheDocument();
+    expect(screen.getByText("检测到异常")).toBeInTheDocument();
     expect(
-      screen.getByTitle("模型验证发现异常，请点击「模型验证」查看详情"),
+      screen.getByTitle("检测到响应不一致。打开“模型验证”查看详情。"),
     ).toBeInTheDocument();
   });
 
   it("shows a success-colored label for a verified model", () => {
     renderRow({ verificationVerdictForTier: () => "trusted" });
 
-    const label = screen.getByText("模型已验证").closest("span");
+    const label = screen.getByText("验证通过").closest("span");
     expect(label).toHaveClass("text-emerald-600");
     expect(
-      screen.getByTitle("模型验证通过，请点击「模型验证」查看详情"),
+      screen.getByTitle("现有证据验证通过。打开“模型验证”查看详情。"),
     ).toBeInTheDocument();
-    expect(screen.queryByText("模型存疑")).not.toBeInTheDocument();
+    expect(screen.queryByText("需要复核")).not.toBeInTheDocument();
   });
 
   it("does not render a tier label for an inconclusive result", () => {
     renderRow({ verificationVerdictForTier: () => "inconclusive" });
 
-    expect(screen.queryByText("模型已验证")).not.toBeInTheDocument();
-    expect(screen.queryByText("模型存疑")).not.toBeInTheDocument();
-    expect(screen.queryByText("模型异常")).not.toBeInTheDocument();
+    expect(screen.queryByText("验证通过")).not.toBeInTheDocument();
+    expect(screen.queryByText("需要复核")).not.toBeInTheDocument();
+    expect(screen.queryByText("检测到异常")).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/relay/model-verification/__tests__/ModelVerificationDialog.test.tsx
+++ b/src/components/relay/model-verification/__tests__/ModelVerificationDialog.test.tsx
@@ -33,15 +33,15 @@ vi.mock("react-i18next", () => ({
         "loongport.modelVerification.actions.retry": "重试",
         "loongport.modelVerification.status.running":
           "正在验证 {{completed}} / {{total}}",
-        "loongport.modelVerification.verdict.trusted": "可信",
-        "loongport.modelVerification.verdict.suspicious": "可疑",
-        "loongport.modelVerification.verdict.anomaly": "异常",
-        "loongport.modelVerification.verdict.inconclusive": "结论不足",
+        "loongport.modelVerification.verdict.trusted": "验证通过",
+        "loongport.modelVerification.verdict.suspicious": "需要复核",
+        "loongport.modelVerification.verdict.anomaly": "检测到异常",
+        "loongport.modelVerification.verdict.inconclusive": "证据不足",
         "loongport.modelVerification.failure.network": "网络连接失败",
         "loongport.modelVerification.history.title": "最近 5 条验证记录",
         "loongport.modelVerification.history.empty": "暂无验证记录",
-        "loongport.modelVerification.history.source.active": "主动检测",
-        "loongport.modelVerification.history.source.runtime": "使用时检测",
+        "loongport.modelVerification.history.source.active": "当前验证",
+        "loongport.modelVerification.history.source.runtime": "自动验证",
         "loongport.modelVerification.evidence.fact.modelMatch": "模型身份",
         "loongport.modelVerification.evidence.fact.streamLifecycle":
           "流式响应生命周期",
@@ -310,10 +310,10 @@ describe("ModelVerificationDialog", () => {
     await screen.findByText("网络连接失败");
 
     for (const [verdict, label] of [
-      ["trusted", "可信"],
-      ["suspicious", "可疑"],
-      ["anomaly", "异常"],
-      ["inconclusive", "结论不足"],
+      ["trusted", "验证通过"],
+      ["suspicious", "需要复核"],
+      ["anomaly", "检测到异常"],
+      ["inconclusive", "证据不足"],
     ] as const) {
       rerender(<DialogHarness report={report(verdict)} />);
       await screen.findByText(label);
@@ -326,8 +326,8 @@ describe("ModelVerificationDialog", () => {
     render(<DialogHarness />);
 
     expect(await screen.findByText("最近 5 条验证记录")).toBeInTheDocument();
-    expect(screen.getByText("主动检测")).toBeInTheDocument();
-    expect(screen.getByText("使用时检测")).toBeInTheDocument();
+    expect(screen.getByText("当前验证")).toBeInTheDocument();
+    expect(screen.getByText("自动验证")).toBeInTheDocument();
     expect(screen.getByText("gpt-5.6-sol")).toBeInTheDocument();
     expect(screen.getByText("流式响应生命周期")).toBeInTheDocument();
     expect(screen.getByText("未通过")).toBeInTheDocument();

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3059,197 +3059,210 @@
   },
   "loongport": {
     "sections": {
-      "relay": "Relay Stations",
+      "relay": "Relay services",
       "official": "Official API",
-      "other": "Others"
+      "other": "Other"
     },
     "tierList": {
-      "empty": "No relay site added yet",
-      "addSite": "Add relay site",
-      "refresh": "Refresh tiers & keys"
+      "empty": "No relay services added",
+      "addSite": "Add relay service",
+      "refresh": "Update connection profiles"
     },
     "row": {
       "expand": "Expand",
       "collapse": "Collapse",
       "notLoggedIn": "Not signed in",
       "login": "Sign in",
-      "sessionExpired": "Session expired",
+      "sessionExpired": "Sign-in session expired",
       "reLogin": "Sign in again",
-      "noTiers": "This account has no available group for this platform",
-      "getKeys": "Get keys",
-      "tierCount": "{{count}} tier(s)",
+      "noTiers": "This account has no groups available for the current platform",
+      "getKeys": "Create connection profiles",
+      "tierCount": "{{count}} connection profiles",
       "dragHandle": "Drag to reorder",
-      "refetchGroups": "Re-fetch available groups",
-      "purchaseHint": "Click to top up (opens this site’s purchase page in-app)",
-      "lowBalanceHint": "Balance below ${{threshold}} — click to top up",
-      "remove": "Remove this account (and its tiers)",
-      "removeBlockedByCurrent": "One of its tiers is in use — switch to another tier first",
-      "removeConfirmTitle": "Remove this account?",
-      "removeConfirmMessage": "This removes the login for “{{label}}” along with the {{count}} tier(s) it generated. Any balance stays with the relay — sign in again to use it.",
-      "removeConfirmMessageNeverLoggedIn": "This removes the “{{label}}” row along with the {{count}} tier(s) it generated. This account was never signed in, so you can add it again any time."
+      "more": "More actions",
+      "refetchGroups": "Update available groups",
+      "purchaseHint": "Open the relay service's top-up page",
+      "lowBalanceHint": "Balance is below ${{threshold}}. Select to top up",
+      "remove": "Delete account and connection profiles",
+      "removeBlockedByCurrent": "A connection profile from this account is in use. Switch to another profile before deleting it",
+      "removeConfirmTitle": "Delete this account?",
+      "removeConfirmMessage": "This deletes the sign-in session for “{{label}}” and its {{count}} connection profiles. Your balance remains with the relay service, and you can sign in again later.",
+      "removeConfirmMessageNeverLoggedIn": "This deletes “{{label}}” and its {{count}} connection profiles. You can add the account again later."
     },
     "tier": {
       "rateUnknown": "Rate unknown",
-      "rate": "{{value}}x",
+      "rate": "{{value}}×",
       "models": "Supported models",
-      "selectModel": "Switch to model {{model}}",
+      "selectModel": "Switch to {{model}}",
       "modelSelected": "Current model",
       "switching": "Switching…",
-      "checkConnectivity": "Check connectivity",
-      "resetConfig": "Restore default config",
-      "resetConfirmTitle": "Restore default config?",
-      "resetConfirmMessage": "This overwrites every edit you made to “{{name}}” with LoongPort's defaults. Your API key is kept.",
+      "checkConnectivity": "Test connection",
+      "resetConfig": "Restore default configuration",
+      "resetConfirmTitle": "Restore default configuration?",
+      "resetConfirmMessage": "This replaces all manual changes to “{{name}}” with the LoongPort defaults. The API key is preserved.",
       "resetConfirmButton": "Restore defaults",
-      "resetDone": "Restored default config for “{{name}}”",
-      "edit": "Edit config",
-      "editConfirmTitle": "Edit the config for “{{name}}” manually?",
-      "editConfirmMessage": "Once you save, this tier is yours to maintain: “Fetch keys” will only refresh its API key from then on, and will no longer overwrite your other changes.\n\nIf it stops working after your edits, use “Restore default config” on the tier row to go back to the defaults (your API key is kept).",
-      "editConfirmButton": "Continue to edit",
+      "resetDone": "Restored the default configuration for “{{name}}”",
+      "edit": "Edit connection profile",
+      "editConfirmTitle": "Edit the “{{name}}” connection profile?",
+      "editConfirmMessage": "After you save, LoongPort will no longer overwrite manual changes to this connection profile. Future group updates will update only the API key.\n\nTo undo your changes, select “Restore default configuration.” The API key is preserved.",
+      "editConfirmButton": "Continue editing",
       "userEdited": "Manually maintained",
-      "userEditedHint": "You have edited this tier's config. Refreshing groups will not overwrite it (only the API key is updated). Click here to restore the default config.",
-      "editMissing": "That tier's record no longer exists — use “Fetch keys” to regenerate it.",
-      "editCurrentNote": "This is the tier you're currently using. If your changes don't take effect, quit and reopen the ChatGPT desktop app — while it's running it rewrites Codex's config."
+      "userEditedHint": "This connection profile contains manual changes. Group updates change only the API key and preserve all other settings. Select to restore the defaults.",
+      "editMissing": "This connection profile could not be found. Create the connection profiles again.",
+      "editCurrentNote": "This connection profile is in use. If your changes do not take effect, quit and reopen the ChatGPT desktop app; a running ChatGPT app may overwrite the Codex configuration."
     },
     "stats": {
       "title": "Help improve LoongPort",
-      "intro": "We would like to know which relay sites people actually use, so we can prioritise support.",
-      "sendsLabel": "What is sent",
-      "sendsBody": "The relay site domains you added, how many accounts, the app version and your OS type.",
-      "neverLabel": "What is never sent",
-      "neverBody": "Accounts, emails, balances, keys, or usage records.",
-      "canChange": "You can turn this off at any time in Settings → General.",
-      "accept": "Sounds good",
-      "decline": "No thanks",
-      "idNote": "A randomly generated install ID is included, used only to de-duplicate reports. It is unrelated to your relay-site accounts."
+      "intro": "To prioritize relay service support, we would like to understand how LoongPort is being used.",
+      "sendsLabel": "Will collect",
+      "sendsBody": "Relay service domains, account counts, app version, and operating system.",
+      "neverLabel": "Will not collect",
+      "neverBody": "Sign-in details, email addresses, balances, API keys, or usage records.",
+      "canChange": "You can change this at any time in Settings → General.",
+      "accept": "Allow sharing",
+      "decline": "Don't share",
+      "idNote": "The data includes a randomly generated installation ID for deduplication. It is not linked to your relay service accounts."
     },
     "site": {
       "removed": "Removed {{label}}"
     },
     "session": {
-      "expired": "{{count}} account(s) signed out — please sign in again",
-      "connected": "Connected, fetching keys… (you can close the sign-in window)"
+      "expired": "The sign-in sessions for {{count}} accounts have expired. Sign in again.",
+      "connected": "Connected. Creating connection profiles. You can close the sign-in window now."
     },
     "provision": {
-      "ready": "{{count}} tier(s) ready",
-      "readyWithKeys": "{{count}} tier(s) ready, {{keys}} key(s) created",
-      "landedOnOtherPlatforms": "This account has {{count}} group(s), but none of them are for the current CLI. Switch to the matching tab above to see them.",
+      "ready": "Synced {{count}} connection profiles",
+      "readyWithKeys": "Synced {{count}} connection profiles and created {{keys}} API keys",
+      "landedOnOtherPlatforms": "This account has {{count}} groups, but none are available for the current platform. Select the corresponding platform above to view them.",
       "groupFailed": "{{group}}: {{reason}}",
-      "mergedProviders": "Adopted {{count}} duplicate provider(s) from cc-switch",
-      "refreshed": "Refreshed {{relays}} relay(s), {{tiers}} tier(s) total",
-      "refreshFailedWithReason": "Failed to refresh {{name}}: {{reason}}",
-      "refreshedWithKeys": "Refreshed {{relays}} relay(s), {{tiers}} tier(s) total, {{keys}} new key(s)"
+      "mergedProviders": "Merged {{count}} duplicate configurations",
+      "refreshed": "Updated {{relays}} relay services and synced {{tiers}} connection profiles",
+      "refreshFailedWithReason": "Could not update {{name}}: {{reason}}",
+      "refreshedWithKeys": "Updated {{relays}} relay services, synced {{tiers}} connection profiles, and created {{keys}} API keys"
     },
     "switch": {
       "done": "Switched to {{name}}",
-      "doneRelaunched": "Switched to {{name}}, ChatGPT reopened",
-      "doneNeedsRestart": "Switched to {{name}} — please restart ChatGPT manually",
-      "modelDone": "Switched {{name}} to model {{model}}",
-      "modelDoneRelaunched": "Switched {{name}} to model {{model}}, ChatGPT reopened",
-      "modelDoneNeedsRestart": "Switched {{name}} to model {{model}} — please restart ChatGPT manually"
+      "doneRelaunched": "Switched to {{name}} and reopened ChatGPT",
+      "doneNeedsRestart": "Switched to {{name}}. Restart ChatGPT manually",
+      "modelDone": "Switched {{name}} to {{model}}",
+      "modelDoneRelaunched": "Switched {{name}} to {{model}} and reopened ChatGPT",
+      "modelDoneNeedsRestart": "Switched {{name}} to {{model}}. Restart ChatGPT manually"
     },
     "official": {
-      "button": "Switch back to official login",
-      "hint": "Clear the routing LoongPort wrote and use your own ChatGPT account",
-      "confirmTitle": "Switch back to official login?",
-      "confirmMessage": "This quits ChatGPT, clears the routing config LoongPort wrote, and deletes the current codex login (backed up first). You'll need to sign in to ChatGPT yourself afterwards.",
-      "confirmButton": "Switch to official",
-      "done": "Switched back to official login — please sign in to ChatGPT",
-      "doneWithBackup": "Switched back to official login. Previous login backed up to {{path}}"
+      "button": "Restore official sign-in",
+      "hint": "Remove LoongPort routing and sign in with your official ChatGPT account",
+      "confirmTitle": "Restore official sign-in?",
+      "confirmMessage": "This quits ChatGPT, removes LoongPort routing, and deletes the current Codex sign-in session after backing it up. You will need to sign in to ChatGPT again.",
+      "confirmButton": "Restore official sign-in",
+      "done": "Official sign-in restored. Sign in to ChatGPT again",
+      "doneWithBackup": "Official sign-in restored. The previous sign-in session was backed up to {{path}}"
     },
     "quitConfirm": {
       "title": "Switch to {{name}}",
-      "body": "ChatGPT only reads its config at startup, so it has to be quit first and reopened after the switch.",
-      "declineNote": "If it has an ongoing conversation it will ask you to confirm — cancelling there aborts this switch and leaves your config untouched.",
-      "forceKillWarning": "⚠️ On Windows, ChatGPT can only be force-closed (it ignores normal close requests) and you won't be asked to save — save any conversation in progress first. We'll reopen it for you afterwards.",
-      "platformNote": "If we can't close it for you, the config still switches — just restart ChatGPT yourself.",
-      "switchOnly": "Switch only, I'll restart it",
-      "quitAndSwitch": "Quit and switch"
+      "body": "ChatGPT reads connection profiles only at startup. LoongPort will quit ChatGPT, switch profiles, and then reopen it.",
+      "declineNote": "On macOS, ChatGPT may ask for confirmation when a conversation is in progress. Selecting Cancel stops the switch and leaves the configuration unchanged.",
+      "forceKillWarning": "⚠️ On Windows, ChatGPT must be force-closed and will not show a save prompt. Save any conversation in progress first; LoongPort will reopen ChatGPT after the switch.",
+      "platformNote": "If LoongPort cannot close ChatGPT, the connection profile will still be switched. Restart ChatGPT manually to apply it.",
+      "switchOnly": "Switch only",
+      "quitAndSwitch": "Quit ChatGPT and switch"
     },
     "addSite": {
-      "firstRunTitle": "Choose a relay site",
-      "firstRunBody": "Paste the relay’s domain — copying straight from your browser’s address bar works too; any trailing path is stripped for you. Leave it empty to use {{site}}.",
-      "title": "Add relay site",
-      "body": "Paste another relay’s domain. One site can hold several accounts — just log in with a different one; duplicates are merged automatically.",
+      "firstRunTitle": "Choose a relay service",
+      "firstRunBody": "Paste a relay service domain or full URL. LoongPort removes the path automatically. Leave it blank to use the default relay service, {{site}}.",
+      "title": "Add relay service",
+      "body": "Enter another relay service domain. You can add multiple accounts for the same service; duplicate accounts are merged automatically.",
       "connected": "Connected to {{name}}",
-      "inputLabel": "Site domain",
-      "inputLabelWithSponsors": "Or enter a domain manually",
-      "inputHint": "e.g. bestapi.store, or paste https://bestapi.store/usage directly",
-      "sponsorsLabel": "Recommended sites",
-      "sponsorAddAnother": "{{count}} account(s) · add another"
+      "inputLabel": "Relay service domain",
+      "inputLabelWithSponsors": "Or enter a relay service domain",
+      "inputHint": "For example, bestapi.store or https://bestapi.store/usage",
+      "sponsorsLabel": "Recommended relay services",
+      "sponsorAddAnother": "{{count}} accounts added · Add another"
     },
     "vendor": {
-      "add": "Add an official account",
-      "empty": "No official account added yet",
-      "remove": "Remove this official account (and its configs)",
-      "removeConfirmTitle": "Remove this official account?",
-      "removeConfirmMessage": "Removes the session and local key for “{{label}}”, along with the configs it generated for six platforms. The API key on the vendor's site is kept — sign in again to reuse it.",
-      "removed": "Removed {{label}}",
-      "noKey": "No key yet",
-      "keyReady": "Configs ready for {{count}} platform(s)",
-      "keyCreated": "Created a new key on the vendor's site and set up {{count}} platform(s)",
-      "refreshKey": "Set up the key again",
-      "sessionExpiredUsable": "Your session expired, but the key still works (only the balance is unavailable). Click to sign in again.",
-      "loginFailed": "Sign-in did not complete: {{reason}}",
-      "openKeyPage": "Manage keys on the site",
-      "userEditedHint": "You have edited this account's config for the current app. “Fetch keys” will not overwrite it (only the API key is updated). Click here to restore the default config.",
-      "editConfirmMessage": "Once you save, this account's config for the current app is yours to maintain: “Fetch keys” will only refresh its API key from then on, and will no longer overwrite your other changes.\n\nIf it stops working after your edits, use “Restore default config” on this row to go back to the defaults (your API key is kept)."
+      "add": "Add provider account",
+      "empty": "No provider accounts added",
+      "remove": "Delete provider account and connection profiles",
+      "removeConfirmTitle": "Delete this provider account?",
+      "removeConfirmMessage": "This deletes the sign-in session and local API key for “{{label}}”, along with its connection profiles for six platforms. The API key on the provider website is not deleted, and you can sign in again later.",
+      "removed": "Deleted {{label}}",
+      "noKey": "No API key configured",
+      "keyReady": "Created connection profiles for {{count}} platforms",
+      "keyCreated": "Created an API key on the provider website and connection profiles for {{count}} platforms",
+      "refreshKey": "Reapply key configuration",
+      "sessionExpiredUsable": "The sign-in session has expired, but the API key still works. Balance information is temporarily unavailable. Select to sign in again.",
+      "loginFailed": "Sign-in failed: {{reason}}",
+      "openKeyPage": "Manage API key",
+      "userEditedHint": "This provider account has manual changes for the current platform. Reapplying the key configuration updates only the API key and preserves all other settings. Select to restore the defaults.",
+      "editConfirmMessage": "After you save, LoongPort will no longer overwrite manual changes for this provider account on the current platform. Reapplying the key configuration will update only the API key.\n\nTo undo your changes, select “Restore default configuration.” The API key is preserved."
     },
     "imageTab": {
-      "companionNotice": "This page is not usable on its own — it works alongside Codex chat.",
-      "companionDetail": "Image generation runs through the tool (MCP) bundled with LoongPort: say \"generate an image\" in codex / claude and it uses the tier selected here. Chat still goes through whichever tier you picked on the Codex page — the two are independent, so you can chat with DeepSeek or any other site.",
-      "howTo": "Switching image tiers needs no CLI restart — the next generation uses the new one. Only the very first image tier requires a fresh terminal so codex picks up the tool.",
-      "emptyTitle": "No image tiers yet",
-      "emptyBody": "Image tiers are detected automatically when you fetch keys: if your relay has a group that only serves gpt-image models, it shows up here. Your site may not offer image groups at all — then this page simply stays empty and nothing is added to your CLI config."
+      "companionNotice": "Image generation works with Codex or Claude.",
+      "companionDetail": "Image generation uses the connection profile selected on this page. Chat uses the profile selected on the Codex or Claude page, so the two selections do not affect each other.",
+      "howTo": "You do not need to restart after switching image-generation profiles; the next generation uses the new profile. After creating your first image-generation profile, open a new terminal to load image-generation support.",
+      "emptyTitle": "No image-generation connection profiles",
+      "emptyBody": "When you create connection profiles, LoongPort identifies groups that support only gpt-image models. If your relay service does not offer such a group, this page remains empty."
     },
     "modelVerification": {
-      "title": "Verify model",
-      "titleWithTier": "Verify model · {{tierName}}",
-      "description": "Run a verification against one model configured for this provider.",
-      "globalScopeNote": "Apply automatic verification to all configured models.",
+      "title": "Model verification",
+      "titleWithTier": "Model verification · {{tierName}}",
+      "description": "Verify the response characteristics of the model selected for this connection profile.",
+      "globalScopeNote": "Automatic verification applies to all configured models.",
       "model": {
-        "label": "Model",
+        "label": "Select model",
         "placeholder": "Select a model",
         "loading": "Loading models…",
-        "empty": "No models are available to verify.",
-        "error": "Could not load models."
+        "empty": "No models are available for verification",
+        "error": "Could not load the model list. Try again."
       },
       "actions": {
         "start": "Start verification",
         "stop": "Stop verification",
-        "retry": "Retry"
+        "retry": "Try again"
       },
-      "status": { "running": "Verifying {{completed}} / {{total}}" },
+      "status": {
+        "running": "Verifying {{completed}} of {{total}}"
+      },
       "runtime": {
-        "autoLabel": "Automatic runtime verification (global)",
-        "autoHelp": "Applies to all relay groups and models. LoongPort observes actual Codex and Claude responses through the local proxy; it sends no extra probes and never saves conversation content.",
-        "loadError": "Could not load runtime verification status.",
-        "anomalyToast": "An anomaly was detected for {{app}} model {{model}}. Open Verify model for details.",
-        "apps": { "codex": "Codex", "claude": "Claude" },
-        "status": { "active": "Active", "waiting": "Waiting", "error": "Error" }
+        "autoLabel": "Automatic verification",
+        "autoHelp": "Automatically verifies all relay groups and models from actual Codex and Claude responses. It does not send additional verification requests and does not save conversation content.",
+        "loadError": "Could not load the automatic verification status. Try again.",
+        "anomalyToast": "An anomaly was detected for {{model}} in {{app}}. Open Model verification for details.",
+        "apps": {
+          "codex": "Codex",
+          "claude": "Claude"
+        },
+        "status": {
+          "active": "Enabled",
+          "waiting": "Waiting for an available response",
+          "error": "Not running correctly"
+        }
       },
       "history": {
-        "title": "Latest 5 verification results",
+        "title": "5 most recent verification results",
         "loading": "Loading verification results…",
-        "empty": "No verification results yet.",
-        "error": "Could not load verification results.",
-        "source": { "active": "Active check", "runtime": "Runtime check" }
+        "empty": "No verification results yet",
+        "error": "Could not load verification results. Try again.",
+        "source": {
+          "active": "Current verification",
+          "runtime": "Automatic verification"
+        }
       },
       "tierVerdict": {
-        "trusted": "Model verified",
-        "suspicious": "Model suspicious",
-        "anomaly": "Model anomaly",
-        "trustedHint": "Model verification passed. Select Verify model for details.",
-        "suspiciousHint": "Verification found suspicious behavior. Select Verify model for details.",
-        "anomalyHint": "Verification found an anomaly. Select Verify model for details."
+        "trusted": "Verified",
+        "suspicious": "Review needed",
+        "anomaly": "Anomaly detected",
+        "trustedHint": "The available evidence passed verification. Open Model verification for details.",
+        "suspiciousHint": "The current result needs manual review. Open Model verification for details.",
+        "anomalyHint": "An inconsistent response was detected. Open Model verification for details."
       },
       "verdict": {
-        "trusted": "Trusted",
-        "suspicious": "Suspicious",
-        "anomaly": "Anomaly",
-        "inconclusive": "Inconclusive"
+        "trusted": "Verified",
+        "suspicious": "Review needed",
+        "anomaly": "Anomaly detected",
+        "inconclusive": "Insufficient evidence"
       },
       "evidence": {
-        "title": "Evidence",
+        "title": "Verification evidence",
         "level": {
           "cryptographic": "Cryptographic evidence",
           "protocolBehavior": "Protocol behavior evidence",
@@ -3257,32 +3270,32 @@
         },
         "outcome": {
           "passed": "Passed",
-          "failed": "Failed",
+          "failed": "Did not pass",
           "skipped": "Skipped"
         },
         "fact": {
-          "basicEnvelope": "Basic response envelope",
+          "basicEnvelope": "Basic response structure",
           "modelMatch": "Model identity",
           "streamLifecycle": "Streaming lifecycle",
           "usageConsistency": "Usage consistency",
-          "toolCallShape": "Tool-call shape",
+          "toolCallShape": "Tool-call structure",
           "structuredOutput": "Structured output",
           "thinkingSignature": "Reasoning signature",
-          "signatureContinuation": "Signature continuation",
-          "foreignProtocol": "Foreign protocol",
-          "foreignSelfIdentification": "Foreign self-identification"
+          "signatureContinuation": "Signature continuity",
+          "foreignProtocol": "Other protocol characteristics",
+          "foreignSelfIdentification": "Other model self-identification"
         }
       },
       "failure": {
-        "authentication": "Authentication failed.",
-        "rateLimited": "The provider rate limited this verification.",
-        "insufficientBalance": "Insufficient balance to verify this model.",
-        "network": "Network connection failed.",
-        "upstream": "The provider could not complete verification.",
-        "timeout": "Verification timed out.",
-        "modelUnavailable": "This model is unavailable.",
-        "cancelled": "Verification was stopped.",
-        "invalidResponse": "The provider returned an invalid response."
+        "authentication": "Authentication failed. Check the sign-in session or API key and try again.",
+        "rateLimited": "The request was rate-limited. Try again later.",
+        "insufficientBalance": "The balance is too low to verify this model. Top up and try again.",
+        "network": "The network connection failed. Check your connection and try again.",
+        "upstream": "The provider could not complete verification. Try again later.",
+        "timeout": "Verification timed out. Try again later.",
+        "modelUnavailable": "This model is unavailable. Select another model.",
+        "cancelled": "Verification stopped.",
+        "invalidResponse": "The provider's response could not be verified. Try again later or review it manually."
       }
     }
   }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3059,14 +3059,14 @@
   },
   "loongport": {
     "sections": {
-      "relay": "中継",
-      "official": "公式API",
+      "relay": "中継サービス",
+      "official": "公式 API",
       "other": "その他"
     },
     "tierList": {
-      "empty": "中継サイトがまだ追加されていません",
-      "addSite": "中継サイトを追加",
-      "refresh": "プランとキーを更新"
+      "empty": "中継サービスはまだ追加されていません",
+      "addSite": "中継サービスを追加",
+      "refresh": "接続プロファイルを更新"
     },
     "row": {
       "expand": "展開",
@@ -3075,185 +3075,198 @@
       "login": "ログイン",
       "sessionExpired": "ログインの有効期限が切れました",
       "reLogin": "再ログイン",
-      "noTiers": "このアカウントにはこのプラットフォーム用のグループがありません",
-      "getKeys": "キーを取得",
-      "tierCount": "{{count}} 件のプラン",
-      "dragHandle": "ドラッグして並び替え",
-      "refetchGroups": "利用可能なグループを再取得",
-      "purchaseHint": "クリックしてチャージ（このサイトの購入ページをアプリ内で開きます）",
+      "noTiers": "このアカウントには現在のプラットフォームで利用できるグループがありません",
+      "getKeys": "接続プロファイルを作成",
+      "tierCount": "接続プロファイル {{count}} 件",
+      "dragHandle": "ドラッグして並べ替え",
+      "more": "その他の操作",
+      "refetchGroups": "利用可能なグループを更新",
+      "purchaseHint": "中継サービスのチャージページを開く",
       "lowBalanceHint": "残高が ${{threshold}} 未満です。クリックしてチャージ",
-      "remove": "このアカウントを削除（プランも一緒に）",
-      "removeBlockedByCurrent": "使用中のプランがあります。先に別のプランに切り替えてください",
+      "remove": "アカウントと接続プロファイルを削除",
+      "removeBlockedByCurrent": "このアカウントの接続プロファイルが使用中です。別のプロファイルに切り替えてから削除してください",
       "removeConfirmTitle": "このアカウントを削除しますか？",
-      "removeConfirmMessage": "「{{label}}」のログイン情報と、生成済みの {{count}} 件のプランを削除します。チャージ済みの残高は中継サイト側に残るため、再ログインすれば引き続き使えます。",
-      "removeConfirmMessageNeverLoggedIn": "「{{label}}」の行と、生成済みの {{count}} 件のプランを削除します。このアカウントは未ログインのため、いつでも再度追加できます。"
+      "removeConfirmMessage": "「{{label}}」のログイン情報と {{count}} 件の接続プロファイルを削除します。中継サービスの残高は保持され、後から再ログインできます。",
+      "removeConfirmMessageNeverLoggedIn": "「{{label}}」と {{count}} 件の接続プロファイルを削除します。後からこのアカウントを再度追加できます。"
     },
     "tier": {
       "rateUnknown": "倍率不明",
       "rate": "{{value}} 倍",
       "models": "対応モデル",
-      "selectModel": "モデル {{model}} に切り替え",
+      "selectModel": "{{model}} に切り替え",
       "modelSelected": "現在のモデル",
       "switching": "切り替え中…",
-      "checkConnectivity": "接続を確認",
+      "checkConnectivity": "接続テスト",
       "resetConfig": "デフォルト設定に戻す",
       "resetConfirmTitle": "デフォルト設定に戻しますか？",
-      "resetConfirmMessage": "「{{name}}」への編集はすべて LoongPort のデフォルト設定で上書きされます。API キーは保持されます。",
+      "resetConfirmMessage": "「{{name}}」への手動変更を LoongPort のデフォルト設定で上書きします。API キーは保持されます。",
       "resetConfirmButton": "デフォルトに戻す",
       "resetDone": "「{{name}}」をデフォルト設定に戻しました",
-      "edit": "設定を編集",
-      "editConfirmTitle": "「{{name}}」の設定を手動で編集しますか？",
-      "editConfirmMessage": "保存すると、この枠はご自身での管理になります。以降「キーを取得」はキーのみを更新し、その他の変更は上書きしません。\n\n編集後に接続できなくなった場合は、枠の行にある「デフォルト設定に戻す」で既定値に戻せます（キーは保持されます）。",
+      "edit": "接続プロファイルを編集",
+      "editConfirmTitle": "「{{name}}」の接続プロファイルを編集しますか？",
+      "editConfirmMessage": "保存後、LoongPort はこの接続プロファイルへの手動変更を上書きしません。今後グループを更新しても、API キーだけが更新されます。\n\n変更を取り消すには「デフォルト設定に戻す」を選択してください。API キーは保持されます。",
       "editConfirmButton": "編集を続ける",
-      "userEdited": "手動管理中",
-      "userEditedHint": "この枠の設定を編集済みです。グループを更新しても上書きされません（キーのみ更新）。クリックでデフォルト設定に戻せます。",
-      "editMissing": "この枠のレコードが見つかりません。「キーを取得」で再生成してください。",
-      "editCurrentNote": "これは現在使用中の枠です。変更が反映されない場合は ChatGPT デスクトップ版を終了して開き直してください —— 起動中は Codex の設定を書き戻します。"
+      "userEdited": "手動管理",
+      "userEditedHint": "この接続プロファイルには手動変更が含まれています。グループを更新しても API キーだけが更新され、その他の設定は保持されます。クリックするとデフォルト設定に戻せます。",
+      "editMissing": "この接続プロファイルが見つかりません。接続プロファイルを作成し直してください。",
+      "editCurrentNote": "これは使用中の接続プロファイルです。変更が反映されない場合は、ChatGPT デスクトップアプリを終了して再度開いてください。起動中の ChatGPT が Codex の設定を上書きすることがあります。"
     },
     "stats": {
       "title": "LoongPort の改善に協力",
-      "intro": "どの中継サイトが実際に使われているかを知り、対応の優先順位を決めたいと考えています。",
-      "sendsLabel": "送信される情報",
-      "sendsBody": "追加した中継サイトのドメイン、アカウント数、アプリのバージョン、OS の種類。",
-      "neverLabel": "送信されない情報",
-      "neverBody": "アカウント、メールアドレス、残高、キー、利用記録。",
-      "canChange": "「設定 → 一般」からいつでも無効にできます。",
-      "accept": "同意する",
-      "decline": "参加しない",
-      "idNote": "重複集計のためランダムなインストール識別子を含みます（中継サイトのアカウントとは無関係です）。"
+      "intro": "優先して対応する中継サービスを判断するため、LoongPort の利用状況を確認したいと考えています。",
+      "sendsLabel": "収集する情報",
+      "sendsBody": "追加した中継サービスのドメイン、アカウント数、アプリのバージョン、OS の種類。",
+      "neverLabel": "収集しない情報",
+      "neverBody": "ログイン情報、メールアドレス、残高、API キー、利用履歴。",
+      "canChange": "この設定は「設定 → 一般」でいつでも変更できます。",
+      "accept": "共有を許可",
+      "decline": "共有しない",
+      "idNote": "データには重複集計を防ぐためのランダムなインストール ID が含まれます。中継サービスのアカウントとは関連付けられません。"
     },
     "site": {
       "removed": "{{label}} を削除しました"
     },
     "session": {
-      "expired": "{{count}} 件のアカウントのログインが無効になりました。再度ログインしてください",
-      "connected": "接続しました。キーを取得中…（ログインウィンドウは閉じても大丈夫です）"
+      "expired": "{{count}} 件のアカウントでログインの有効期限が切れました。再ログインしてください。",
+      "connected": "接続しました。接続プロファイルを作成しています。ログインウィンドウは閉じて構いません。"
     },
     "provision": {
-      "ready": "{{count}} 件のプランを準備しました",
-      "readyWithKeys": "{{count}} 件のプランを準備し、{{keys}} 個のキーを作成しました",
-      "landedOnOtherPlatforms": "このアカウントには {{count}} 件のグループがありますが、現在の CLI 向けのものはありません。上部の該当タブに切り替えてご確認ください。",
+      "ready": "接続プロファイル {{count}} 件を同期しました",
+      "readyWithKeys": "接続プロファイル {{count}} 件を同期し、API キー {{keys}} 件を作成しました",
+      "landedOnOtherPlatforms": "このアカウントには {{count}} 件のグループがありますが、現在のプラットフォームでは利用できません。上部で該当するプラットフォームに切り替えて確認してください。",
       "groupFailed": "{{group}}：{{reason}}",
-      "mergedProviders": "cc-switch の重複プロバイダー {{count}} 件を取り込みました",
-      "refreshed": "{{relays}} 件の中継サイトを更新し、合計 {{tiers}} 件のプランを取得しました",
-      "refreshFailedWithReason": "{{name}} の更新に失敗しました：{{reason}}",
-      "refreshedWithKeys": "{{relays}} 件の中継サイトを更新しました（枠 {{tiers}} 件、新規キー {{keys}} 本）"
+      "mergedProviders": "重複する設定 {{count}} 件を統合しました",
+      "refreshed": "中継サービス {{relays}} 件を更新し、接続プロファイル {{tiers}} 件を同期しました",
+      "refreshFailedWithReason": "{{name}} を更新できませんでした：{{reason}}",
+      "refreshedWithKeys": "中継サービス {{relays}} 件を更新し、接続プロファイル {{tiers}} 件を同期して、API キー {{keys}} 件を作成しました"
     },
     "switch": {
       "done": "{{name}} に切り替えました",
-      "doneRelaunched": "{{name}} に切り替え、ChatGPT を再起動しました",
+      "doneRelaunched": "{{name}} に切り替え、ChatGPT を再度開きました",
       "doneNeedsRestart": "{{name}} に切り替えました。ChatGPT を手動で再起動してください",
-      "modelDone": "{{name}} のモデルを {{model}} に切り替えました",
-      "modelDoneRelaunched": "{{name}} のモデルを {{model}} に切り替え、ChatGPT を再起動しました",
-      "modelDoneNeedsRestart": "{{name}} のモデルを {{model}} に切り替えました。ChatGPT を手動で再起動してください"
+      "modelDone": "{{name}} をモデル {{model}} に切り替えました",
+      "modelDoneRelaunched": "{{name}} をモデル {{model}} に切り替え、ChatGPT を再度開きました",
+      "modelDoneNeedsRestart": "{{name}} をモデル {{model}} に切り替えました。ChatGPT を手動で再起動してください"
     },
     "official": {
       "button": "公式ログインに戻す",
-      "hint": "LoongPort が書き込んだルーティングを消し、自分の ChatGPT アカウントを使います",
+      "hint": "LoongPort のルーティングを削除し、ChatGPT の公式アカウントでログインします",
       "confirmTitle": "公式ログインに戻しますか？",
-      "confirmMessage": "ChatGPT を終了し、LoongPort が書き込んだルーティング設定を消して、現在の codex ログイン情報を削除します（削除前に自動バックアップします）。その後は自分で ChatGPT にログインしてください。",
-      "confirmButton": "公式に戻す",
-      "done": "公式ログインに戻しました。ChatGPT にログインしてください",
-      "doneWithBackup": "公式ログインに戻しました。以前のログイン情報は {{path}} にバックアップしました"
+      "confirmMessage": "ChatGPT を終了し、LoongPort のルーティングを削除します。現在の Codex ログイン情報はバックアップ後に削除されるため、完了後に ChatGPT へ再ログインしてください。",
+      "confirmButton": "公式ログインに戻す",
+      "done": "公式ログインに戻しました。ChatGPT に再ログインしてください",
+      "doneWithBackup": "公式ログインに戻しました。元のログイン情報は {{path}} にバックアップされています"
     },
     "quitConfirm": {
       "title": "{{name}} に切り替え",
-      "body": "ChatGPT は起動時にしか設定を読まないため、いったん終了してから切り替え、その後で開き直します。",
-      "declineNote": "進行中の会話がある場合は確認ダイアログが出ます。そこでキャンセルすると切り替えは中止され、設定は変更されません。",
-      "forceKillWarning": "⚠️ Windows では ChatGPT を強制終了するしかありません（通常の終了要求に応じないため）。保存の確認は出ないので、進行中の会話は先に保存してください。終了後は開き直します。",
-      "platformNote": "代わりに終了できなかった場合も設定は切り替わるので、ChatGPT はご自身で再起動してください。",
-      "switchOnly": "切り替えのみ（自分で再起動）",
-      "quitAndSwitch": "終了して切り替え"
+      "body": "ChatGPT は起動時にのみ接続プロファイルを読み込みます。LoongPort は ChatGPT を終了し、切り替え後に再度開きます。",
+      "declineNote": "macOS では、進行中の会話があると ChatGPT が終了確認を表示することがあります。「キャンセル」を選ぶと切り替えは中止され、設定は変更されません。",
+      "forceKillWarning": "⚠️ Windows では ChatGPT を強制終了する必要があり、保存の確認は表示されません。進行中の会話を先に保存してください。切り替え後、LoongPort が ChatGPT を再度開きます。",
+      "platformNote": "LoongPort が ChatGPT を終了できなかった場合も、接続プロファイルの切り替えは完了します。反映するには ChatGPT を手動で再起動してください。",
+      "switchOnly": "切り替えのみ",
+      "quitAndSwitch": "ChatGPT を終了して切り替え"
     },
     "addSite": {
-      "firstRunTitle": "中継サイトを選択",
-      "firstRunBody": "中継サイトのドメインを貼り付けてください —— ブラウザのアドレスバーからそのままコピーしても大丈夫です（末尾のパスは自動で取り除きます）。空欄なら {{site}} を使います。",
-      "title": "中継サイトを追加",
-      "body": "別の中継サイトのドメインを貼り付けてください。同じサイトに複数アカウントを持てます —— 別のアカウントでログインするだけで、重複は自動的にまとめられます。",
+      "firstRunTitle": "中継サービスを選択",
+      "firstRunBody": "中継サービスのドメインまたは URL を貼り付けてください。パスは自動的に削除されます。空欄の場合は既定の中継サービス {{site}} を使用します。",
+      "title": "中継サービスを追加",
+      "body": "別の中継サービスのドメインを入力します。同じサービスに複数のアカウントを追加でき、重複するアカウントは自動的に統合されます。",
       "connected": "{{name}} に接続しました",
-      "inputLabel": "サイトのドメイン",
-      "inputLabelWithSponsors": "または手動でドメインを入力",
-      "inputHint": "例：bestapi.store、または https://bestapi.store/usage をそのまま貼り付け",
-      "sponsorsLabel": "おすすめのサイト",
-      "sponsorAddAnother": "アカウント {{count}} 件 · さらに追加"
+      "inputLabel": "中継サービスのドメイン",
+      "inputLabelWithSponsors": "または中継サービスのドメインを入力",
+      "inputHint": "例：bestapi.store、https://bestapi.store/usage",
+      "sponsorsLabel": "おすすめの中継サービス",
+      "sponsorAddAnother": "{{count}} 件のアカウントを追加済み · もう 1 件追加"
     },
     "vendor": {
-      "add": "公式アカウントを追加",
-      "empty": "公式アカウントがまだ追加されていません",
-      "remove": "この公式アカウントを削除（設定も一緒に）",
-      "removeConfirmTitle": "この公式アカウントを削除しますか？",
-      "removeConfirmMessage": "「{{label}}」のログイン情報とローカルのキー、および 6 つのプラットフォーム向けに生成した設定を削除します。公式サイト側の API キーは残るので、再度ログインすれば使えます。",
+      "add": "プロバイダーアカウントを追加",
+      "empty": "プロバイダーアカウントはまだ追加されていません",
+      "remove": "プロバイダーアカウントと接続プロファイルを削除",
+      "removeConfirmTitle": "このプロバイダーアカウントを削除しますか？",
+      "removeConfirmMessage": "「{{label}}」のログイン情報とローカル API キー、および 6 つのプラットフォーム用の接続プロファイルを削除します。プロバイダーの Web サイトにある API キーは削除されず、後から再ログインできます。",
       "removed": "{{label}} を削除しました",
-      "noKey": "キーが未準備です",
-      "keyReady": "{{count}} 個のプラットフォームの設定を準備しました",
-      "keyCreated": "公式サイトで新しいキーを作成し、{{count}} 個のプラットフォームの設定を準備しました",
-      "refreshKey": "キーを再準備する",
-      "sessionExpiredUsable": "ログインは期限切れですが、キーはまだ使えます（残高だけ取得できません）。ここをクリックして再ログインできます。",
-      "loginFailed": "ログインが完了しませんでした：{{reason}}",
-      "openKeyPage": "公式サイトで整理する",
-      "userEditedHint": "このアカウントの現在のアプリ向け設定を編集済みです。「キーを取得」しても上書きされません（キーのみ更新）。クリックでデフォルト設定に戻せます。",
-      "editConfirmMessage": "保存すると、このアカウントの現在のアプリ向け設定はご自身での管理になります。以降「キーを取得」はキーのみを更新し、その他の変更は上書きしません。\n\n編集後に接続できなくなった場合は、この行にある「デフォルト設定に戻す」で既定値に戻せます（キーは保持されます）。"
+      "noKey": "API キーが設定されていません",
+      "keyReady": "{{count}} 個のプラットフォーム用に接続プロファイルを作成しました",
+      "keyCreated": "プロバイダーの Web サイトで API キーを作成し、{{count}} 個のプラットフォーム用に接続プロファイルを作成しました",
+      "refreshKey": "キー設定を再適用",
+      "sessionExpiredUsable": "ログインの有効期限が切れていますが、API キーは引き続き使用できます。残高は一時的に確認できません。クリックして再ログインしてください。",
+      "loginFailed": "ログインできませんでした：{{reason}}",
+      "openKeyPage": "API キーを管理",
+      "userEditedHint": "このプロバイダーアカウントには、現在のプラットフォーム用の手動変更があります。キー設定を再適用しても API キーだけが更新され、その他の設定は保持されます。クリックするとデフォルト設定に戻せます。",
+      "editConfirmMessage": "保存後、LoongPort は現在のプラットフォームに対するこのプロバイダーアカウントの手動変更を上書きしません。キー設定を再適用しても API キーだけが更新されます。\n\n変更を取り消すには「デフォルト設定に戻す」を選択してください。API キーは保持されます。"
     },
     "imageTab": {
-      "companionNotice": "このページは単独では使えません。codex のチャットと併せて使います。",
-      "companionDetail": "画像生成は LoongPort 同梱のツール（MCP）が担います。codex / claude で「画像を生成して」と言えば、ここで選んだティアで出力されます。会話は Codex タブで選んだティアのまま —— 両者は独立しているので、チャットは DeepSeek でも他のサイトでも構いません。",
-      "howTo": "画像生成のティアを切り替えても CLI の再起動は不要で、次回の生成から新しいティアが使われます。初めて画像ティアを持ったときだけ、codex にツールを認識させるため新しいターミナルを開いてください。",
-      "emptyTitle": "画像生成のティアはまだありません",
-      "emptyBody": "画像ティアは「キーを取得」時に自動判定されます。gpt-image 系モデルだけを持つグループがあれば、ここに現れます。ご利用のサイトに画像グループが無い場合もあります —— そのときはこのページは空のままで、CLI の設定には何も追加されません。"
+      "companionNotice": "画像生成は Codex または Claude と組み合わせて使用します。",
+      "companionDetail": "画像生成にはこのページで選択した接続プロファイルが使用されます。チャットには Codex または Claude ページで選択したプロファイルが使用されるため、2 つの選択は互いに影響しません。",
+      "howTo": "画像生成用の接続プロファイルを切り替えても再起動は不要で、次回の生成から反映されます。初めて画像生成用プロファイルを作成した後は、新しいターミナルを開いて画像生成機能を読み込んでください。",
+      "emptyTitle": "画像生成用の接続プロファイルがありません",
+      "emptyBody": "接続プロファイルの作成時に、LoongPort は gpt-image モデルのみに対応するグループを識別します。中継サービスに該当するグループがない場合、このページは空のままです。"
     },
     "modelVerification": {
-      "title": "モデルを検証",
-      "titleWithTier": "モデルを検証 · {{tierName}}",
-      "description": "このプロバイダーに設定されたモデルを 1 つ検証します。",
-      "globalScopeNote": "設定済みのすべてのモデルに自動検証を適用します。",
+      "title": "モデル検証",
+      "titleWithTier": "モデル検証 · {{tierName}}",
+      "description": "この接続プロファイルで選択されているモデルの応答特性を検証します。",
+      "globalScopeNote": "自動検証は設定済みのすべてのモデルに適用されます。",
       "model": {
         "label": "モデルを選択",
         "placeholder": "モデルを選択してください",
         "loading": "モデルを読み込み中…",
         "empty": "検証できるモデルはありません",
-        "error": "モデル一覧を読み込めませんでした"
+        "error": "モデル一覧を読み込めませんでした。もう一度お試しください。"
       },
       "actions": {
         "start": "検証を開始",
         "stop": "検証を停止",
         "retry": "再試行"
       },
-      "status": { "running": "検証中 {{completed}} / {{total}}" },
+      "status": {
+        "running": "{{completed}} / {{total}} を検証中"
+      },
       "runtime": {
-        "autoLabel": "実行時の自動検証（グローバル）",
-        "autoHelp": "すべてのリレーグループとモデルに適用されます。LoongPort はローカルプロキシ経由で Codex と Claude の実際の応答を監視します。追加の検証リクエストは送信せず、会話内容も保存しません。",
-        "loadError": "実行時検証の状態を読み込めませんでした。",
-        "anomalyToast": "{{app}} のモデル {{model}} で異常を検出しました。モデル検証を開いて確認してください。",
-        "apps": { "codex": "Codex", "claude": "Claude" },
-        "status": { "active": "有効", "waiting": "待機中", "error": "エラー" }
+        "autoLabel": "自動検証",
+        "autoHelp": "Codex と Claude の実際の応答に基づき、すべての中継サービスのグループとモデルを自動検証します。追加の検証リクエストは送信せず、会話内容は保存しません。",
+        "loadError": "自動検証の状態を読み込めませんでした。もう一度お試しください。",
+        "anomalyToast": "{{app}} のモデル {{model}} で異常を検出しました。モデル検証を開いて詳細を確認してください。",
+        "apps": {
+          "codex": "Codex",
+          "claude": "Claude"
+        },
+        "status": {
+          "active": "有効",
+          "waiting": "利用可能な応答を待機中",
+          "error": "正常に動作していません"
+        }
       },
       "history": {
         "title": "直近 5 件の検証結果",
-        "loading": "検証結果を読み込んでいます…",
-        "empty": "検証結果はまだありません。",
-        "error": "検証結果を読み込めませんでした。",
-        "source": { "active": "手動検証", "runtime": "使用時の検証" }
+        "loading": "検証結果を読み込み中…",
+        "empty": "検証結果はまだありません",
+        "error": "検証結果を読み込めませんでした。もう一度お試しください。",
+        "source": {
+          "active": "現在の検証",
+          "runtime": "自動検証"
+        }
       },
       "tierVerdict": {
-        "trusted": "モデル検証済み",
-        "suspicious": "モデルに疑い",
-        "anomaly": "モデル異常",
-        "trustedHint": "モデル検証に合格しました。モデルを検証で詳細を確認してください。",
-        "suspiciousHint": "検証で疑わしい挙動が見つかりました。モデルを検証で詳細を確認してください。",
-        "anomalyHint": "検証で異常が見つかりました。モデルを検証で詳細を確認してください。"
+        "trusted": "検証済み",
+        "suspicious": "要確認",
+        "anomaly": "異常を検出",
+        "trustedHint": "現在の証拠では検証に合格しています。「モデル検証」を開いて詳細を確認してください。",
+        "suspiciousHint": "現在の結果は手動確認が必要です。「モデル検証」を開いて詳細を確認してください。",
+        "anomalyHint": "応答の不整合を検出しました。「モデル検証」を開いて詳細を確認してください。"
       },
       "verdict": {
-        "trusted": "信頼済み",
-        "suspicious": "疑わしい",
-        "anomaly": "異常",
-        "inconclusive": "判断不能"
+        "trusted": "検証済み",
+        "suspicious": "要確認",
+        "anomaly": "異常を検出",
+        "inconclusive": "証拠不足"
       },
       "evidence": {
         "title": "検証根拠",
         "level": {
-          "cryptographic": "暗号学的根拠",
-          "protocolBehavior": "プロトコル動作の根拠",
-          "insufficient": "根拠不足"
+          "cryptographic": "暗号学的証拠",
+          "protocolBehavior": "プロトコル動作の証拠",
+          "insufficient": "証拠不足"
         },
         "outcome": {
           "passed": "合格",
@@ -3268,21 +3281,21 @@
           "toolCallShape": "ツール呼び出しの構造",
           "structuredOutput": "構造化出力",
           "thinkingSignature": "推論シグネチャ",
-          "signatureContinuation": "シグネチャの継続",
-          "foreignProtocol": "外部プロトコル",
-          "foreignSelfIdentification": "外部自己識別"
+          "signatureContinuation": "シグネチャの連続性",
+          "foreignProtocol": "他のプロトコル特性",
+          "foreignSelfIdentification": "他のモデルによる自己識別"
         }
       },
       "failure": {
-        "authentication": "認証に失敗しました",
-        "rateLimited": "プロバイダーにより検証が制限されました",
-        "insufficientBalance": "残高不足のためこのモデルを検証できません",
-        "network": "ネットワーク接続に失敗しました",
-        "upstream": "プロバイダーは検証を完了できませんでした",
-        "timeout": "検証がタイムアウトしました",
-        "modelUnavailable": "このモデルは利用できません",
-        "cancelled": "検証を停止しました",
-        "invalidResponse": "プロバイダーが無効な応答を返しました"
+        "authentication": "認証に失敗しました。ログイン情報または API キーを確認して、もう一度お試しください。",
+        "rateLimited": "リクエストが制限されました。しばらくしてからもう一度お試しください。",
+        "insufficientBalance": "残高不足のため、このモデルを検証できません。チャージしてからもう一度お試しください。",
+        "network": "ネットワーク接続に失敗しました。接続を確認して、もう一度お試しください。",
+        "upstream": "プロバイダーが検証を完了できませんでした。しばらくしてからもう一度お試しください。",
+        "timeout": "検証がタイムアウトしました。しばらくしてからもう一度お試しください。",
+        "modelUnavailable": "このモデルは利用できません。別のモデルを選択してください。",
+        "cancelled": "検証を停止しました。",
+        "invalidResponse": "プロバイダーの応答を検証できませんでした。しばらくしてから再試行するか、手動で確認してください。"
       }
     }
   }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3065,221 +3065,238 @@
       "other": "其他"
     },
     "tierList": {
-      "empty": "還沒有新增任何中轉站",
+      "empty": "尚未新增中轉站",
       "addSite": "新增中轉站",
-      "refresh": "重新整理檔位與金鑰"
+      "refresh": "更新連線設定檔"
     },
     "row": {
       "expand": "展開",
       "collapse": "收合",
-      "notLoggedIn": "還沒登入",
-      "login": "前往登入",
+      "notLoggedIn": "尚未登入",
+      "login": "登入",
       "sessionExpired": "登入已過期",
       "reLogin": "重新登入",
-      "noTiers": "該帳號在此平台下沒有可用群組",
-      "getKeys": "取得密鑰",
-      "tierCount": "{{count}} 個方案",
-      "dragHandle": "拖動排序",
-      "refetchGroups": "重新拉取可用群組",
-      "purchaseHint": "點擊充值（在應用內開啟該站點的充值頁）",
-      "lowBalanceHint": "餘額不足 ${{threshold}}，點擊充值",
-      "remove": "刪除這個帳號（連帶它的方案）",
-      "removeBlockedByCurrent": "它有方案正在使用，先切到其他方案再刪",
-      "removeConfirmTitle": "刪除這個帳號？",
-      "removeConfirmMessage": "會刪掉「{{label}}」的登入狀態，連帶它已產生的 {{count}} 個方案。已充值的餘額留在中轉站那邊，重新登入就能再用。",
-      "removeConfirmMessageNeverLoggedIn": "會刪掉「{{label}}」這一行，連帶它已產生的 {{count}} 個方案。這個帳號從沒登入過，隨時可以重新新增。"
+      "noTiers": "此帳號在目前平台沒有可用群組",
+      "getKeys": "建立連線設定檔",
+      "tierCount": "{{count}} 個連線設定檔",
+      "dragHandle": "拖曳排序",
+      "more": "更多操作",
+      "refetchGroups": "更新可用群組",
+      "purchaseHint": "開啟中轉站儲值頁面",
+      "lowBalanceHint": "餘額低於 ${{threshold}}，點一下儲值",
+      "remove": "刪除帳號與連線設定檔",
+      "removeBlockedByCurrent": "此帳號有連線設定檔正在使用，請先切換至其他連線設定檔",
+      "removeConfirmTitle": "刪除此帳號？",
+      "removeConfirmMessage": "將刪除「{{label}}」的登入資訊及其 {{count}} 個連線設定檔。中轉站內的餘額不會受到影響；之後可重新登入繼續使用。",
+      "removeConfirmMessageNeverLoggedIn": "將刪除「{{label}}」及其 {{count}} 個連線設定檔。之後可重新新增此帳號。"
     },
     "tier": {
       "rateUnknown": "倍率未知",
       "rate": "{{value}} 倍",
       "models": "支援的模型",
-      "selectModel": "切換至模型 {{model}}",
+      "selectModel": "切換至 {{model}}",
       "modelSelected": "目前模型",
-      "switching": "切換中…",
-      "checkConnectivity": "檢測連通",
-      "resetConfig": "恢復預設設定",
-      "resetConfirmTitle": "恢復預設設定？",
-      "resetConfirmMessage": "會用 LoongPort 的預設設定覆蓋「{{name}}」的全部編輯，金鑰保留不變。",
-      "resetConfirmButton": "恢復預設",
-      "resetDone": "已恢復「{{name}}」的預設設定",
-      "edit": "編輯設定",
-      "editConfirmTitle": "手動編輯「{{name}}」的設定？",
-      "editConfirmMessage": "儲存後這個檔位就歸你自己維護：以後「取得金鑰」只會更新它的金鑰，不再覆寫你改的其它內容。\n\n如果改完連不上，用檔位列上的「恢復預設設定」退回預設值（金鑰保留不變）。",
+      "switching": "正在切換…",
+      "checkConnectivity": "測試連線",
+      "resetConfig": "還原預設設定",
+      "resetConfirmTitle": "還原預設設定？",
+      "resetConfirmMessage": "將使用 LoongPort 預設設定覆蓋「{{name}}」的手動修改。API 金鑰會保留。",
+      "resetConfirmButton": "還原預設設定",
+      "resetDone": "已還原「{{name}}」的預設設定",
+      "edit": "編輯連線設定檔",
+      "editConfirmTitle": "編輯「{{name}}」的連線設定檔？",
+      "editConfirmMessage": "儲存後，LoongPort 將不再覆蓋此連線設定檔的手動修改；後續更新群組時只會更新 API 金鑰。\n\n若要撤銷修改，請選擇「還原預設設定」。API 金鑰會保留。",
       "editConfirmButton": "繼續編輯",
-      "userEdited": "已手動維護",
-      "userEditedHint": "這個檔位的設定你改過。重新整理分組不會覆寫它（只更新金鑰）。點這裡恢復預設設定。",
-      "editMissing": "這個檔位的記錄已經不在了，請點「取得金鑰」重新產生。",
-      "editCurrentNote": "這是目前正在使用的檔位。改完如果沒生效，結束並重新開啟 ChatGPT 桌面版 —— 它在執行時會把 codex 的設定改回去。"
+      "userEdited": "手動維護",
+      "userEditedHint": "此連線設定檔包含手動修改。更新群組時只會更新 API 金鑰，不會覆蓋其他內容。點一下可還原預設設定。",
+      "editMissing": "找不到此連線設定檔。請重新建立連線設定檔。",
+      "editCurrentNote": "這是正在使用的連線設定檔。若修改未生效，請結束並重新開啟 ChatGPT 桌面版；執行中的 ChatGPT 可能會覆蓋 Codex 設定。"
     },
     "stats": {
       "title": "協助改進 LoongPort",
-      "intro": "我們想知道大家實際在用哪些中轉站，據此決定優先適配誰。",
-      "sendsLabel": "會上報",
-      "sendsBody": "你新增的中轉站網域、帳號數量、應用版本與作業系統類型。",
-      "neverLabel": "不會上報",
-      "neverBody": "帳號、電子郵件、餘額、密鑰、用量記錄。",
-      "canChange": "可以隨時在「設定 → 一般」中關閉。",
-      "accept": "好",
-      "decline": "不參與",
-      "idNote": "會帶一個隨機產生的安裝識別碼（用於去重統計，與你在中轉站的帳號無關）。"
+      "intro": "為了決定優先支援的中轉站，我們想瞭解 LoongPort 的實際使用情況。",
+      "sendsLabel": "將收集",
+      "sendsBody": "已新增的中轉站網域、帳號數量、應用程式版本與作業系統類型。",
+      "neverLabel": "不會收集",
+      "neverBody": "帳號登入資訊、電子郵件、餘額、API 金鑰與用量記錄。",
+      "canChange": "可隨時在「設定 → 一般」中變更此選項。",
+      "accept": "允許分享",
+      "decline": "不分享",
+      "idNote": "資料包含隨機產生的安裝識別碼，僅用於去重統計，與中轉站帳號無關。"
     },
     "site": {
       "removed": "已移除 {{label}}"
     },
     "session": {
-      "expired": "{{count}} 個帳號的登入已失效，請重新登入",
-      "connected": "已連線，正在取得金鑰…（登入視窗可以自己關掉）"
+      "expired": "{{count}} 個帳號的登入已過期，請重新登入",
+      "connected": "已連線，正在建立連線設定檔。現在可以關閉登入視窗。"
     },
     "provision": {
-      "ready": "已備好 {{count}} 個方案",
-      "readyWithKeys": "已備好 {{count}} 個方案，新建 {{keys}} 把金鑰",
-      "landedOnOtherPlatforms": "這個帳號有 {{count}} 個分組，但都不屬於目前這個 CLI。切到上方對應的標籤頁查看。",
+      "ready": "已同步 {{count}} 個連線設定檔",
+      "readyWithKeys": "已同步 {{count}} 個連線設定檔，其中建立了 {{keys}} 個 API 金鑰",
+      "landedOnOtherPlatforms": "此帳號有 {{count}} 個群組，但都不適用於目前平台。請切換至上方對應的平台查看。",
       "groupFailed": "{{group}}：{{reason}}",
-      "mergedProviders": "已從 cc-switch 收編 {{count}} 個重複設定",
-      "refreshed": "已重新整理 {{relays}} 個中轉站，共 {{tiers}} 個方案",
-      "refreshFailedWithReason": "{{name}} 重新整理失敗：{{reason}}",
-      "refreshedWithKeys": "已重新整理 {{relays}} 個中轉站，共 {{tiers}} 個檔位，新建 {{keys}} 把金鑰"
+      "mergedProviders": "已合併 {{count}} 個重複設定",
+      "refreshed": "已更新 {{relays}} 個中轉站，共同步 {{tiers}} 個連線設定檔",
+      "refreshFailedWithReason": "無法更新 {{name}}：{{reason}}",
+      "refreshedWithKeys": "已更新 {{relays}} 個中轉站，共同步 {{tiers}} 個連線設定檔，其中建立了 {{keys}} 個 API 金鑰"
     },
     "switch": {
-      "done": "已切換到 {{name}}",
-      "doneRelaunched": "已切換到 {{name}}，已重新開啟 ChatGPT",
-      "doneNeedsRestart": "已切換到 {{name}}，請手動重啟 ChatGPT",
-      "modelDone": "已切換至 {{name}} 的模型 {{model}}",
-      "modelDoneRelaunched": "已切換至 {{name}} 的模型 {{model}}，已重新開啟 ChatGPT",
-      "modelDoneNeedsRestart": "已切換至 {{name}} 的模型 {{model}}，請手動重啟 ChatGPT"
+      "done": "已切換至 {{name}}",
+      "doneRelaunched": "已切換至 {{name}}，並重新開啟 ChatGPT",
+      "doneNeedsRestart": "已切換至 {{name}}。請手動重新啟動 ChatGPT",
+      "modelDone": "已將 {{name}} 切換至模型 {{model}}",
+      "modelDoneRelaunched": "已將 {{name}} 切換至模型 {{model}}，並重新開啟 ChatGPT",
+      "modelDoneNeedsRestart": "已將 {{name}} 切換至模型 {{model}}。請手動重新啟動 ChatGPT"
     },
     "official": {
-      "button": "切回官方登入",
-      "hint": "清掉 LoongPort 寫入的路由，改用你自己的 ChatGPT 帳號",
-      "confirmTitle": "切回官方登入？",
-      "confirmMessage": "會結束 ChatGPT、清掉 LoongPort 寫入的路由設定，並刪除目前的 codex 登入狀態（刪除前會自動備份）。之後需要你自己登入 ChatGPT。",
-      "confirmButton": "切回官方",
-      "done": "已切回官方登入，請自己登入 ChatGPT",
-      "doneWithBackup": "已切回官方登入。原登入狀態已備份至 {{path}}"
+      "button": "還原官方登入",
+      "hint": "移除 LoongPort 路由，改用 ChatGPT 官方帳號登入",
+      "confirmTitle": "還原官方登入？",
+      "confirmMessage": "將結束 ChatGPT、移除 LoongPort 路由，並在備份後刪除目前的 Codex 登入狀態。完成後需要重新登入 ChatGPT。",
+      "confirmButton": "還原官方登入",
+      "done": "已還原官方登入。請重新登入 ChatGPT",
+      "doneWithBackup": "已還原官方登入。原登入狀態已備份至 {{path}}"
     },
     "quitConfirm": {
-      "title": "切換到 {{name}}",
-      "body": "ChatGPT 啟動時才讀取設定，所以要先結束它、切換完再開啟。",
-      "declineNote": "如果它有進行中的對話，會彈出確認框 —— 在那裡點取消的話，本次切換會中止、設定不會改動。",
-      "forceKillWarning": "⚠️ Windows 上只能強制關閉 ChatGPT（它不回應普通的關閉請求），不會提示你儲存 —— 有正在進行的對話請先自己儲存。關掉後會再幫你開啟。",
-      "platformNote": "萬一沒能替你關掉，設定仍會切好，只需你手動重啟 ChatGPT。",
-      "switchOnly": "只切換，我自己重啟",
-      "quitAndSwitch": "結束並切換"
+      "title": "切換至 {{name}}",
+      "body": "ChatGPT 只會在啟動時讀取連線設定檔。LoongPort 將先結束 ChatGPT，完成切換後再重新開啟。",
+      "declineNote": "在 macOS 上，若 ChatGPT 有進行中的對話，系統可能顯示結束確認。選擇「取消」將中止切換，設定不會變更。",
+      "forceKillWarning": "⚠️ Windows 上必須強制關閉 ChatGPT，且不會顯示儲存提醒。請先儲存進行中的對話；切換完成後 LoongPort 會重新開啟 ChatGPT。",
+      "platformNote": "如果 LoongPort 無法關閉 ChatGPT，連線設定檔仍會完成切換。請手動重新啟動 ChatGPT 使其生效。",
+      "switchOnly": "僅切換",
+      "quitAndSwitch": "結束 ChatGPT 並切換"
     },
     "addSite": {
-      "firstRunTitle": "選擇服務站點",
-      "firstRunBody": "把中轉站的網域貼進來就行 —— 從瀏覽器網址欄直接複製也可以，網址後面的路徑會自動去掉。留空則用預設的 {{site}}。",
+      "firstRunTitle": "選擇中轉站",
+      "firstRunBody": "貼上中轉站網域或完整網址，LoongPort 會自動移除路徑。留白將使用預設中轉站 {{site}}。",
       "title": "新增中轉站",
-      "body": "把另一個中轉站的網域貼進來。同一個站可以掛多個帳號 —— 登入不同帳號即可，重複的會自動合併。",
-      "connected": "已連上 {{name}}",
-      "inputLabel": "站點網域",
-      "inputLabelWithSponsors": "或手動輸入網域",
-      "inputHint": "例如 bestapi.store，或直接貼 https://bestapi.store/usage",
-      "sponsorsLabel": "推薦站點",
-      "sponsorAddAnother": "已有 {{count}} 個帳號 · 再加一個"
+      "body": "輸入另一個中轉站的網域。同一中轉站可新增多個帳號，重複帳號會自動合併。",
+      "connected": "已連線至 {{name}}",
+      "inputLabel": "中轉站網域",
+      "inputLabelWithSponsors": "或輸入中轉站網域",
+      "inputHint": "例如 bestapi.store，或 https://bestapi.store/usage",
+      "sponsorsLabel": "推薦中轉站",
+      "sponsorAddAnother": "已有 {{count}} 個帳號 · 再新增一個"
     },
     "vendor": {
-      "add": "新增官網帳號",
-      "empty": "還沒有新增任何官網帳號",
-      "remove": "刪除這個官網帳號（連帶它的設定）",
-      "removeConfirmTitle": "刪除這個官網帳號？",
-      "removeConfirmMessage": "會刪掉「{{label}}」的登入狀態與本機金鑰，連帶它在六個平台產生的設定。官網上那把 API 金鑰不會被刪，重新登入就能再用。",
+      "add": "新增服務商帳號",
+      "empty": "尚未新增服務商帳號",
+      "remove": "刪除服務商帳號與連線設定檔",
+      "removeConfirmTitle": "刪除此服務商帳號？",
+      "removeConfirmMessage": "將刪除「{{label}}」的登入資訊、本機 API 金鑰，以及為六個平台建立的連線設定檔。服務商網站上的 API 金鑰不會被刪除；之後可重新登入繼續使用。",
       "removed": "已刪除 {{label}}",
-      "noKey": "還沒備好金鑰",
-      "keyReady": "已備好 {{count}} 個平台的設定",
-      "keyCreated": "已在官網新建金鑰，並備好 {{count}} 個平台的設定",
-      "refreshKey": "重新備一次金鑰",
-      "sessionExpiredUsable": "登入已過期，但金鑰仍然可用（只是查不到餘額）。點這裡重新登入。",
-      "loginFailed": "登入沒能完成：{{reason}}",
-      "openKeyPage": "去官網刪除",
-      "userEditedHint": "這個帳號在目前這個應用下的設定你改過。「取得金鑰」不會覆寫它（只更新金鑰）。點這裡恢復預設設定。",
-      "editConfirmMessage": "儲存後這個帳號在目前這個應用下的設定就歸你自己維護：以後「取得金鑰」只會更新它的金鑰，不再覆寫你改的其它內容。\n\n如果改完連不上，用這一列上的「恢復預設設定」退回預設值（金鑰保留不變）。"
+      "noKey": "尚未設定 API 金鑰",
+      "keyReady": "已為 {{count}} 個平台建立連線設定檔",
+      "keyCreated": "已在服務商網站建立 API 金鑰，並為 {{count}} 個平台建立連線設定檔",
+      "refreshKey": "重新套用金鑰設定",
+      "sessionExpiredUsable": "登入已過期，但 API 金鑰仍可使用；暫時無法查詢餘額。點一下重新登入。",
+      "loginFailed": "登入失敗：{{reason}}",
+      "openKeyPage": "管理 API 金鑰",
+      "userEditedHint": "此服務商帳號在目前平台的連線設定檔包含手動修改。重新套用金鑰設定時只會更新 API 金鑰，不會覆蓋其他內容。點一下可還原預設設定。",
+      "editConfirmMessage": "儲存後，LoongPort 將不再覆蓋此服務商帳號在目前平台的手動修改；後續重新套用金鑰設定時只會更新 API 金鑰。\n\n若要撤銷修改，請選擇「還原預設設定」。API 金鑰會保留。"
     },
     "imageTab": {
-      "companionNotice": "這一頁不能單獨使用，要配合 codex 聊天一起用。",
-      "companionDetail": "生圖靠 LoongPort 自帶的工具（MCP）完成：你在 codex / claude 裡說「生成一張圖」，它就用這裡選定的檔位出圖。而對話仍走 Codex 標籤頁裡選的那個檔位 —— 兩者各自獨立，聊天可以用 DeepSeek 或任何別的站。",
-      "howTo": "換生圖檔位不用重啟 CLI，下一次生成就用新的。只有第一次有生圖檔位時要新開一個終端，讓 codex 讀到那個工具。",
-      "emptyTitle": "還沒有生圖檔位",
-      "emptyBody": "生圖檔位由「取得密鑰」自動識別：中轉站那邊有只掛 gpt-image 模型的分組時，它就出現在這裡。你的站點可能沒有提供生圖分組 —— 那樣這一頁保持空著就好，CLI 的設定裡不會多出任何東西。"
+      "companionNotice": "圖像生成需要搭配 Codex 或 Claude 使用。",
+      "companionDetail": "圖像生成會使用此頁面選取的連線設定檔；聊天則使用 Codex 或 Claude 頁面選取的連線設定檔，兩者互不影響。",
+      "howTo": "切換圖像生成連線設定檔後不必重新啟動，下次生成起生效。首次建立圖像生成連線設定檔後，請開啟新的終端機以載入圖像生成功能。",
+      "emptyTitle": "尚無圖像生成連線設定檔",
+      "emptyBody": "建立連線設定檔時，LoongPort 會識別只支援 gpt-image 模型的群組。若中轉站未提供這類群組，此頁面將保持空白。"
     },
     "modelVerification": {
       "title": "模型驗證",
-      "titleWithTier": "驗證模型 · {{tierName}}",
-      "description": "驗證這個供應商已設定的一個模型。",
-      "globalScopeNote": "對所有已設定模型啟用自動驗證。",
+      "titleWithTier": "模型驗證 · {{tierName}}",
+      "description": "驗證目前連線設定檔所選模型的回應特徵。",
+      "globalScopeNote": "自動驗證適用於所有已設定的模型。",
       "model": {
         "label": "選擇模型",
         "placeholder": "請選擇模型",
         "loading": "正在載入模型…",
         "empty": "沒有可驗證的模型",
-        "error": "模型清單載入失敗"
+        "error": "無法載入模型清單。請再試一次。"
       },
-      "actions": { "start": "開始驗證", "stop": "停止驗證", "retry": "重試" },
-      "status": { "running": "正在驗證 {{completed}} / {{total}}" },
+      "actions": {
+        "start": "開始驗證",
+        "stop": "停止驗證",
+        "retry": "再試一次"
+      },
+      "status": {
+        "running": "正在驗證 {{completed}} / {{total}}"
+      },
       "runtime": {
-        "autoLabel": "執行時自動檢測（全域）",
-        "autoHelp": "對所有中轉分組和模型生效。開啟後，LoongPort 會透過本機代理觀察 Codex 和 Claude 的實際回應；不會額外發送檢測請求，也不會保存對話內容。",
-        "loadError": "執行時檢測狀態載入失敗",
-        "anomalyToast": "{{app}} 的模型 {{model}} 檢測到異常，請開啟模型驗證查看。",
-        "apps": { "codex": "Codex", "claude": "Claude" },
-        "status": { "active": "已啟用", "waiting": "等待中", "error": "錯誤" }
+        "autoLabel": "自動驗證",
+        "autoHelp": "根據 Codex 與 Claude 的實際回應，自動驗證所有中轉站群組與模型；不會另外傳送驗證請求，也不會儲存對話內容。",
+        "loadError": "無法載入自動驗證狀態。請再試一次。",
+        "anomalyToast": "{{app}} 的模型 {{model}} 偵測到異常。請開啟模型驗證查看詳細資料。",
+        "apps": {
+          "codex": "Codex",
+          "claude": "Claude"
+        },
+        "status": {
+          "active": "已啟用",
+          "waiting": "等待可用回應",
+          "error": "執行異常"
+        }
       },
       "history": {
         "title": "最近 5 筆驗證記錄",
         "loading": "正在載入驗證記錄…",
-        "empty": "暫無驗證記錄",
-        "error": "驗證記錄載入失敗",
-        "source": { "active": "主動檢測", "runtime": "使用時檢測" }
+        "empty": "尚無驗證記錄",
+        "error": "無法載入驗證記錄。請再試一次。",
+        "source": {
+          "active": "目前驗證",
+          "runtime": "自動驗證"
+        }
       },
       "tierVerdict": {
-        "trusted": "模型已驗證",
-        "suspicious": "模型存疑",
-        "anomaly": "模型異常",
-        "trustedHint": "模型驗證通過，請點擊「模型驗證」查看詳情",
-        "suspiciousHint": "模型驗證結果存疑，請點擊「模型驗證」查看詳情",
-        "anomalyHint": "模型驗證發現異常，請點擊「模型驗證」查看詳情"
+        "trusted": "驗證通過",
+        "suspicious": "需要複核",
+        "anomaly": "偵測到異常",
+        "trustedHint": "現有證據已通過驗證。開啟「模型驗證」查看詳細資料。",
+        "suspiciousHint": "現有結果需要人工複核。開啟「模型驗證」查看詳細資料。",
+        "anomalyHint": "偵測到回應不一致。開啟「模型驗證」查看詳細資料。"
       },
       "verdict": {
-        "trusted": "可信",
-        "suspicious": "可疑",
-        "anomaly": "異常",
-        "inconclusive": "結論不足"
+        "trusted": "驗證通過",
+        "suspicious": "需要複核",
+        "anomaly": "偵測到異常",
+        "inconclusive": "證據不足"
       },
       "evidence": {
         "title": "驗證依據",
         "level": {
-          "cryptographic": "密碼學依據",
-          "protocolBehavior": "協定行為依據",
-          "insufficient": "依據不足"
+          "cryptographic": "加密證據",
+          "protocolBehavior": "通訊協定行為證據",
+          "insufficient": "證據不足"
         },
         "outcome": {
           "passed": "通過",
           "failed": "未通過",
-          "skipped": "已跳過"
+          "skipped": "已略過"
         },
         "fact": {
-          "basicEnvelope": "基礎回應結構",
-          "modelMatch": "模型身分",
+          "basicEnvelope": "基本回應結構",
+          "modelMatch": "模型識別",
           "streamLifecycle": "串流回應生命週期",
           "usageConsistency": "用量一致性",
           "toolCallShape": "工具呼叫結構",
           "structuredOutput": "結構化輸出",
-          "thinkingSignature": "推理特徵",
-          "signatureContinuation": "特徵延續",
-          "foreignProtocol": "外部協定",
-          "foreignSelfIdentification": "外部自我識別"
+          "thinkingSignature": "推理簽章",
+          "signatureContinuation": "簽章連續性",
+          "foreignProtocol": "其他通訊協定特徵",
+          "foreignSelfIdentification": "其他模型自我識別"
         }
       },
       "failure": {
-        "authentication": "驗證失敗",
-        "rateLimited": "供應商限制了本次驗證",
-        "insufficientBalance": "餘額不足，無法驗證此模型",
-        "network": "網路連線失敗",
-        "upstream": "供應商無法完成驗證",
-        "timeout": "驗證逾時",
-        "modelUnavailable": "此模型不可用",
-        "cancelled": "驗證已停止",
-        "invalidResponse": "供應商回傳了無效回應"
+        "authentication": "身分驗證失敗。請檢查登入資訊或 API 金鑰後再試一次。",
+        "rateLimited": "請求頻率受限。請稍後再試。",
+        "insufficientBalance": "餘額不足，無法驗證此模型。請儲值後再試。",
+        "network": "網路連線失敗。請檢查網路後再試。",
+        "upstream": "服務商暫時無法完成驗證。請稍後再試。",
+        "timeout": "驗證逾時。請稍後再試。",
+        "modelUnavailable": "此模型無法使用。請選擇其他模型。",
+        "cancelled": "驗證已停止。",
+        "invalidResponse": "服務商傳回的回應無法驗證。請稍後再試或人工複核。"
       }
     }
   }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -3064,192 +3064,209 @@
       "other": "其他"
     },
     "tierList": {
-      "empty": "还没有添加任何中转站",
+      "empty": "尚未添加中转站",
       "addSite": "添加中转站",
-      "refresh": "刷新档位与密钥"
+      "refresh": "更新接入配置"
     },
     "row": {
       "expand": "展开",
       "collapse": "折叠",
-      "notLoggedIn": "还没登录",
-      "login": "去登录",
+      "notLoggedIn": "未登录",
+      "login": "登录",
       "sessionExpired": "登录已过期",
       "reLogin": "重新登录",
-      "noTiers": "该账号在此平台下没有可用分组",
-      "getKeys": "获取密钥",
-      "tierCount": "{{count}} 个档位",
+      "noTiers": "此账号在当前平台没有可用分组",
+      "getKeys": "创建接入配置",
+      "tierCount": "{{count}} 个接入配置",
       "dragHandle": "拖动排序",
-      "refetchGroups": "重新拉取可用分组",
-      "purchaseHint": "点击充值（在应用内打开该站点的充值页）",
-      "lowBalanceHint": "余额不足 ${{threshold}}，点击充值",
-      "remove": "删除这个账号（连带它的档位）",
-      "removeBlockedByCurrent": "它有档位正在使用，先切到别的档位再删",
-      "removeConfirmTitle": "删除这个账号？",
-      "removeConfirmMessage": "会删掉「{{label}}」的登录态，连带它已生成的 {{count}} 个档位。已充值的余额留在中转站那边，重新登录就能再用。",
-      "removeConfirmMessageNeverLoggedIn": "会删掉「{{label}}」这一行，连带它已生成的 {{count}} 个档位。这个账号从没登录过，随时可以重新添加。"
+      "more": "更多操作",
+      "refetchGroups": "更新可用分组",
+      "purchaseHint": "打开中转站充值页面",
+      "lowBalanceHint": "余额低于 ${{threshold}}，点击充值",
+      "remove": "删除账号及接入配置",
+      "removeBlockedByCurrent": "此账号有接入配置正在使用，请先切换到其他接入配置",
+      "removeConfirmTitle": "删除此账号？",
+      "removeConfirmMessage": "将删除「{{label}}」的登录信息及其 {{count}} 个接入配置。中转站中的余额不会受影响；之后可重新登录恢复使用。",
+      "removeConfirmMessageNeverLoggedIn": "将删除「{{label}}」及其 {{count}} 个接入配置。之后可重新添加此账号。"
     },
     "tier": {
       "rateUnknown": "倍率未知",
       "rate": "{{value}} 倍",
       "models": "支持的模型",
-      "selectModel": "切换到模型 {{model}}",
+      "selectModel": "切换到 {{model}}",
       "modelSelected": "当前模型",
-      "switching": "切换中…",
-      "checkConnectivity": "检测连通",
+      "switching": "正在切换…",
+      "checkConnectivity": "测试连接",
       "resetConfig": "恢复默认配置",
       "resetConfirmTitle": "恢复默认配置？",
-      "resetConfirmMessage": "会用 LoongPort 的默认配置覆盖「{{name}}」的全部编辑，密钥保留不变。",
-      "resetConfirmButton": "恢复默认",
+      "resetConfirmMessage": "将使用 LoongPort 默认配置覆盖「{{name}}」的手动修改。API 密钥会保留。",
+      "resetConfirmButton": "恢复默认配置",
       "resetDone": "已恢复「{{name}}」的默认配置",
-      "edit": "编辑配置",
-      "editConfirmTitle": "手动编辑「{{name}}」的配置？",
-      "editConfirmMessage": "保存后这个档位就归你自己维护：以后「获取密钥」只会更新它的密钥，不再覆盖你改的其它内容。\n\n如果改完连不上，用档位行上的「恢复默认配置」退回默认值（密钥保留不变）。",
+      "edit": "编辑接入配置",
+      "editConfirmTitle": "编辑「{{name}}」的接入配置？",
+      "editConfirmMessage": "保存后，LoongPort 将不再覆盖此接入配置的手动修改；后续更新分组时只会更新 API 密钥。\n\n如需撤销修改，请选择“恢复默认配置”。API 密钥会保留。",
       "editConfirmButton": "继续编辑",
-      "userEdited": "已手动维护",
-      "userEditedHint": "这个档位的配置你改过。刷新分组不会覆盖它（只更新密钥）。点这里恢复默认配置。",
-      "editMissing": "这个档位的记录已经不在了，请点「获取密钥」重新生成。",
-      "editCurrentNote": "这是当前正在使用的档位。改完如果没生效，退出并重开 ChatGPT 桌面版 —— 它在跑的时候会把 codex 的配置改回去。"
+      "userEdited": "手动维护",
+      "userEditedHint": "此接入配置包含手动修改。更新分组时只会更新 API 密钥，不会覆盖其他内容。点击可恢复默认配置。",
+      "editMissing": "未找到此接入配置。请重新创建接入配置。",
+      "editCurrentNote": "这是正在使用的接入配置。若修改未生效，请退出并重新打开 ChatGPT 桌面版；运行中的 ChatGPT 可能会覆盖 Codex 配置。"
     },
     "stats": {
       "title": "帮助改进 LoongPort",
-      "intro": "我们想知道大家实际在用哪些中转站，据此决定优先适配谁。",
-      "sendsLabel": "会上报",
-      "sendsBody": "你添加的中转站域名、账号个数、应用版本与操作系统类型。",
-      "neverLabel": "不会上报",
-      "neverBody": "账号、邮箱、余额、密钥、用量记录。",
-      "canChange": "可以随时在「设置 → 通用」里关掉。",
-      "accept": "好",
-      "decline": "不参与",
-      "idNote": "会带一个随机生成的安装标识（用于去重统计，与你在中转站的账号无关）。"
+      "intro": "为了确定优先适配的中转站，我们希望了解 LoongPort 的实际使用情况。",
+      "sendsLabel": "将收集",
+      "sendsBody": "已添加的中转站域名、账号数量、应用版本和操作系统类型。",
+      "neverLabel": "不会收集",
+      "neverBody": "账号登录信息、电子邮箱、余额、API 密钥和用量记录。",
+      "canChange": "可随时在“设置 → 通用”中更改此选项。",
+      "accept": "允许分享",
+      "decline": "不分享",
+      "idNote": "数据包含随机生成的安装标识，仅用于去重统计，与中转站账号无关。"
     },
     "site": {
       "removed": "已移除 {{label}}"
     },
     "session": {
-      "expired": "{{count}} 个账号的登录已失效，请重新登录",
-      "connected": "已连接，正在获取密钥…（登录窗口可以自己关掉）"
+      "expired": "{{count}} 个账号的登录已过期，请重新登录",
+      "connected": "已连接，正在创建接入配置。现在可以关闭登录窗口。"
     },
     "provision": {
-      "ready": "已备好 {{count}} 个档位",
-      "readyWithKeys": "已备好 {{count}} 个档位，新建 {{keys}} 把密钥",
-      "landedOnOtherPlatforms": "这个账号有 {{count}} 个分组，但都不属于当前这个 CLI。切到上方对应的标签页查看。",
+      "ready": "已同步 {{count}} 个接入配置",
+      "readyWithKeys": "已同步 {{count}} 个接入配置，其中创建了 {{keys}} 个 API 密钥",
+      "landedOnOtherPlatforms": "此账号有 {{count}} 个分组，但均不适用于当前平台。请切换到上方对应的平台查看。",
       "groupFailed": "{{group}}：{{reason}}",
-      "mergedProviders": "已从 cc-switch 收编 {{count}} 个重复配置",
-      "refreshed": "已刷新 {{relays}} 个中转站，共 {{tiers}} 个档位",
-      "refreshFailedWithReason": "{{name}} 刷新失败：{{reason}}",
-      "refreshedWithKeys": "已刷新 {{relays}} 个中转站，共 {{tiers}} 个档位，新建 {{keys}} 把密钥"
+      "mergedProviders": "已合并 {{count}} 个重复配置",
+      "refreshed": "已更新 {{relays}} 个中转站，共同步 {{tiers}} 个接入配置",
+      "refreshFailedWithReason": "无法更新 {{name}}：{{reason}}",
+      "refreshedWithKeys": "已更新 {{relays}} 个中转站，共同步 {{tiers}} 个接入配置，其中创建了 {{keys}} 个 API 密钥"
     },
     "switch": {
-      "done": "已切换到 {{name}}",
-      "doneRelaunched": "已切换到 {{name}}，已重新打开 ChatGPT",
-      "doneNeedsRestart": "已切换到 {{name}}，请手动重启 ChatGPT",
-      "modelDone": "已切换到 {{name}} 的模型 {{model}}",
-      "modelDoneRelaunched": "已切换到 {{name}} 的模型 {{model}}，已重新打开 ChatGPT",
-      "modelDoneNeedsRestart": "已切换到 {{name}} 的模型 {{model}}，请手动重启 ChatGPT"
+      "done": "已切换至 {{name}}",
+      "doneRelaunched": "已切换至 {{name}}，并重新打开 ChatGPT",
+      "doneNeedsRestart": "已切换至 {{name}}。请手动重启 ChatGPT",
+      "modelDone": "已将 {{name}} 切换至模型 {{model}}",
+      "modelDoneRelaunched": "已将 {{name}} 切换至模型 {{model}}，并重新打开 ChatGPT",
+      "modelDoneNeedsRestart": "已将 {{name}} 切换至模型 {{model}}。请手动重启 ChatGPT"
     },
     "official": {
-      "button": "切回官方登录",
-      "hint": "清掉 LoongPort 写入的路由，改用你自己的 ChatGPT 账号",
-      "confirmTitle": "切回官方登录？",
-      "confirmMessage": "会退出 ChatGPT、清掉 LoongPort 写入的路由配置，并删除当前的 codex 登录态（删前会自动备份）。之后需要你自己登录 ChatGPT。",
-      "confirmButton": "切回官方",
-      "done": "已切回官方登录，请自己登录 ChatGPT",
-      "doneWithBackup": "已切回官方登录。原登录态已备份到 {{path}}"
+      "button": "恢复官方登录",
+      "hint": "移除 LoongPort 路由，改用 ChatGPT 官方账号登录",
+      "confirmTitle": "恢复官方登录？",
+      "confirmMessage": "将退出 ChatGPT，移除 LoongPort 路由，并在备份后删除当前 Codex 登录状态。完成后需要重新登录 ChatGPT。",
+      "confirmButton": "恢复官方登录",
+      "done": "已恢复官方登录。请重新登录 ChatGPT",
+      "doneWithBackup": "已恢复官方登录。原登录状态已备份至 {{path}}"
     },
     "quitConfirm": {
-      "title": "切换到 {{name}}",
-      "body": "ChatGPT 启动时才读取配置，所以要先退出它、切换完再打开。",
-      "declineNote": "如果它有进行中的对话，会弹出确认框 —— 在那里点取消的话，本次切换会中止、配置不会改动。",
-      "forceKillWarning": "⚠️ Windows 上只能强制关闭 ChatGPT（它不响应普通的关闭请求），不会提示你保存 —— 有正在进行的对话请先自己保存。关掉后会再帮你打开。",
-      "platformNote": "万一没能替你关掉，配置仍会切好，只需你手动重启 ChatGPT。",
-      "switchOnly": "只切换，我自己重启",
-      "quitAndSwitch": "退出并切换"
+      "title": "切换至 {{name}}",
+      "body": "ChatGPT 仅在启动时读取接入配置。LoongPort 将先退出 ChatGPT，完成切换后再重新打开。",
+      "declineNote": "在 macOS 上，若 ChatGPT 有进行中的对话，系统可能显示退出确认框。选择“取消”将中止切换，配置不会更改。",
+      "forceKillWarning": "⚠️ Windows 上需要强制关闭 ChatGPT，且不会显示保存提醒。请先保存正在进行的对话；切换完成后 LoongPort 会重新打开 ChatGPT。",
+      "platformNote": "如果 LoongPort 无法关闭 ChatGPT，接入配置仍会完成切换。请手动重启 ChatGPT 使其生效。",
+      "switchOnly": "仅切换",
+      "quitAndSwitch": "退出 ChatGPT 并切换"
     },
     "addSite": {
-      "firstRunTitle": "选择服务站点",
-      "firstRunBody": "把中转站的域名粘进来就行 —— 从浏览器地址栏直接复制也可以，网址后面的路径会自动去掉。留空则用默认的 {{site}}。",
+      "firstRunTitle": "选择中转站",
+      "firstRunBody": "粘贴中转站域名或完整网址，LoongPort 会自动移除路径。留空将使用默认中转站 {{site}}。",
       "title": "添加中转站",
-      "body": "把另一个中转站的域名粘进来。同一个站可以挂多个账号 —— 登录不同账号即可，重复的会自动合并。",
-      "connected": "已连上 {{name}}",
-      "inputLabel": "站点域名",
-      "inputLabelWithSponsors": "或手动输入域名",
-      "inputHint": "例如 bestapi.store，或直接粘 https://bestapi.store/usage",
-      "sponsorsLabel": "推荐站点",
-      "sponsorAddAnother": "已有 {{count}} 个账号 · 再加一个"
+      "body": "输入另一个中转站的域名。同一中转站可添加多个账号，重复账号会自动合并。",
+      "connected": "已连接 {{name}}",
+      "inputLabel": "中转站域名",
+      "inputLabelWithSponsors": "或输入中转站域名",
+      "inputHint": "例如 bestapi.store，或 https://bestapi.store/usage",
+      "sponsorsLabel": "推荐中转站",
+      "sponsorAddAnother": "已有 {{count}} 个账号 · 再添加一个"
     },
     "vendor": {
-      "add": "添加官网账号",
-      "empty": "还没有添加任何官网账号",
-      "remove": "删除这个官网账号（连带它的配置）",
-      "removeConfirmTitle": "删除这个官网账号？",
-      "removeConfirmMessage": "会删掉「{{label}}」的登录态与本地密钥，连带它在六个平台生成的配置。官网上那把 API key 不会被删，重新登录就能再用。",
+      "add": "添加服务商账号",
+      "empty": "尚未添加服务商账号",
+      "remove": "删除服务商账号及接入配置",
+      "removeConfirmTitle": "删除此服务商账号？",
+      "removeConfirmMessage": "将删除「{{label}}」的登录信息、本地 API 密钥及其为六个平台生成的接入配置。服务商网站上的 API 密钥不会被删除；之后可重新登录恢复使用。",
       "removed": "已删除 {{label}}",
-      "noKey": "还没备好密钥",
-      "keyReady": "已备好 {{count}} 个平台的配置",
-      "keyCreated": "已在官网新建密钥，并备好 {{count}} 个平台的配置",
-      "refreshKey": "重新备一次密钥",
-      "sessionExpiredUsable": "登录已过期，但密钥仍然可用（只是查不到余额）。点这里重新登录。",
-      "loginFailed": "登录没能完成：{{reason}}",
-      "openKeyPage": "去官网删除",
-      "userEditedHint": "这个账号在当前这个应用下的配置你改过。「获取密钥」不会覆盖它（只更新密钥）。点这里恢复默认配置。",
-      "editConfirmMessage": "保存后这个账号在当前这个应用下的配置就归你自己维护：以后「获取密钥」只会更新它的密钥，不再覆盖你改的其它内容。\n\n如果改完连不上，用这一行上的「恢复默认配置」退回默认值（密钥保留不变）。"
+      "noKey": "尚未配置 API 密钥",
+      "keyReady": "已为 {{count}} 个平台创建接入配置",
+      "keyCreated": "已在服务商网站创建 API 密钥，并为 {{count}} 个平台创建接入配置",
+      "refreshKey": "重新应用密钥配置",
+      "sessionExpiredUsable": "登录已过期，但 API 密钥仍可使用；余额暂时无法查询。点击重新登录。",
+      "loginFailed": "登录失败：{{reason}}",
+      "openKeyPage": "管理 API 密钥",
+      "userEditedHint": "此服务商账号在当前平台的接入配置包含手动修改。重新应用密钥配置时只会更新 API 密钥，不会覆盖其他内容。点击可恢复默认配置。",
+      "editConfirmMessage": "保存后，LoongPort 将不再覆盖此服务商账号在当前平台的手动修改；后续重新应用密钥配置时只会更新 API 密钥。\n\n如需撤销修改，请选择“恢复默认配置”。API 密钥会保留。"
     },
     "imageTab": {
-      "companionNotice": "这一页不能单独使用，要配合 codex 聊天一起用。",
-      "companionDetail": "生图靠 LoongPort 自带的工具（MCP）完成：你在 codex / claude 里说「生成一张图」，它就用这里选定的档位出图。而对话仍走 Codex 标签页里选的那个档位 —— 两者各自独立，聊天可以用 DeepSeek 或任何别的站。",
-      "howTo": "换生图档位不用重启 CLI，下一次生成就用新的。只有第一次有生图档位时要新开一个终端，让 codex 读到那个工具。",
-      "emptyTitle": "还没有生图档位",
-      "emptyBody": "生图档位由「获取密钥」自动识别：中转站那边有只挂 gpt-image 模型的分组时，它就出现在这里。你的站点可能没有提供生图分组 —— 那样这一页保持空着就好，CLI 的配置里不会多出任何东西。"
+      "companionNotice": "图像生成需要与 Codex 或 Claude 配合使用。",
+      "companionDetail": "图像生成使用此页面选择的接入配置；聊天使用 Codex 或 Claude 页面选择的接入配置，两者互不影响。",
+      "howTo": "切换图像生成接入配置后无需重启，下次生成起生效。首次创建图像生成接入配置后，请新开终端以加载图像生成功能。",
+      "emptyTitle": "尚无图像生成接入配置",
+      "emptyBody": "创建接入配置时，LoongPort 会识别仅支持 gpt-image 模型的分组。若中转站未提供这类分组，本页将保持为空。"
     },
     "modelVerification": {
       "title": "模型验证",
-      "titleWithTier": "验证模型 · {{tierName}}",
-      "description": "验证这个供应商已配置的一个模型。",
-      "globalScopeNote": "对所有已配置模型启用自动验证。",
+      "titleWithTier": "模型验证 · {{tierName}}",
+      "description": "验证当前接入配置所选模型的响应特征。",
+      "globalScopeNote": "自动验证适用于所有已配置的模型。",
       "model": {
         "label": "选择模型",
         "placeholder": "请选择模型",
         "loading": "正在加载模型…",
         "empty": "没有可验证的模型",
-        "error": "模型列表加载失败"
+        "error": "无法加载模型列表。请重试。"
       },
-      "actions": { "start": "开始验证", "stop": "停止验证", "retry": "重试" },
-      "status": { "running": "正在验证 {{completed}} / {{total}}" },
+      "actions": {
+        "start": "开始验证",
+        "stop": "停止验证",
+        "retry": "重试"
+      },
+      "status": {
+        "running": "正在验证 {{completed}} / {{total}}"
+      },
       "runtime": {
-        "autoLabel": "运行时自动检测（全局）",
-        "autoHelp": "对所有中转分组和模型生效。开启后，LoongPort 会通过本地代理观察 Codex 和 Claude 的实际响应；不会额外发送检测请求，也不会保存对话内容。",
-        "loadError": "运行时检测状态加载失败",
-        "anomalyToast": "{{app}} 的模型 {{model}} 检测到异常，请打开模型验证查看。",
-        "apps": { "codex": "Codex", "claude": "Claude" },
-        "status": { "active": "已启用", "waiting": "等待中", "error": "异常" }
+        "autoLabel": "自动验证",
+        "autoHelp": "根据 Codex 和 Claude 的实际响应自动验证所有中转站分组和模型；不额外发送验证请求，也不保存对话内容。",
+        "loadError": "无法加载自动验证状态。请重试。",
+        "anomalyToast": "{{app}} 的模型 {{model}} 检测到异常。请打开模型验证查看详情。",
+        "apps": {
+          "codex": "Codex",
+          "claude": "Claude"
+        },
+        "status": {
+          "active": "已启用",
+          "waiting": "等待可用响应",
+          "error": "运行异常"
+        }
       },
       "history": {
         "title": "最近 5 条验证记录",
         "loading": "正在加载验证记录…",
         "empty": "暂无验证记录",
-        "error": "验证记录加载失败",
-        "source": { "active": "主动检测", "runtime": "使用时检测" }
+        "error": "无法加载验证记录。请重试。",
+        "source": {
+          "active": "当前验证",
+          "runtime": "自动验证"
+        }
       },
       "tierVerdict": {
-        "trusted": "模型已验证",
-        "suspicious": "模型存疑",
-        "anomaly": "模型异常",
-        "trustedHint": "模型验证通过，请点击「模型验证」查看详情",
-        "suspiciousHint": "模型验证结果存疑，请点击「模型验证」查看详情",
-        "anomalyHint": "模型验证发现异常，请点击「模型验证」查看详情"
+        "trusted": "验证通过",
+        "suspicious": "需要复核",
+        "anomaly": "检测到异常",
+        "trustedHint": "现有证据验证通过。打开“模型验证”查看详情。",
+        "suspiciousHint": "现有结果需要人工复核。打开“模型验证”查看详情。",
+        "anomalyHint": "检测到响应不一致。打开“模型验证”查看详情。"
       },
       "verdict": {
-        "trusted": "可信",
-        "suspicious": "可疑",
-        "anomaly": "异常",
-        "inconclusive": "结论不足"
+        "trusted": "验证通过",
+        "suspicious": "需要复核",
+        "anomaly": "检测到异常",
+        "inconclusive": "证据不足"
       },
       "evidence": {
         "title": "验证依据",
         "level": {
-          "cryptographic": "密码学依据",
-          "protocolBehavior": "协议行为依据",
-          "insufficient": "依据不足"
+          "cryptographic": "加密证据",
+          "protocolBehavior": "协议行为证据",
+          "insufficient": "证据不足"
         },
         "outcome": {
           "passed": "通过",
@@ -3258,27 +3275,27 @@
         },
         "fact": {
           "basicEnvelope": "基础响应结构",
-          "modelMatch": "模型身份",
+          "modelMatch": "模型标识",
           "streamLifecycle": "流式响应生命周期",
           "usageConsistency": "用量一致性",
           "toolCallShape": "工具调用结构",
           "structuredOutput": "结构化输出",
-          "thinkingSignature": "推理特征",
-          "signatureContinuation": "特征延续",
-          "foreignProtocol": "外部协议",
-          "foreignSelfIdentification": "外部自我标识"
+          "thinkingSignature": "推理签名",
+          "signatureContinuation": "签名连续性",
+          "foreignProtocol": "其他协议特征",
+          "foreignSelfIdentification": "其他模型自我标识"
         }
       },
       "failure": {
-        "authentication": "认证失败",
-        "rateLimited": "供应商限制了本次验证",
-        "insufficientBalance": "余额不足，无法验证此模型",
-        "network": "网络连接失败",
-        "upstream": "供应商无法完成验证",
-        "timeout": "验证超时",
-        "modelUnavailable": "此模型不可用",
-        "cancelled": "验证已停止",
-        "invalidResponse": "供应商返回了无效响应"
+        "authentication": "身份验证失败。请检查登录信息或 API 密钥后重试。",
+        "rateLimited": "请求频率受限。请稍后重试。",
+        "insufficientBalance": "余额不足，无法验证此模型。请充值后重试。",
+        "network": "网络连接失败。请检查网络后重试。",
+        "upstream": "服务商暂时无法完成验证。请稍后重试。",
+        "timeout": "验证超时。请稍后重试。",
+        "modelUnavailable": "此模型不可用。请选择其他模型。",
+        "cancelled": "验证已停止。",
+        "invalidResponse": "服务商返回的响应无法验证。请稍后重试或人工复核。"
       }
     }
   }

--- a/tests/config/loongportLocales.test.ts
+++ b/tests/config/loongportLocales.test.ts
@@ -251,6 +251,18 @@ function interpolationVariables(value: string): string[] {
   ).sort();
 }
 
+function flattenStringValues(root: unknown): string[] {
+  if (typeof root === "string") return [root];
+  if (root == null || typeof root !== "object") return [];
+  return Object.values(root as Translations).flatMap(flattenStringValues);
+}
+
+function visibleCopy(root: unknown): string {
+  return flattenStringValues(root)
+    .map((value) => value.replace(/\{\{[^}]+\}\}/g, ""))
+    .join("\n");
+}
+
 describe("LoongPort tier page locale coverage", () => {
   it.each(locales)("defines every loongport key in %s", (_locale, ns) => {
     const missing = requiredKeys.filter((key) => {
@@ -277,6 +289,148 @@ describe("LoongPort tier page locale coverage", () => {
       });
 
       expect(mismatched).toEqual([]);
+    },
+  );
+
+  it.each([
+    ["zh", zh.loongport, "接入配置", /档位/u],
+    ["zh-TW", zhTW.loongport, "連線設定檔", /檔位|方案/u],
+    ["en", en.loongport, "connection profile", /\btier(?:s)?\b/iu],
+    ["ja", ja.loongport, "接続プロファイル", /プラン|ティア|枠/u],
+  ] as const)(
+    "%s uses the approved connection-profile terminology",
+    (_locale, ns, approvedTerm, deprecatedTerm) => {
+      const copy = visibleCopy(ns);
+
+      expect(copy).toContain(approvedTerm);
+      expect(copy).not.toMatch(deprecatedTerm);
+    },
+  );
+
+  it.each([
+    ["zh", zh.loongport, /去登录|收编|会上报|不会上报|本地代理观察/u],
+    ["zh-TW", zhTW.loongport, /去登入|收編|會上報|不會上報|本機代理/u],
+    ["en", en.loongport, /Get keys|Re-fetch available groups|local proxy/iu],
+    ["ja", ja.loongport, /キーを取得|ローカルプロキシ/u],
+  ] as const)(
+    "%s omits internal and conversational wording",
+    (_locale, ns, deprecatedWording) => {
+      expect(visibleCopy(ns)).not.toMatch(deprecatedWording);
+    },
+  );
+
+  it.each([
+    [
+      "zh",
+      zh.loongport,
+      {
+        trusted: "验证通过",
+        suspicious: "需要复核",
+        anomaly: "检测到异常",
+        inconclusive: "证据不足",
+      },
+    ],
+    [
+      "zh-TW",
+      zhTW.loongport,
+      {
+        trusted: "驗證通過",
+        suspicious: "需要複核",
+        anomaly: "偵測到異常",
+        inconclusive: "證據不足",
+      },
+    ],
+    [
+      "en",
+      en.loongport,
+      {
+        trusted: "Verified",
+        suspicious: "Review needed",
+        anomaly: "Anomaly detected",
+        inconclusive: "Insufficient evidence",
+      },
+    ],
+    [
+      "ja",
+      ja.loongport,
+      {
+        trusted: "検証済み",
+        suspicious: "要確認",
+        anomaly: "異常を検出",
+        inconclusive: "証拠不足",
+      },
+    ],
+  ] as const)(
+    "%s keeps the approved model-verification verdict semantics",
+    (_locale, ns, expectedVerdicts) => {
+      expect(ns.modelVerification.verdict).toMatchObject(expectedVerdicts);
+    },
+  );
+
+  it.each([
+    [
+      "zh",
+      zh.loongport,
+      {
+        sendsLabel: "将收集",
+        neverLabel: "不会收集",
+        accept: "允许分享",
+        decline: "不分享",
+        noExtraRequest: "不额外发送验证请求",
+        noConversationStorage: "不保存对话内容",
+      },
+    ],
+    [
+      "zh-TW",
+      zhTW.loongport,
+      {
+        sendsLabel: "將收集",
+        neverLabel: "不會收集",
+        accept: "允許分享",
+        decline: "不分享",
+        noExtraRequest: "不會另外傳送驗證請求",
+        noConversationStorage: "不會儲存對話內容",
+      },
+    ],
+    [
+      "en",
+      en.loongport,
+      {
+        sendsLabel: "Will collect",
+        neverLabel: "Will not collect",
+        accept: "Allow sharing",
+        decline: "Don't share",
+        noExtraRequest: "does not send additional verification requests",
+        noConversationStorage: "does not save conversation content",
+      },
+    ],
+    [
+      "ja",
+      ja.loongport,
+      {
+        sendsLabel: "収集する情報",
+        neverLabel: "収集しない情報",
+        accept: "共有を許可",
+        decline: "共有しない",
+        noExtraRequest: "追加の検証リクエストは送信せず",
+        noConversationStorage: "会話内容は保存しません",
+      },
+    ],
+  ] as const)(
+    "%s states the approved privacy facts and consent actions",
+    (_locale, ns, expected) => {
+      expect(ns.stats).toMatchObject({
+        sendsLabel: expected.sendsLabel,
+        neverLabel: expected.neverLabel,
+        accept: expected.accept,
+        decline: expected.decline,
+      });
+      expect(ns.modelVerification.runtime.autoHelp).toContain(
+        expected.noExtraRequest,
+      );
+      expect(ns.modelVerification.runtime.autoHelp).toContain(
+        expected.noConversationStorage,
+      );
     },
   );
 });


### PR DESCRIPTION
## Summary

- standardize all LoongPort user-facing copy across Simplified Chinese, Traditional Chinese, English, and Japanese
- replace internal or ambiguous terminology with mature product language while leaving CC Switch copy unchanged
- move relay-group refresh and vendor key reapplication behind clearly labeled action menus
- add locale terminology, privacy, platform-warning, and action-menu regression coverage

## Impact

LoongPort now uses consistent terminology for relay services, groups, connection profiles, API keys, providers, and verification verdicts. Windows/macOS switching warnings and automatic-verification privacy statements remain explicit and platform-accurate.

## Validation

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm exec vitest run` — 121 files, 762 tests
- `pnpm build:renderer`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- four-locale key/interpolation/boundary/terminology audit
