### PR TITLE
feat(codex): restore million-token context opt-in

### DIFF
--- a/src/components/providers/forms/CodexConfigSections.tsx
+++ b/src/components/providers/forms/CodexConfigSections.tsx
@@ -1,6 +1,3 @@
-// NOTE: Codex 1M 上下文 UI 已暂时隐藏（详见下方 CodexConfigSection 内 JSX 注释）。
-// 如需恢复，请同时：
-//   - 取消下面 `@/utils/providerConfigUtils` import 的注释
 import React, {
   useCallback,
   useEffect,
@@ -11,18 +8,18 @@ import React, {
 import { useTranslation } from "react-i18next";
 import JsonEditor from "@/components/JsonEditor";
 import {
+  extractCodexTopLevelInt,
   isCodexGoalModeEnabled,
   isCodexRemoteCompactionEnabled,
+  removeCodexTopLevelField,
   setCodexGoalMode,
   setCodexRemoteCompaction,
-} from "@/utils/providerConfigUtils";
-/*
-import {
-  extractCodexTopLevelInt,
   setCodexTopLevelInt,
-  removeCodexTopLevelField,
 } from "@/utils/providerConfigUtils";
-*/
+
+const MILLION_CONTEXT_WINDOW = 1_050_000;
+const LEGACY_MILLION_CONTEXT_WINDOW = 1_000_000;
+const MILLION_CONTEXT_COMPACT_LIMIT = 900_000;
 
 interface CodexAuthSectionProps {
   value: string;
@@ -196,9 +193,7 @@ export const CodexConfigSection: React.FC<CodexConfigSectionProps> = ({
     [handleLocalChange, providerName],
   );
 
-  // Codex 1M 上下文相关状态/回调暂时禁用——见同文件下方 JSX 注释处的恢复说明。
-  /*
-  // Parse toggle states from TOML text
+  // Parse million-token context opt-in from top-level TOML fields.
   const toggleStates = useMemo(() => {
     const contextWindow = extractCodexTopLevelInt(
       localValue,
@@ -209,8 +204,10 @@ export const CodexConfigSection: React.FC<CodexConfigSectionProps> = ({
       "model_auto_compact_token_limit",
     );
     return {
-      contextWindow1M: contextWindow === 1000000,
-      compactLimit: compactLimit ?? 900000,
+      contextWindow1M:
+        contextWindow !== undefined &&
+        contextWindow >= LEGACY_MILLION_CONTEXT_WINDOW,
+      compactLimit: compactLimit ?? MILLION_CONTEXT_COMPACT_LIMIT,
     };
   }, [localValue]);
 
@@ -221,7 +218,11 @@ export const CodexConfigSection: React.FC<CodexConfigSectionProps> = ({
     (checked: boolean) => {
       let toml = localValueRef.current || "";
       if (checked) {
-        toml = setCodexTopLevelInt(toml, "model_context_window", 1000000);
+        toml = setCodexTopLevelInt(
+          toml,
+          "model_context_window",
+          MILLION_CONTEXT_WINDOW,
+        );
         // Auto-set compact limit if not already present
         if (
           extractCodexTopLevelInt(toml, "model_auto_compact_token_limit") ===
@@ -230,7 +231,7 @@ export const CodexConfigSection: React.FC<CodexConfigSectionProps> = ({
           toml = setCodexTopLevelInt(
             toml,
             "model_auto_compact_token_limit",
-            900000,
+            MILLION_CONTEXT_COMPACT_LIMIT,
           );
         }
       } else {
@@ -265,7 +266,6 @@ export const CodexConfigSection: React.FC<CodexConfigSectionProps> = ({
   useEffect(() => {
     return () => clearTimeout(compactTimerRef.current);
   }, []);
-  */
 
   return (
     <div className="space-y-2">
@@ -331,8 +331,6 @@ export const CodexConfigSection: React.FC<CodexConfigSectionProps> = ({
         </p>
       )}
 
-      {/* Codex 1M 上下文 UI 已隐藏：模型不再支持该字段。
-          恢复方法：(1) 取消本段 JSX 注释；(2) 取消文件顶部 import 中 useMemo / extractCodexTopLevelInt / setCodexTopLevelInt / removeCodexTopLevelField 的注释；(3) 取消下方 toggleStates / compactTimerRef / handleContextWindowToggle / handleCompactLimitChange / cleanup useEffect 的注释。
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
         <label className="inline-flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
           <input
@@ -357,7 +355,6 @@ export const CodexConfigSection: React.FC<CodexConfigSectionProps> = ({
           />
         </label>
       </div>
-      */}
 
       <JsonEditor
         value={localValue}

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -1610,14 +1610,14 @@ model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 disable_response_storage = true
 personality = "pragmatic"
+model_context_window = 1050000
+model_auto_compact_token_limit = 900000
 
 [model_providers.custom]
 name = "E-FlowCode"
 base_url = "https://e-flowcode.cc/v1"
 wire_api = "responses"
-requires_openai_auth = true
-model_context_window = 1000000
-model_auto_compact_token_limit = 9000000`,
+requires_openai_auth = true`,
     category: "third_party",
     endpointCandidates: ["https://e-flowcode.cc/v1"],
     icon: "eflowcode",

--- a/tests/components/CodexConfigSections.test.tsx
+++ b/tests/components/CodexConfigSections.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { parse as parseToml } from "smol-toml";
+import { describe, expect, it, vi } from "vitest";
+import { CodexConfigSection } from "@/components/providers/forms/CodexConfigSections";
+
+vi.mock("@/components/JsonEditor", () => ({
+  default: ({ value }: { value: string }) => (
+    <textarea aria-label="config-editor" value={value} readOnly />
+  ),
+}));
+
+function renderSection(value: string, onChange = vi.fn()) {
+  render(
+    <CodexConfigSection
+      value={value}
+      onChange={onChange}
+      useCommonConfig={false}
+      onCommonConfigToggle={() => {}}
+      onEditCommonConfig={() => {}}
+    />,
+  );
+  return onChange;
+}
+
+describe("CodexConfigSection million-token opt-in", () => {
+  it("recognizes the legacy 1,000,000-token opt-in", () => {
+    renderSection(`model_context_window = 1000000
+model_auto_compact_token_limit = 900000`);
+
+    expect(
+      screen.getByRole("checkbox", {
+        name: "codexConfig.contextWindow1M",
+      }),
+    ).toBeChecked();
+  });
+
+  it("is disabled by default and writes aligned top-level limits when enabled", async () => {
+    const user = userEvent.setup();
+    const onChange = renderSection(`model = "gpt-5.6-sol"
+
+[model_providers.custom]
+name = "custom"
+base_url = "https://example.com/v1"`);
+
+    const toggle = screen.getByRole("checkbox", {
+      name: "codexConfig.contextWindow1M",
+    });
+    expect(toggle).not.toBeChecked();
+
+    await user.click(toggle);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const parsed = parseToml(onChange.mock.calls[0][0]) as {
+      model_context_window?: number;
+      model_auto_compact_token_limit?: number;
+      model_providers?: { custom?: Record<string, unknown> };
+    };
+    expect(parsed.model_context_window).toBe(1_050_000);
+    expect(parsed.model_auto_compact_token_limit).toBe(900_000);
+    expect(
+      parsed.model_providers?.custom?.model_context_window,
+    ).toBeUndefined();
+    expect(
+      parsed.model_providers?.custom?.model_auto_compact_token_limit,
+    ).toBeUndefined();
+  });
+});

--- a/tests/config/codexProviderPresets.contextWindow.test.ts
+++ b/tests/config/codexProviderPresets.contextWindow.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { parse as parseToml } from "smol-toml";
+import {
+  codexProviderPresets,
+  generateThirdPartyConfig,
+} from "@/config/codexProviderPresets";
+
+describe("Codex provider context-window presets", () => {
+  it("keeps generic third-party configs capability-driven", () => {
+    const parsed = parseToml(
+      generateThirdPartyConfig(
+        "custom",
+        "https://example.com/v1",
+        "gpt-5.6-sol",
+      ),
+    ) as Record<string, unknown>;
+
+    expect(parsed.model_context_window).toBeUndefined();
+    expect(parsed.model_auto_compact_token_limit).toBeUndefined();
+  });
+
+  it("places E-FlowCode's verified million-token opt-in at TOML top level", () => {
+    const preset = codexProviderPresets.find(
+      (candidate) => candidate.name === "E-FlowCode",
+    );
+    expect(preset).toBeDefined();
+
+    const parsed = parseToml(preset!.config) as {
+      model_context_window?: number;
+      model_auto_compact_token_limit?: number;
+      model_providers?: {
+        custom?: Record<string, unknown>;
+      };
+    };
+
+    expect(parsed.model_context_window).toBe(1_050_000);
+    expect(parsed.model_auto_compact_token_limit).toBe(900_000);
+    expect(
+      parsed.model_providers?.custom?.model_context_window,
+    ).toBeUndefined();
+    expect(
+      parsed.model_providers?.custom?.model_auto_compact_token_limit,
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary / 概述

- 恢复 Codex 百万上下文高级选项，默认保持关闭，避免对不支持的供应商强行写入上下文参数。
- 启用时写入 `model_context_window = 1050000` 与 `model_auto_compact_token_limit = 900000`，并兼容旧的 `1000000` 配置。
- 修正 E-FlowCode preset：字段移到 TOML 顶层，修复百万上下文与自动压缩阈值。
- 增加 UI 与 preset 回归测试。

## Related Issue / 关联 Issue

Fixes #

## Screenshots / 截图

不适用：本次为配置行为与回归测试修复。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（未新增文案，沿用现有翻译）

验证补充：
- `pnpm test:unit`: 123 个测试文件，766/766 通过。
- `cargo test -- --skip services::provider::tests::update_current_claude_desktop_provider_syncs_profile_when_proxy_takeover_is_active`: 其余完整 Rust 测试通过。
- 未关闭正在运行的 LoongPort；被跳过的 Rust 测试依赖 `127.0.0.1:15721` 空闲环境。
