### PR TITLE
fix(relay): reuse browser session and centralize diagnostics

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,0 +1,101 @@
+# 诊断日志规范
+
+LoongPort 的诊断日志必须同时满足两个目标：**发生故障时能还原阶段与根因**，以及
+**任何凭据和请求/响应正文都不能进入日志文件**。本页是新增日志和排查日志缺口时的
+维护约定。
+
+## 日志位置与保留
+
+Rust 后端和 WebView 前端统一写入：
+
+```text
+<app_config_dir>/logs/loongport.log
+```
+
+崩溃时另写 `<app_config_dir>/crash.log`，其 panic message 同样复用统一脱敏策略。
+
+默认单文件上限 20 MiB，保留 4 个轮转归档；当前文件与归档合计最多约 100 MiB。
+日志级别由应用设置动态控制，默认 `info`。
+
+## 唯一安全出口
+
+- Rust：`src-tauri/src/diagnostics.rs` 的 `format_log_line` 是
+  `tauri-plugin-log` 的最终 formatter。所有 Rust 日志以及从 WebView 进入插件的日志，
+  在写入 stdout 和文件之前都会统一脱敏、截断。
+- 前端：`src/lib/frontendLogger.ts` 负责结构化序列化、属性级脱敏和长度限制。
+  `src/main.tsx` 启动时安装 console bridge，因此遗留和第三方 `console.*` 也会进入
+  持久化日志，并且 DevTools 只显示脱敏后的文本。
+- 最终 formatter 是兜底，不是允许调用方记录敏感数据的理由。新代码应在产生日志时
+  就只保留安全元数据。
+
+当前安全出口会隐藏 URL userinfo/query、认证与 Cookie 头、常见 Token/密钥形状、私钥、
+命名的 secret/key/token/password/cookie 字段、请求/响应正文和 payload，并限制单条日志
+长度。新增认证机制或新的敏感字段形状时，必须同时补 Rust 与前端脱敏测试。
+
+## 结构化事件
+
+跨阶段或需要长期检索的诊断使用稳定的单行 JSON 事件：
+
+```rust
+log::warn!(
+    "{}",
+    DiagnosticEvent::new("relay.browser_probe", "unmatched")
+        .field_display("site", crate::url_for_log(site))
+        .field("probe", safe_probe_summary)
+);
+```
+
+```ts
+reportFrontendLog("warn", "settings.save", "failed", {
+  section: "proxy",
+});
+```
+
+字段约定：
+
+- `event`：稳定的领域动作，使用点号分层，例如 `proxy.takeover.rollback`；
+- `outcome`：稳定结果，例如 `started`、`completed`、`failed`、`timeout`、`skipped`；
+- 其它字段只放排查所需的安全上下文，例如 `phase`、`app`、状态码、content type、字节数；
+- Rust 错误支持 `std::error::Error` 时使用 `format_error_chain`，不要只记最外层文案；
+- URL 必须先走 `url_for_log`，即使最终 formatter 仍会再次兜底脱敏。
+
+不要把事件名、字段名或 outcome 塞进自由文本；稳定字段才能被 grep 和脚本可靠聚合。
+
+## 必须记录的 best-effort 失败
+
+“主流程继续执行”不等于“错误可以静默”。以下失败即使不向用户返回错误，也必须记录：
+
+- 数据库状态、迁移标志或同步状态无法持久化；
+- 配置接管、恢复、回滚和备份清理失败；
+- 后台任务未启动、任务崩溃、通道关闭或最终执行失败；
+- 用户需要看到的安全/认证警告无法发送；
+- 写入 Live 配置失败。
+
+Rust `Result` 在这些路径使用 `ResultLogExt::warn_on_err` 或 `error_on_err`，并提供
+`DiagnosticEvent` 的阶段和对象上下文。
+
+以下情况可以不升为 warning：窗口 show/focus、已关闭窗口的事件发送、预期的编辑中
+JSON/TOML 解析 fallback、用于合并高频变更的通道 Full。若这类跳过会导致后台 worker
+永久失效或数据状态不一致，则不再属于“预期”，必须记录。
+
+## 严禁写入日志
+
+- `Authorization`、Cookie、Bearer/API key、OAuth token、密码、私钥；
+- 请求正文、响应正文、Cloudflare/验证页 HTML、完整 payload；
+- 完整 Provider/Settings 对象；
+- 含敏感 query 的原始 URL；
+- 为“方便排查”而输出 localStorage、认证头或 WebView 会话数据。
+
+协议探针只记录候选 ID、HTTP 状态、content type、正文长度、是否 JSON-like 和安全错误分类；
+Bearer token 只在目标 origin 的 WebView 请求内使用，不回传 Rust，也不进入日志。
+
+## 新日志的验收
+
+至少检查：
+
+1. 正常、失败、超时/跳过三个关键结果能否区分；
+2. 日志是否包含动作阶段、对象和完整安全错误链；
+3. 测试是否覆盖新增敏感形状，且断言原文不出现；
+4. `cargo test diagnostics::tests --lib` 与 `tests/lib/frontendLogger*.test.ts` 通过；
+5. `cargo clippy --all-targets --all-features -- -D warnings`、TypeScript、Prettier 和完整
+   Vitest 通过。

--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -710,6 +710,7 @@ async fn browser_import(
     );
 
     let context = Arc::new(Mutex::new(initial_context));
+    let last_probe_summary = Arc::new(Mutex::new(None::<String>));
     let (creds_tx, mut creds_rx) = tokio::sync::mpsc::channel::<login::Credentials>(1);
     let (error_tx, mut error_rx) = tokio::sync::mpsc::channel::<RelayImportError>(1);
     let (closed_tx, mut closed_rx) = tokio::sync::mpsc::channel::<()>(1);
@@ -717,6 +718,7 @@ async fn browser_import(
     let context_for_load = Arc::clone(&context);
     let app_for_nav = app_handle.clone();
     let context_for_nav = Arc::clone(&context);
+    let last_probe_summary_for_nav = Arc::clone(&last_probe_summary);
     let site_origin_for_nav = site_origin.clone();
     let aff_for_nav = login_aff_code.clone();
     let promo_for_nav = login_promo_code.clone();
@@ -764,7 +766,10 @@ async fn browser_import(
             let batch = match result {
                 Ok(batch) => batch,
                 Err(error) => {
-                    log::warn!("站点探测回传解析失败: {error}");
+                    log::warn!(
+                        "站点探测回传解析失败：site={} error={error}",
+                        crate::url_for_log(&site_origin_for_nav)
+                    );
                     let _ = probe_error_tx.try_send(error.into());
                     return false;
                 }
@@ -780,14 +785,33 @@ async fn browser_import(
                 return false;
             }
 
+            let probe_summary = discovery::probe_batch_summary(&batch.responses);
+            let probe_summary_changed = match last_probe_summary_for_nav.lock() {
+                Ok(mut guard) => {
+                    let changed = guard.as_deref() != Some(probe_summary.as_str());
+                    *guard = Some(probe_summary.clone());
+                    changed
+                }
+                Err(_) => true,
+            };
+
             let detected = match discovery::converge_probe_responses(&batch.responses) {
                 Ok(detected) => detected,
                 Err(error) if error.kind == discovery::DiscoveryErrorKind::UnsupportedSite => {
-                    // 本轮只有未知或不匹配的 JSON 响应。页面可能还在验证或跳转，继续轮询。
+                    if probe_summary_changed {
+                        log::info!(
+                            "站点协议探针本批次未匹配：site={} {probe_summary}",
+                            crate::url_for_log(&site_origin_for_nav)
+                        );
+                    }
+                    // 页面可能仍在验证或跳转，继续在同一 WebView 会话中轮询。
                     return false;
                 }
                 Err(error) => {
-                    log::warn!("站点探测批次无法收敛: {error}");
+                    log::warn!(
+                        "站点探测批次无法收敛：site={} {probe_summary} error={error}",
+                        crate::url_for_log(&site_origin_for_nav)
+                    );
                     let _ = probe_error_tx.try_send(error.into());
                     return false;
                 }
@@ -817,6 +841,10 @@ async fn browser_import(
                     return false;
                 }
             }
+            log::info!(
+                "站点协议探针识别成功：site={} backend={backend_kind:?} {probe_summary}",
+                crate::url_for_log(&site_origin_for_nav)
+            );
 
             let Some(window) = app_for_nav.get_webview_window(login::LOGIN_WINDOW_LABEL) else {
                 let _ = probe_error_tx.try_send(RelayImportError::message("站点导入窗口已关闭"));
@@ -973,10 +1001,35 @@ async fn browser_import(
             let _ = window.destroy();
             Err(error)
         }
-        Ok(BrowserLoginOutcome::Closed) => import_result_after_incomplete_browser_flow(&context),
+        Ok(BrowserLoginOutcome::Closed) => {
+            let backend_kind = context
+                .lock()
+                .ok()
+                .and_then(|guard| guard.as_ref().map(|context| context.backend_kind));
+            let probe_detail = last_probe_summary
+                .lock()
+                .ok()
+                .and_then(|guard| guard.clone())
+                .unwrap_or_else(|| "未收到协议探针回传".into());
+            log::info!(
+                "站点导入窗口已关闭：site={} backend={backend_kind:?} probe={probe_detail}",
+                crate::url_for_log(&site_origin)
+            );
+            import_result_after_incomplete_browser_flow(&context)
+        }
         Err(_) => {
+            let backend_kind = context
+                .lock()
+                .ok()
+                .and_then(|guard| guard.as_ref().map(|context| context.backend_kind));
+            let probe_detail = last_probe_summary
+                .lock()
+                .ok()
+                .and_then(|guard| guard.clone())
+                .unwrap_or_else(|| "未收到协议探针回传".into());
             log::warn!(
-                "站点导入等待超时（{LOGIN_TIMEOUT_SECS} 秒内未完成识别与登录）：{site_origin}"
+                "站点导入等待超时（{LOGIN_TIMEOUT_SECS} 秒内未完成识别与登录）：site={} backend={backend_kind:?} probe={probe_detail}",
+                crate::url_for_log(&site_origin)
             );
             let _ = window.destroy();
             import_result_after_incomplete_browser_flow(&context)

--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -767,8 +767,16 @@ async fn browser_import(
                 Ok(batch) => batch,
                 Err(error) => {
                     log::warn!(
-                        "站点探测回传解析失败：site={} error={error}",
-                        crate::url_for_log(&site_origin_for_nav)
+                        "{}",
+                        crate::diagnostics::DiagnosticEvent::new(
+                            "relay.browser_probe.callback",
+                            "parse_failed",
+                        )
+                        .field_display("site", crate::url_for_log(&site_origin_for_nav))
+                        .field(
+                            "error_chain",
+                            crate::diagnostics::format_error_chain(&error),
+                        )
                     );
                     let _ = probe_error_tx.try_send(error.into());
                     return false;
@@ -800,8 +808,13 @@ async fn browser_import(
                 Err(error) if error.kind == discovery::DiscoveryErrorKind::UnsupportedSite => {
                     if probe_summary_changed {
                         log::info!(
-                            "站点协议探针本批次未匹配：site={} {probe_summary}",
-                            crate::url_for_log(&site_origin_for_nav)
+                            "{}",
+                            crate::diagnostics::DiagnosticEvent::new(
+                                "relay.browser_probe",
+                                "unmatched",
+                            )
+                            .field_display("site", crate::url_for_log(&site_origin_for_nav))
+                            .field("probe", probe_summary.clone())
                         );
                     }
                     // 页面可能仍在验证或跳转，继续在同一 WebView 会话中轮询。
@@ -809,8 +822,14 @@ async fn browser_import(
                 }
                 Err(error) => {
                     log::warn!(
-                        "站点探测批次无法收敛：site={} {probe_summary} error={error}",
-                        crate::url_for_log(&site_origin_for_nav)
+                        "{}",
+                        crate::diagnostics::DiagnosticEvent::new(
+                            "relay.browser_probe",
+                            "conflict",
+                        )
+                        .field_display("site", crate::url_for_log(&site_origin_for_nav))
+                        .field("probe", probe_summary.clone())
+                        .field("error_chain", crate::diagnostics::format_error_chain(&error))
                     );
                     let _ = probe_error_tx.try_send(error.into());
                     return false;
@@ -842,8 +861,11 @@ async fn browser_import(
                 }
             }
             log::info!(
-                "站点协议探针识别成功：site={} backend={backend_kind:?} {probe_summary}",
-                crate::url_for_log(&site_origin_for_nav)
+                "{}",
+                crate::diagnostics::DiagnosticEvent::new("relay.browser_probe", "matched")
+                    .field_display("site", crate::url_for_log(&site_origin_for_nav))
+                    .field_display("backend", format_args!("{backend_kind:?}"))
+                    .field("probe", probe_summary)
             );
 
             let Some(window) = app_for_nav.get_webview_window(login::LOGIN_WINDOW_LABEL) else {
@@ -1012,8 +1034,11 @@ async fn browser_import(
                 .and_then(|guard| guard.clone())
                 .unwrap_or_else(|| "未收到协议探针回传".into());
             log::info!(
-                "站点导入窗口已关闭：site={} backend={backend_kind:?} probe={probe_detail}",
-                crate::url_for_log(&site_origin)
+                "{}",
+                crate::diagnostics::DiagnosticEvent::new("relay.browser_import", "closed")
+                    .field_display("site", crate::url_for_log(&site_origin))
+                    .field_display("backend", format_args!("{backend_kind:?}"))
+                    .field("probe", probe_detail)
             );
             import_result_after_incomplete_browser_flow(&context)
         }
@@ -1028,8 +1053,12 @@ async fn browser_import(
                 .and_then(|guard| guard.clone())
                 .unwrap_or_else(|| "未收到协议探针回传".into());
             log::warn!(
-                "站点导入等待超时（{LOGIN_TIMEOUT_SECS} 秒内未完成识别与登录）：site={} backend={backend_kind:?} probe={probe_detail}",
-                crate::url_for_log(&site_origin)
+                "{}",
+                crate::diagnostics::DiagnosticEvent::new("relay.browser_import", "timeout")
+                    .field_display("site", crate::url_for_log(&site_origin))
+                    .field_display("backend", format_args!("{backend_kind:?}"))
+                    .field("probe", probe_detail)
+                    .field("timeout_seconds", LOGIN_TIMEOUT_SECS)
             );
             let _ = window.destroy();
             import_result_after_incomplete_browser_flow(&context)

--- a/src-tauri/src/commands/s3_sync.rs
+++ b/src-tauri/src/commands/s3_sync.rs
@@ -6,6 +6,7 @@ use tauri::State;
 use crate::commands::sync_support::{
     attach_warning, post_sync_warning_from_result, run_post_import_sync,
 };
+use crate::diagnostics::{DiagnosticEvent, ResultLogExt};
 use crate::error::AppError;
 use crate::services::s3_sync as s3_sync_service;
 use crate::settings::{self, S3SyncSettings};
@@ -14,7 +15,11 @@ use crate::store::AppState;
 fn persist_sync_error(settings: &mut S3SyncSettings, error: &AppError, source: &str) {
     settings.status.last_error = Some(error.to_string());
     settings.status.last_error_source = Some(source.to_string());
-    let _ = settings::update_s3_sync_status(settings.status.clone());
+    settings::update_s3_sync_status(settings.status.clone()).error_on_err(
+        DiagnosticEvent::new("sync.status", "persist_failed")
+            .field("backend", "s3")
+            .field("source", source),
+    );
 }
 
 fn s3_not_configured_error() -> String {

--- a/src-tauri/src/commands/webdav_sync.rs
+++ b/src-tauri/src/commands/webdav_sync.rs
@@ -6,6 +6,7 @@ use tauri::State;
 use crate::commands::sync_support::{
     attach_warning, post_sync_warning_from_result, run_post_import_sync,
 };
+use crate::diagnostics::{DiagnosticEvent, ResultLogExt};
 use crate::error::AppError;
 use crate::services::webdav_sync as webdav_sync_service;
 use crate::settings::{self, WebDavSyncSettings};
@@ -14,7 +15,11 @@ use crate::store::AppState;
 fn persist_sync_error(settings: &mut WebDavSyncSettings, error: &AppError, source: &str) {
     settings.status.last_error = Some(error.to_string());
     settings.status.last_error_source = Some(source.to_string());
-    let _ = settings::update_webdav_sync_status(settings.status.clone());
+    settings::update_webdav_sync_status(settings.status.clone()).error_on_err(
+        DiagnosticEvent::new("sync.status", "persist_failed")
+            .field("backend", "webdav")
+            .field("source", source),
+    );
 }
 
 fn webdav_not_configured_error() -> String {

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -3,6 +3,7 @@
 //! 负责数据库表结构的创建和版本迁移。
 
 use super::{lock_conn, Database, SCHEMA_VERSION};
+use crate::diagnostics::DiagnosticEvent;
 use crate::error::AppError;
 use rusqlite::{params, Connection};
 use serde::Serialize;
@@ -337,46 +338,35 @@ impl Database {
             )
             .is_ok()
         {
-            let _ = conn.execute("DELETE FROM settings WHERE key = 'current_profile_id'", []);
+            if let Err(error) =
+                conn.execute("DELETE FROM settings WHERE key = 'current_profile_id'", [])
+            {
+                log::warn!(
+                    "{}",
+                    DiagnosticEvent::new("database.schema_cleanup", "legacy_key_delete_failed")
+                        .field("key", "current_profile_id")
+                        .field_display("error", error)
+                );
+            }
         }
 
-        // 尝试添加 live_takeover_active 列到 proxy_config 表
-        let _ = conn.execute(
-            "ALTER TABLE proxy_config ADD COLUMN live_takeover_active INTEGER NOT NULL DEFAULT 0",
-            [],
-        );
-
-        // 尝试添加基础配置列到 proxy_config 表（兼容 v3.9.0-2 升级）
-        let _ = conn.execute(
-            "ALTER TABLE proxy_config ADD COLUMN proxy_enabled INTEGER NOT NULL DEFAULT 0",
-            [],
-        );
-        let _ = conn.execute(
-            "ALTER TABLE proxy_config ADD COLUMN listen_address TEXT NOT NULL DEFAULT '127.0.0.1'",
-            [],
-        );
-        let _ = conn.execute(
-            "ALTER TABLE proxy_config ADD COLUMN listen_port INTEGER NOT NULL DEFAULT 15721",
-            [],
-        );
-        let _ = conn.execute(
-            "ALTER TABLE proxy_config ADD COLUMN enable_logging INTEGER NOT NULL DEFAULT 1",
-            [],
-        );
-
-        // 尝试添加超时配置列到 proxy_config 表
-        let _ = conn.execute(
-            "ALTER TABLE proxy_config ADD COLUMN streaming_first_byte_timeout INTEGER NOT NULL DEFAULT 60",
-            [],
-        );
-        let _ = conn.execute(
-            "ALTER TABLE proxy_config ADD COLUMN streaming_idle_timeout INTEGER NOT NULL DEFAULT 120",
-            [],
-        );
-        let _ = conn.execute(
-            "ALTER TABLE proxy_config ADD COLUMN non_streaming_timeout INTEGER NOT NULL DEFAULT 600",
-            [],
-        );
+        // 兼容早期数据库：统一走“先查列、再 ALTER”的幂等 helper。旧代码直接吞掉
+        // 所有 ALTER 错误，会把磁盘损坏/权限问题伪装成“列已存在”。
+        for (column, definition) in [
+            ("live_takeover_active", "INTEGER NOT NULL DEFAULT 0"),
+            ("proxy_enabled", "INTEGER NOT NULL DEFAULT 0"),
+            ("listen_address", "TEXT NOT NULL DEFAULT '127.0.0.1'"),
+            ("listen_port", "INTEGER NOT NULL DEFAULT 15721"),
+            ("enable_logging", "INTEGER NOT NULL DEFAULT 1"),
+            (
+                "streaming_first_byte_timeout",
+                "INTEGER NOT NULL DEFAULT 60",
+            ),
+            ("streaming_idle_timeout", "INTEGER NOT NULL DEFAULT 120"),
+            ("non_streaming_timeout", "INTEGER NOT NULL DEFAULT 600"),
+        ] {
+            Self::add_column_if_missing(conn, "proxy_config", column, definition)?;
+        }
 
         // 兼容：若旧版 proxy_config 仍为单例结构（无 app_type），则在启动时直接转换为三行结构
         // 说明：user_version=2 时不会再触发 v1->v2 迁移，但新代码查询依赖 app_type 列。
@@ -395,15 +385,18 @@ impl Database {
         )?;
 
         // 删除旧的 failover_queue 表（如果存在）
-        let _ = conn.execute("DROP INDEX IF EXISTS idx_failover_queue_order", []);
-        let _ = conn.execute("DROP TABLE IF EXISTS failover_queue", []);
+        conn.execute("DROP INDEX IF EXISTS idx_failover_queue_order", [])
+            .map_err(|error| AppError::Database(format!("删除旧故障转移索引失败: {error}")))?;
+        conn.execute("DROP TABLE IF EXISTS failover_queue", [])
+            .map_err(|error| AppError::Database(format!("删除旧故障转移表失败: {error}")))?;
 
         // 为故障转移队列创建索引（基于 providers 表）
-        let _ = conn.execute(
+        conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_providers_failover
              ON providers(app_type, in_failover_queue, sort_index)",
             [],
-        );
+        )
+        .map_err(|error| AppError::Database(format!("创建故障转移索引失败: {error}")))?;
 
         // LoongPort：中转站与凭据（单行表）
         crate::relay::creds::create_table(conn)?;
@@ -1023,14 +1016,18 @@ impl Database {
         // 标记：需要在启动后从文件系统扫描并重建 Skills 数据
         // 说明：v3 结构将 Skills 的 SSOT 迁移到 ~/.cc-switch/skills/，
         // 旧表只存“安装记录”，无法直接无损迁移到新结构，因此改为启动后扫描 app 目录导入。
-        let _ = conn.execute(
+        conn.execute(
             "INSERT OR REPLACE INTO settings (key, value) VALUES ('skills_ssot_migration_pending', 'true')",
             [],
-        );
-        let _ = conn.execute(
+        )
+        .map_err(|error| {
+            AppError::Database(format!("写入 Skills 迁移待处理标志失败: {error}"))
+        })?;
+        conn.execute(
             "INSERT OR REPLACE INTO settings (key, value) VALUES ('skills_ssot_migration_snapshot', ?1)",
             [snapshot_json],
-        );
+        )
+        .map_err(|error| AppError::Database(format!("写入 Skills 迁移快照失败: {error}")))?;
 
         // 2. 删除旧表
         conn.execute("DROP TABLE IF EXISTS skills", [])

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -1,0 +1,338 @@
+//! 全应用诊断日志的唯一安全出口。
+//!
+//! 负责日志正文脱敏、长度上限、统一事件结构和错误链展开。具体日志目标、轮转和
+//! 动态级别仍由 `tauri-plugin-log` 管理。
+
+use regex::Regex;
+use serde_json::{Map, Value};
+use std::{error::Error, fmt, sync::LazyLock};
+
+pub(crate) const MAX_LOG_MESSAGE_LENGTH: usize = 12_000;
+pub(crate) const MAX_RAW_LOG_INPUT_LENGTH: usize = 16_000;
+const MAX_ERROR_CHAIN_DEPTH: usize = 8;
+
+static QUERY_VALUE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"([?&][A-Za-z0-9_.~-]+)=([^&#\s"'<>]*)"#).expect("valid query regex")
+});
+static URL_CREDENTIAL_PATTERN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)(https?://)[^/@\s]+@").expect("valid URL credential regex"));
+static SENSITIVE_HEADER_LINE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?im)(^|[\r\n])([ \t]*(?:(?:proxy-)?authorization|cookie|set-cookie|x-api-key|api-key)\s*[:=]\s*)[^\r\n]+",
+    )
+    .expect("valid sensitive header regex")
+});
+static AUTH_SCHEME_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?i)\b(Bearer|Basic|Token|ApiKey|Digest|Negotiate|AWS4-HMAC-SHA256)\s+[^\s"',}\]]+"#,
+    )
+    .expect("valid auth scheme regex")
+});
+static JSON_BODY_FIELD_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?i)(["'](?:request[_-]?body|response[_-]?body|body|payload)["']\s*:\s*)(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\[[^\]]*\]|\{[^{}]*\}|[^,}\r\n]+)"#,
+    )
+    .expect("valid JSON body field regex")
+});
+static BODY_FIELD_LINE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?im)(^|[\r\n \t])((?:request[_-]?body|response[_-]?body|body|payload)\b\s*[:=]\s*).*$"#,
+    )
+    .expect("valid body field line regex")
+});
+static HTTP_STATUS_BODY_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?im)(HTTP\s+\d{3}\s*:\s*)[^\r\n]*").expect("valid HTTP body regex")
+});
+static NAMED_SECRET_CONTAINER_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?i)((?:\\?["'])?\b(?:api[_-]?key|access[_-]?key|secret[_-]?key|private[_-]?key|client[_-]?secret|auth[_-]?token|access[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?token|session[_-]?id|authorization|credential|password|passwd|bearer|cookie|secret|token|auth|pwd|key)s?(?:\\?["'])?\s*[:=]\s*)(?:\[[^\]]*\]|\{[^{}]*\})"#,
+    )
+    .expect("valid secret container regex")
+});
+static QUOTED_NAMED_SECRET_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?i)(\b(?:api[_-]?key|access[_-]?key|secret[_-]?key|private[_-]?key|client[_-]?secret|auth[_-]?token|access[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?token|session[_-]?id|authorization|credential|password|passwd|bearer|cookie|secret|token|auth|pwd|key)s?\s*["']?\s*[:=]\s*)(?:"[^"]*"|'[^']*')"#,
+    )
+    .expect("valid quoted secret regex")
+});
+static NAMED_SECRET_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?i)(\b(?:api[_-]?key|access[_-]?key|secret[_-]?key|private[_-]?key|client[_-]?secret|auth[_-]?token|access[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?token|session[_-]?id|authorization|credential|password|passwd|bearer|cookie|secret|token|auth|pwd|key)s?\s*["']?\s*[:=]\s*["']?)([^\s"',}]+)"#,
+    )
+    .expect("valid named secret regex")
+});
+static SECRET_VALUE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?i)(^|[^A-Za-z0-9])(?:sk-[A-Za-z0-9._~+/=-]{6,}|AIza[A-Za-z0-9_-]{8,}|github_pat_[A-Za-z0-9_]{6,}|gh[pousr]_[A-Za-z0-9_]{6,}|xox[baprs]-[A-Za-z0-9-]{6,}|ya29\.[A-Za-z0-9._-]{6,}|(?:AKIA|ASIA)[A-Z0-9]{12,}|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)",
+    )
+    .expect("valid secret value regex")
+});
+static PRIVATE_KEY_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?is)-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----.*?(?:-----END (?:RSA |EC |OPENSSH )?PRIVATE KEY-----|\z)",
+    )
+    .expect("valid private key regex")
+});
+
+fn truncate_at_char_boundary(input: &str, max_bytes: usize) -> &str {
+    if input.len() <= max_bytes {
+        return input;
+    }
+    let mut end = max_bytes;
+    while !input.is_char_boundary(end) {
+        end -= 1;
+    }
+    &input[..end]
+}
+
+/// 所有 Rust 与 WebView 日志在写入 stdout/文件前都会经过这里。
+pub(crate) fn redact_log_text(input: &str) -> String {
+    let bounded = truncate_at_char_boundary(input, MAX_RAW_LOG_INPUT_LENGTH);
+    let mut output = URL_CREDENTIAL_PATTERN
+        .replace_all(bounded, "$1[REDACTED]@")
+        .into_owned();
+    output = NAMED_SECRET_CONTAINER_PATTERN
+        .replace_all(&output, "$1\"[REDACTED]\"")
+        .into_owned();
+    output = QUERY_VALUE_PATTERN
+        .replace_all(&output, "$1=[REDACTED]")
+        .into_owned();
+    output = SENSITIVE_HEADER_LINE_PATTERN
+        .replace_all(&output, "$1$2[REDACTED]")
+        .into_owned();
+    output = AUTH_SCHEME_PATTERN
+        .replace_all(&output, "$1 [REDACTED]")
+        .into_owned();
+    output = JSON_BODY_FIELD_PATTERN
+        .replace_all(&output, "$1\"[REDACTED BODY]\"")
+        .into_owned();
+    output = BODY_FIELD_LINE_PATTERN
+        .replace_all(&output, "$1$2[REDACTED BODY]")
+        .into_owned();
+    output = HTTP_STATUS_BODY_PATTERN
+        .replace_all(&output, "$1[REDACTED RESPONSE BODY]")
+        .into_owned();
+    output = QUOTED_NAMED_SECRET_PATTERN
+        .replace_all(&output, "$1\"[REDACTED]\"")
+        .into_owned();
+    output = NAMED_SECRET_PATTERN
+        .replace_all(&output, "$1[REDACTED]")
+        .into_owned();
+    output = SECRET_VALUE_PATTERN
+        .replace_all(&output, "$1[REDACTED]")
+        .into_owned();
+    output = PRIVATE_KEY_PATTERN
+        .replace_all(&output, "[REDACTED PRIVATE KEY]")
+        .into_owned();
+
+    if input.len() > MAX_RAW_LOG_INPUT_LENGTH || output.len() > MAX_LOG_MESSAGE_LENGTH {
+        let truncated = truncate_at_char_boundary(&output, MAX_LOG_MESSAGE_LENGTH);
+        format!("{truncated}\n[truncated]")
+    } else {
+        output
+    }
+}
+
+/// 统一的单行 JSON 诊断事件；字段排序稳定，便于 grep、脚本和 Issue 排查。
+pub(crate) struct DiagnosticEvent {
+    fields: Map<String, Value>,
+}
+
+impl DiagnosticEvent {
+    pub(crate) fn new(event: impl Into<String>, outcome: impl Into<String>) -> Self {
+        let mut fields = Map::new();
+        fields.insert("event".into(), Value::String(event.into()));
+        fields.insert("outcome".into(), Value::String(outcome.into()));
+        Self { fields }
+    }
+
+    pub(crate) fn field(mut self, key: impl Into<String>, value: impl Into<Value>) -> Self {
+        self.fields.insert(key.into(), value.into());
+        self
+    }
+
+    pub(crate) fn field_display(
+        mut self,
+        key: impl Into<String>,
+        value: impl fmt::Display,
+    ) -> Self {
+        self.fields
+            .insert(key.into(), Value::String(value.to_string()));
+        self
+    }
+}
+
+impl fmt::Display for DiagnosticEvent {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Value::Object(self.fields.clone()).fmt(formatter)
+    }
+}
+
+pub(crate) trait ResultLogExt {
+    /// 记录必须继续执行的 best-effort 失败。
+    fn warn_on_err(self, event: DiagnosticEvent);
+
+    /// 记录数据一致性或恢复流程中的严重 best-effort 失败。
+    fn error_on_err(self, event: DiagnosticEvent);
+}
+
+impl<T, E: fmt::Display> ResultLogExt for Result<T, E> {
+    fn warn_on_err(self, event: DiagnosticEvent) {
+        if let Err(error) = self {
+            log::warn!("{}", event.field_display("error", error));
+        }
+    }
+
+    fn error_on_err(self, event: DiagnosticEvent) {
+        if let Err(error) = self {
+            log::error!("{}", event.field_display("error", error));
+        }
+    }
+}
+
+/// 展开标准 Error source 链，避免日志只剩最外层“操作失败”。
+pub(crate) fn format_error_chain(error: &(dyn Error + 'static)) -> String {
+    let mut parts = vec![error.to_string()];
+    let mut source = error.source();
+    while let Some(current) = source {
+        if parts.len() >= MAX_ERROR_CHAIN_DEPTH {
+            parts.push("[error chain truncated]".into());
+            break;
+        }
+        parts.push(current.to_string());
+        source = current.source();
+    }
+    parts.join(" <- ")
+}
+
+/// 供 tauri-plugin-log formatter 使用，保证所有目标共享同一脱敏与行格式。
+pub(crate) fn format_log_line(
+    timestamp: &str,
+    level: log::Level,
+    target: &str,
+    message: &str,
+) -> String {
+    format!(
+        "[{timestamp}][{level}][{}] {}",
+        redact_log_text(target),
+        redact_log_text(message)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_credentials_queries_headers_and_response_bodies() {
+        let input = concat!(
+            "url=https://user:pass@example.com/v1?token=secret-token&model=x\n",
+            "Authorization: Bearer sk-abcdefghijklmnopqrstuvwxyz\n",
+            "cookie=session=opaque-cookie\n",
+            r#"payload={"access_token":"top-secret","nested":{"ok":true}}"#,
+            "\n",
+            "HTTP 403: <html>private verification body</html>",
+        );
+
+        let redacted = redact_log_text(input);
+
+        assert!(!redacted.contains("user:pass"));
+        assert!(!redacted.contains("secret-token"));
+        assert!(!redacted.contains("sk-abcdefghijklmnopqrstuvwxyz"));
+        assert!(!redacted.contains("opaque-cookie"));
+        assert!(!redacted.contains("top-secret"));
+        assert!(!redacted.contains("private verification body"));
+        assert!(redacted.contains("[REDACTED]"));
+        assert!(redacted.contains("HTTP 403: [REDACTED RESPONSE BODY]"));
+    }
+
+    #[test]
+    fn redacts_sensitive_arrays_and_objects_in_legacy_json() {
+        let input = r#"legacy={\"tokens\":[\"short-secret\"],\"auth\":{\"session\":\"opaque\"},\"keep\":\"visible\"}"#;
+
+        let redacted = redact_log_text(input);
+
+        assert!(!redacted.contains("short-secret"));
+        assert!(!redacted.contains("opaque"));
+        assert!(redacted.contains("visible"));
+    }
+
+    #[test]
+    fn keeps_non_sensitive_key_suffixes_visible() {
+        let inputs = [
+            r#"{"monkey":"banana","hotkey":"command-k"}"#,
+            r#"{\"monkey\":\"banana\",\"hotkey\":\"command-k\"}"#,
+            "monkey=banana hotkey=command-k",
+        ];
+
+        for input in inputs {
+            assert_eq!(redact_log_text(input), input);
+        }
+    }
+
+    #[test]
+    fn redacts_truncated_private_keys_without_an_end_marker() {
+        let input = format!(
+            "-----BEGIN PRIVATE KEY-----\nprivate-material\n{}",
+            "A".repeat(MAX_RAW_LOG_INPUT_LENGTH + 100)
+        );
+
+        let redacted = redact_log_text(&input);
+
+        assert!(!redacted.contains("private-material"));
+        assert!(!redacted.contains("BEGIN PRIVATE KEY"));
+        assert!(redacted.contains("[REDACTED PRIVATE KEY]"));
+    }
+
+    #[test]
+    fn bounds_log_messages_before_persisting() {
+        let output = redact_log_text(&"x".repeat(MAX_RAW_LOG_INPUT_LENGTH + 100));
+        assert!(output.len() <= MAX_LOG_MESSAGE_LENGTH + "\n[truncated]".len());
+        assert!(output.ends_with("[truncated]"));
+    }
+
+    #[test]
+    fn diagnostic_events_are_single_line_structured_json() {
+        let event = DiagnosticEvent::new("relay.browser_probe", "unmatched")
+            .field("site", "https://relay.example")
+            .field("status", 403_u64)
+            .field("json", false)
+            .to_string();
+
+        assert_eq!(
+            event,
+            r#"{"event":"relay.browser_probe","outcome":"unmatched","site":"https://relay.example","status":403,"json":false}"#
+        );
+        assert!(!event.contains('\n'));
+    }
+
+    #[test]
+    fn final_redaction_preserves_structured_event_json() {
+        let event = DiagnosticEvent::new("sync.status", "persist_failed")
+            .field("response_body", "private response")
+            .field("status", 403_u64)
+            .to_string();
+
+        let redacted = redact_log_text(&event);
+        let parsed: Value =
+            serde_json::from_str(&redacted).expect("redacted event stays valid JSON");
+
+        assert_eq!(parsed["response_body"], "[REDACTED BODY]");
+        assert_eq!(parsed["status"], 403);
+        assert!(!redacted.contains("private response"));
+    }
+
+    #[test]
+    fn error_chain_keeps_sources_for_root_cause_diagnosis() {
+        let io = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "disk denied");
+        let error = crate::AppError::IoContext {
+            context: "write settings".into(),
+            source: io,
+        };
+
+        assert_eq!(
+            format_error_chain(&error),
+            "write settings: disk denied <- disk denied"
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod commands;
 mod config;
 mod database;
 mod deeplink;
+mod diagnostics;
 mod error;
 mod gemini_config;
 mod gemini_mcp;
@@ -355,7 +356,7 @@ fn macos_tray_icon() -> Option<Image<'static>> {
 /// 一个转发函数只暴露真正要暴露的东西，`main.rs` 那侧读起来也更清楚
 /// ——「这个二进制有两种启动方式」正好对应这里的两个 `pub fn`。
 pub fn run_imagegen_mcp() -> Result<(), String> {
-    relay::imagegen_mcp::serve()
+    relay::imagegen_mcp::serve().map_err(|error| diagnostics::redact_log_text(&error))
 }
 
 /// 启动 MCP server 模式的命令行开关，给 `main.rs` 用。
@@ -367,7 +368,7 @@ pub use relay::imagegen_mcp::IMAGEGEN_MCP_FLAG;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    // 设置 panic hook，在应用崩溃时记录日志到 <app_config_dir>/crash.log（默认 ~/.cc-switch/crash.log）
+    // 设置 panic hook，在应用崩溃时记录日志到 <app_config_dir>/crash.log（默认 ~/.loongport/crash.log）
     panic_hook::setup_panic_hook();
 
     let mut builder = tauri::Builder::default();
@@ -524,7 +525,7 @@ pub fn run() {
             app_store::refresh_app_config_dir_override(app.handle());
             panic_hook::init_app_config_dir(crate::config::get_app_config_dir());
 
-            // 初始化日志（输出到 <app_config_dir>/logs/cc-switch.log）
+            // 初始化日志（输出到 <app_config_dir>/logs/loongport.log）
             {
                 use tauri_plugin_log::{RotationStrategy, Target, TargetKind, TimezoneStrategy};
 
@@ -557,6 +558,21 @@ pub fn run() {
                         .rotation_strategy(RotationStrategy::KeepSome(4))
                         .max_file_size(20 * 1024 * 1024)
                         .timezone_strategy(TimezoneStrategy::UseLocal)
+                        // 所有 Rust 与 WebView 日志共享同一最终安全出口：即使某个调用点
+                        // 忘了主动脱敏，写入 stdout/文件前仍会统一清理凭据、URL query、
+                        // 请求/响应正文并限制长度。
+                        .format(|out, message, record| {
+                            let timestamp = chrono::Local::now()
+                                .format("%Y-%m-%d][%H:%M:%S")
+                                .to_string();
+                            let line = diagnostics::format_log_line(
+                                &timestamp,
+                                record.level(),
+                                record.target(),
+                                &message.to_string(),
+                            );
+                            out.finish(format_args!("{line}"));
+                        })
                         .build(),
                 )?;
 
@@ -744,9 +760,20 @@ pub fn run() {
                         log::info!(
                             "Detected skills_ssot_migration_pending but skills table not empty; skipping auto import."
                         );
-                        let _ = app_state
+                        if let Err(error) = app_state
                             .db
-                            .set_setting("skills_ssot_migration_pending", "false");
+                            .set_setting("skills_ssot_migration_pending", "false")
+                        {
+                            log::warn!(
+                                "{}",
+                                crate::diagnostics::DiagnosticEvent::new(
+                                    "startup.skills_migration",
+                                    "clear_pending_failed",
+                                )
+                                .field("phase", "skip_existing")
+                                .field_display("error", error)
+                            );
+                        }
                     } else {
                         match crate::services::skill::migrate_skills_to_ssot(&app_state.db) {
                             Ok(count) => {
@@ -754,9 +781,20 @@ pub fn run() {
                                 if count > 0 {
                                     crate::init_status::set_skills_migration_result(count);
                                 }
-                                let _ = app_state
+                                if let Err(error) = app_state
                                     .db
-                                    .set_setting("skills_ssot_migration_pending", "false");
+                                    .set_setting("skills_ssot_migration_pending", "false")
+                                {
+                                    log::warn!(
+                                        "{}",
+                                        crate::diagnostics::DiagnosticEvent::new(
+                                            "startup.skills_migration",
+                                            "clear_pending_failed",
+                                        )
+                                        .field("phase", "after_import")
+                                        .field_display("error", error)
+                                    );
+                                }
                             }
                             Err(e) => {
                                 log::warn!("✗ Failed to auto import legacy skills to SSOT: {e}");
@@ -2183,19 +2221,42 @@ fn initialize_common_config_snippets(state: &store::AppState) {
     // This must run before proxy takeover is restored on startup, otherwise we'd read
     // proxy-placeholder configs instead of the user's actual live settings.
     for app_type in crate::app_config::AppType::all() {
-        if !state
-            .db
-            .should_auto_extract_config_snippet(app_type.as_str())
-            .unwrap_or(false)
-        {
+        let app = app_type.as_str();
+        let should_extract = match state.db.should_auto_extract_config_snippet(app) {
+            Ok(value) => value,
+            Err(error) => {
+                log::warn!(
+                    "{}",
+                    crate::diagnostics::DiagnosticEvent::new(
+                        "startup.config_snippet",
+                        "eligibility_check_failed",
+                    )
+                    .field("app", app)
+                    .field_display("error", error)
+                );
+                continue;
+            }
+        };
+        if !should_extract {
             continue;
         }
 
         let settings = match crate::services::provider::ProviderService::read_live_settings(
             app_type.clone(),
         ) {
-            Ok(s) => s,
-            Err(_) => continue,
+            Ok(settings) => settings,
+            Err(error) => {
+                log::debug!(
+                    "{}",
+                    crate::diagnostics::DiagnosticEvent::new(
+                        "startup.config_snippet",
+                        "live_read_skipped",
+                    )
+                    .field("app", app)
+                    .field_display("error", error)
+                );
+                continue;
+            }
         };
 
         match crate::services::provider::ProviderService::extract_common_config_snippet_from_settings(
@@ -2205,7 +2266,17 @@ fn initialize_common_config_snippets(state: &store::AppState) {
             Ok(snippet) if !snippet.is_empty() && snippet != "{}" => {
                 match state.db.set_config_snippet(app_type.as_str(), Some(snippet)) {
                     Ok(()) => {
-                        let _ = state.db.set_config_snippet_cleared(app_type.as_str(), false);
+                        if let Err(error) = state.db.set_config_snippet_cleared(app, false) {
+                            log::warn!(
+                                "{}",
+                                crate::diagnostics::DiagnosticEvent::new(
+                                    "startup.config_snippet",
+                                    "persist_cleared_state_failed",
+                                )
+                                .field("app", app)
+                                .field_display("error", error)
+                            );
+                        }
                         log::info!(
                             "✓ Auto-extracted common config snippet for {}",
                             app_type.as_str()

--- a/src-tauri/src/panic_hook.rs
+++ b/src-tauri/src/panic_hook.rs
@@ -1,6 +1,6 @@
 //! Panic Hook 模块
 //!
-//! 在应用崩溃时捕获 panic 信息并记录到 `<app_config_dir>/crash.log` 文件中（默认 `~/.cc-switch/crash.log`）。
+//! 在应用崩溃时捕获 panic 信息并记录到 `<app_config_dir>/crash.log` 文件中（默认 `~/.loongport/crash.log`）。
 //! 便于用户和开发者诊断闪退问题。
 
 use std::fs::{self, OpenOptions};
@@ -115,6 +115,51 @@ fn get_system_info() -> String {
     )
 }
 
+fn format_crash_entry(
+    timestamp: &str,
+    system_info: &str,
+    message: &str,
+    location: &str,
+    backtrace: &str,
+) -> String {
+    let message = crate::diagnostics::redact_log_text(message);
+    let separator = "=".repeat(80);
+    let sub_separator = "-".repeat(40);
+    format!(
+        r#"
+{separator}
+[CRASH REPORT] {timestamp}
+{separator}
+
+{sub_separator}
+System Information
+{sub_separator}
+{system_info}
+
+{sub_separator}
+Error Details
+{sub_separator}
+Message: {message}
+
+Location: {location}
+
+{sub_separator}
+Stack Trace (Backtrace)
+{sub_separator}
+{backtrace}
+
+{separator}
+"#
+    )
+}
+
+fn append_crash_entry(path: &Path, entry: &str) -> std::io::Result<()> {
+    rotate_crash_log_if_needed(path)?;
+    let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+    file.write_all(entry.as_bytes())?;
+    file.flush()
+}
+
 /// 设置 panic hook，捕获崩溃信息并写入日志文件
 ///
 /// 在应用启动时调用此函数，确保任何 panic 都会被记录。
@@ -130,14 +175,14 @@ pub fn setup_panic_hook() {
         std::env::set_var("RUST_BACKTRACE", "1");
     }
 
-    let default_hook = panic::take_hook();
-
     panic::set_hook(Box::new(move |panic_info| {
         let log_path = get_crash_log_path();
 
         // 确保目录存在
         if let Some(parent) = log_path.parent() {
-            let _ = std::fs::create_dir_all(parent);
+            if let Err(error) = std::fs::create_dir_all(parent) {
+                eprintln!("[LoongPort] failed to create crash log directory: {error}");
+            }
         }
 
         // 构建崩溃信息（使用 catch_unwind 保护时间格式化，避免嵌套 panic）
@@ -184,34 +229,14 @@ pub fn setup_panic_hook() {
         let backtrace = std::backtrace::Backtrace::force_capture();
         let backtrace_str = format!("{backtrace}");
 
-        // 格式化日志条目
-        let separator = "=".repeat(80);
-        let sub_separator = "-".repeat(40);
-        let crash_entry = format!(
-            r#"
-{separator}
-[CRASH REPORT] {timestamp}
-{separator}
-
-{sub_separator}
-System Information
-{sub_separator}
-{system_info}
-
-{sub_separator}
-Error Details
-{sub_separator}
-Message: {message}
-
-Location: {location}
-
-{sub_separator}
-Stack Trace (Backtrace)
-{sub_separator}
-{backtrace_str}
-
-{separator}
-"#
+        // 格式化日志条目。panic payload 可能携带请求失败正文或凭据，
+        // crash.log 不经过 tauri-plugin-log formatter，因此必须显式复用同一脱敏策略。
+        let crash_entry = format_crash_entry(
+            &timestamp,
+            &system_info,
+            &message,
+            &location,
+            &backtrace_str,
         );
 
         // 将 size check、轮转和追加合成同一个临界区，避免多线程同时 panic
@@ -219,26 +244,22 @@ Stack Trace (Backtrace)
         let crash_log_guard = CRASH_LOG_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let _ = rotate_crash_log_if_needed(&log_path);
-        let saved =
-            if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(&log_path) {
-                let _ = file.write_all(crash_entry.as_bytes());
-                let _ = file.flush();
-                true
-            } else {
-                false
-            };
+        let save_result = append_crash_entry(&log_path, &crash_entry);
         drop(crash_log_guard);
 
-        if saved {
-            eprintln!("\n[CC-Switch] Crash log saved to: {}", log_path.display());
+        match save_result {
+            Ok(()) => eprintln!("\n[LoongPort] Crash log saved to: {}", log_path.display()),
+            Err(error) => eprintln!(
+                "\n[LoongPort] Failed to save crash log at {}: {error}",
+                log_path.display()
+            ),
         }
 
         // 同时输出到 stderr（便于开发调试）
         eprintln!("{crash_entry}");
 
-        // 调用默认 hook
-        default_hook(panic_info);
+        // 不再调用默认 hook：它会把未经脱敏的 panic payload 再次写到 stderr。
+        // 上面的 crash_entry 已包含同等的消息、位置和完整 backtrace。
     }));
 }
 
@@ -259,6 +280,22 @@ mod tests {
         assert!(info.contains("OS:"));
         assert!(info.contains("Arch:"));
         assert!(info.contains("App Version:"));
+    }
+
+    #[test]
+    fn crash_entries_redact_sensitive_panic_messages() {
+        let entry = format_crash_entry(
+            "2026-08-11 12:00:00",
+            "OS: test",
+            "Authorization: Bearer sk-private-token\nresponse_body=<html>secret</html>",
+            "src/example.rs:1",
+            "stack",
+        );
+
+        assert!(!entry.contains("sk-private-token"));
+        assert!(!entry.contains("<html>secret</html>"));
+        assert!(entry.contains("[REDACTED]"));
+        assert!(entry.contains("[REDACTED BODY]"));
     }
 
     #[test]

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -23,6 +23,7 @@ use super::{
     ProxyError,
 };
 use crate::commands::{CodexOAuthState, CopilotAuthState, XaiOAuthState};
+use crate::diagnostics::{DiagnosticEvent, ResultLogExt};
 use crate::proxy::providers::codex_oauth_auth::CodexOAuthManager;
 use crate::proxy::providers::copilot_auth::CopilotAuthManager;
 use crate::proxy::providers::xai_oauth_auth::XaiOAuthManager;
@@ -273,6 +274,25 @@ impl RequestForwarder {
         });
     }
 
+    fn spawn_failover_switch(&self, app_type: &str, provider: &Provider) {
+        let manager = self.failover_manager.clone();
+        let app_handle = self.app_handle.clone();
+        let app_type = app_type.to_string();
+        let provider_id = provider.id.clone();
+        let provider_name = provider.name.clone();
+
+        tokio::spawn(async move {
+            manager
+                .try_switch(app_handle.as_ref(), &app_type, &provider_id, &provider_name)
+                .await
+                .warn_on_err(
+                    DiagnosticEvent::new("proxy.failover.switch", "failed")
+                        .field("app", app_type)
+                        .field("provider_id", provider_id),
+                );
+        });
+    }
+
     /// 整流（thinking signature 或 budget）重试失败后的统一收尾。
     ///
     /// `None` 表示已记录熔断器、累积 `last_error`/`last_provider`，
@@ -299,8 +319,7 @@ impl RequestForwarder {
         };
 
         if is_provider_error {
-            let _ = self
-                .router
+            self.router
                 .record_result(
                     &provider.id,
                     app_type_str,
@@ -308,7 +327,13 @@ impl RequestForwarder {
                     false,
                     Some(retry_err.to_string()),
                 )
-                .await;
+                .await
+                .warn_on_err(
+                    DiagnosticEvent::new("proxy.health.record", "failed")
+                        .field("phase", "rectifier_retry_failure")
+                        .field("app", app_type_str)
+                        .field("provider_id", provider.id.clone()),
+                );
             {
                 let mut status = self.status.write().await;
                 status.last_error = Some(format!(
@@ -516,15 +541,7 @@ impl RequestForwarder {
                             status.failover_count += 1;
 
                             // 异步触发供应商切换，更新 UI/托盘，并把“当前供应商”同步为实际使用的 provider
-                            let fm = self.failover_manager.clone();
-                            let ah = self.app_handle.clone();
-                            let pid = provider.id.clone();
-                            let pname = provider.name.clone();
-                            let at = app_type_str.to_string();
-
-                            tokio::spawn(async move {
-                                let _ = fm.try_switch(ah.as_ref(), &at, &pid, &pname).await;
-                            });
+                            self.spawn_failover_switch(app_type_str, provider);
                         }
                         // 重新计算成功率
                         if status.total_requests > 0 {
@@ -618,17 +635,7 @@ impl RequestForwarder {
                                                 != provider.id.as_str();
                                         if should_switch {
                                             status.failover_count += 1;
-                                            let fm = self.failover_manager.clone();
-                                            let ah = self.app_handle.clone();
-                                            let pid = provider.id.clone();
-                                            let pname = provider.name.clone();
-                                            let at = app_type_str.to_string();
-
-                                            tokio::spawn(async move {
-                                                let _ = fm
-                                                    .try_switch(ah.as_ref(), &at, &pid, &pname)
-                                                    .await;
-                                            });
+                                            self.spawn_failover_switch(app_type_str, provider);
                                         }
                                         if status.total_requests > 0 {
                                             status.success_rate = (status.success_requests as f32
@@ -766,17 +773,7 @@ impl RequestForwarder {
                                                 status.failover_count += 1;
 
                                                 // 异步触发供应商切换，更新 UI/托盘
-                                                let fm = self.failover_manager.clone();
-                                                let ah = self.app_handle.clone();
-                                                let pid = provider.id.clone();
-                                                let pname = provider.name.clone();
-                                                let at = app_type_str.to_string();
-
-                                                tokio::spawn(async move {
-                                                    let _ = fm
-                                                        .try_switch(ah.as_ref(), &at, &pid, &pname)
-                                                        .await;
-                                                });
+                                                self.spawn_failover_switch(app_type_str, provider);
                                             }
                                             if status.total_requests > 0 {
                                                 status.success_rate = (status.success_requests
@@ -928,16 +925,7 @@ impl RequestForwarder {
                                                 != provider.id.as_str();
                                         if should_switch {
                                             status.failover_count += 1;
-                                            let fm = self.failover_manager.clone();
-                                            let ah = self.app_handle.clone();
-                                            let pid = provider.id.clone();
-                                            let pname = provider.name.clone();
-                                            let at = app_type_str.to_string();
-                                            tokio::spawn(async move {
-                                                let _ = fm
-                                                    .try_switch(ah.as_ref(), &at, &pid, &pname)
-                                                    .await;
-                                            });
+                                            self.spawn_failover_switch(app_type_str, provider);
                                         }
                                         if status.total_requests > 0 {
                                             status.success_rate = (status.success_requests as f32
@@ -1008,8 +996,7 @@ impl RequestForwarder {
                     match category {
                         ErrorCategory::Retryable => {
                             // 可重试：真正的 provider 故障 → 记录失败并更新熔断器/DB 健康度
-                            let _ = self
-                                .router
+                            self.router
                                 .record_result(
                                     &provider.id,
                                     app_type_str,
@@ -1017,7 +1004,13 @@ impl RequestForwarder {
                                     false,
                                     Some(e.to_string()),
                                 )
-                                .await;
+                                .await
+                                .warn_on_err(
+                                    DiagnosticEvent::new("proxy.health.record", "failed")
+                                        .field("phase", "retryable_failure")
+                                        .field("app", app_type_str)
+                                        .field("provider_id", provider.id.clone()),
+                                );
 
                             {
                                 let mut status = self.status.write().await;

--- a/src-tauri/src/relay/api.rs
+++ b/src-tauri/src/relay/api.rs
@@ -46,6 +46,7 @@ pub const PROBE_ADAPTER: ProbeAdapter = ProbeAdapter {
     candidate: ProbeCandidate {
         id: "sub2api",
         path: "/api/v1/settings/public",
+        bearer_token_storage_key: Some("auth_token"),
     },
     detect: detect_site,
 };

--- a/src-tauri/src/relay/backend.rs
+++ b/src-tauri/src/relay/backend.rs
@@ -26,6 +26,10 @@ pub struct DetectedSite {
 pub struct ProbeCandidate {
     pub id: &'static str,
     pub path: &'static str,
+    /// 可选的页面登录令牌键。仅在目标 origin 内给该候选请求补 Bearer 头；
+    /// 令牌不回传 Rust、不写日志，也不与其它协议候选共享。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bearer_token_storage_key: Option<&'static str>,
 }
 
 #[derive(Clone, Copy)]

--- a/src-tauri/src/relay/discovery.rs
+++ b/src-tauri/src/relay/discovery.rs
@@ -98,6 +98,18 @@ pub fn browser_probe_script(site_origin: &str, candidates: &[ProbeCandidate]) ->
     return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
   }}
 
+  function headersFor(candidate) {{
+    const headers = {{ Accept: 'application/json' }};
+    if (!candidate.bearer_token_storage_key) return headers;
+    try {{
+      const token = localStorage.getItem(candidate.bearer_token_storage_key);
+      if (token) headers.Authorization = 'Bearer ' + token;
+    }} catch (_) {{
+      // Some verification pages disable storage. Cookie-only probing still remains available.
+    }}
+    return headers;
+  }}
+
   async function probe() {{
     if (window.location.origin !== expectedOrigin) return;
     if (probeInFlight) return;
@@ -113,7 +125,7 @@ pub fn browser_probe_script(site_origin: &str, candidates: &[ProbeCandidate]) ->
             const response = await fetch(candidate.path, {{
               credentials: 'include',
               cache: 'no-store',
-              headers: {{ Accept: 'application/json' }},
+              headers: headersFor(candidate),
               signal: controller.signal,
             }});
             return response.text();
@@ -393,10 +405,12 @@ mod tests {
                 ProbeCandidate {
                     id: "sub2api",
                     path: "/api/v1/settings/public",
+                    bearer_token_storage_key: Some("auth_token"),
                 },
                 ProbeCandidate {
                     id: "newapi",
                     path: "/api/status",
+                    bearer_token_storage_key: None,
                 },
             ]
         );
@@ -408,10 +422,12 @@ mod tests {
             ProbeCandidate {
                 id: "sub2api",
                 path: "/api/v1/settings/public",
+                bearer_token_storage_key: Some("auth_token"),
             },
             ProbeCandidate {
                 id: "future",
                 path: "/api/status",
+                bearer_token_storage_key: None,
             },
         ];
         let script = browser_probe_script("https://relay.example", &candidates);

--- a/src-tauri/src/relay/discovery.rs
+++ b/src-tauri/src/relay/discovery.rs
@@ -15,7 +15,7 @@ use std::fmt;
 
 pub const PROBE_SCHEME: &str = "loongport-probe";
 const MAX_PROBE_BODY_BYTES: usize = 64 * 1024;
-const MAX_PROBE_RESPONSE_OVERHEAD_BYTES: usize = 256;
+const MAX_PROBE_RESPONSE_OVERHEAD_BYTES: usize = 512;
 
 pub const PROBE_CANDIDATES: &[ProbeCandidate] = &[
     api::PROBE_ADAPTER.candidate,
@@ -61,10 +61,20 @@ const MAX_PROBE_BATCH_BYTES: usize =
 
 const PROBE_ADAPTERS: &[ProbeAdapter] = &[api::PROBE_ADAPTER, newapi::PROBE_ADAPTER];
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 pub struct ProbeResponse {
     pub candidate_id: String,
     pub body: String,
+    #[serde(default)]
+    pub status: Option<u16>,
+    #[serde(default)]
+    pub content_type: Option<String>,
+    #[serde(default)]
+    pub body_bytes: usize,
+    #[serde(default)]
+    pub json_like: bool,
+    #[serde(default)]
+    pub error_kind: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
@@ -75,7 +85,8 @@ pub struct ProbeBatch {
 /// 生成注入所有页面的协议无关探测脚本。
 ///
 /// 脚本只在目标 origin 上工作；验证页、注册页、登录页都走同一份代码。它不认识任何
-/// 验证产品或 HTTP 状态，只轮询候选端点并把 JSON-like 响应交给 Rust detector。
+/// 验证产品，也不在浏览器层判断协议。每轮回传安全的响应元数据；只有 JSON-like 且大小
+/// 合规的正文才交给 Rust detector，验证页正文、令牌、Cookie 和请求头都不会离开 WebView。
 pub fn browser_probe_script(site_origin: &str, candidates: &[ProbeCandidate]) -> String {
     let expected_origin = serde_json::to_string(site_origin).expect("origin can be JSON encoded");
     let candidates =
@@ -110,6 +121,24 @@ pub fn browser_probe_script(site_origin: &str, candidates: &[ProbeCandidate]) ->
     return headers;
   }}
 
+  function responseContentType(response) {{
+    try {{
+      const value = response.headers && response.headers.get
+        ? response.headers.get('content-type')
+        : null;
+      if (typeof value !== 'string' || !value) return null;
+      return value.replace(/[\u0000-\u001f\u007f]/g, ' ').slice(0, 128);
+    }} catch (_) {{
+      return null;
+    }}
+  }}
+
+  function safeErrorKind(error) {{
+    const name = error && typeof error.name === 'string' ? error.name : '';
+    const safeName = name.replace(/[^A-Za-z0-9_.-]/g, '').slice(0, 64);
+    return safeName || 'Error';
+  }}
+
   async function probe() {{
     if (window.location.origin !== expectedOrigin) return;
     if (probeInFlight) return;
@@ -128,27 +157,45 @@ pub fn browser_probe_script(site_origin: &str, candidates: &[ProbeCandidate]) ->
               headers: headersFor(candidate),
               signal: controller.signal,
             }});
-            return response.text();
+            const body = await response.text();
+            return {{ response, body }};
           }})();
           const timeout = new Promise((_, reject) => {{
             timeoutId = setTimeout(() => {{
               controller.abort();
-              reject(new Error('probe request timed out'));
+              const error = new Error('probe request timed out');
+              error.name = 'ProbeTimeout';
+              reject(error);
             }}, requestTimeoutMs);
           }});
-          const body = await Promise.race([request, timeout]);
+          const {{ response, body }} = await Promise.race([request, timeout]);
+          const bodyBytes = new TextEncoder().encode(body).length;
           const trimmed = body.trim();
-          if (!trimmed || (trimmed[0] !== '{{' && trimmed[0] !== '[')) continue;
-          if (new TextEncoder().encode(body).length > {MAX_PROBE_BODY_BYTES}) continue;
-          responses.push({{ candidate_id: candidate.id, body }});
-        }} catch (_) {{
-          // 页面仍可能处于验证或跳转阶段；下一轮继续，不在浏览器层解释失败原因。
+          const jsonLike = Boolean(trimmed) && (trimmed[0] === '{{' || trimmed[0] === '[');
+          responses.push({{
+            candidate_id: candidate.id,
+            body: jsonLike && bodyBytes <= {MAX_PROBE_BODY_BYTES} ? body : '',
+            status: Number.isInteger(response.status) ? response.status : null,
+            content_type: responseContentType(response),
+            body_bytes: bodyBytes,
+            json_like: jsonLike,
+            error_kind: null,
+          }});
+        }} catch (error) {{
+          responses.push({{
+            candidate_id: candidate.id,
+            body: '',
+            status: null,
+            content_type: null,
+            body_bytes: 0,
+            json_like: false,
+            error_kind: safeErrorKind(error),
+          }});
         }} finally {{
           if (timeoutId !== undefined) clearTimeout(timeoutId);
         }}
       }}
 
-      if (!responses.length) return;
       const batch = JSON.stringify(responses);
       if (batch === previousBatch) return;
       previousBatch = batch;
@@ -189,11 +236,20 @@ pub fn parse_probe_navigation(url: &url::Url) -> Option<Result<ProbeBatch, AppEr
         let responses = serde_json::from_slice::<Vec<ProbeResponse>>(&bytes)
             .map_err(|e| AppError::Config(format!("站点探测回传不是候选响应批次: {e}")))?;
         if responses.len() > PROBE_CANDIDATES.len()
-            || responses
-                .iter()
-                .any(|response| response.body.len() > MAX_PROBE_BODY_BYTES)
+            || responses.iter().any(|response| {
+                response.candidate_id.len() > 64
+                    || response.body.len() > MAX_PROBE_BODY_BYTES
+                    || response
+                        .content_type
+                        .as_deref()
+                        .is_some_and(|value| value.len() > 128)
+                    || response
+                        .error_kind
+                        .as_deref()
+                        .is_some_and(|value| value.len() > 64)
+            })
         {
-            return Err(AppError::Config("站点探测回传正文过大".into()));
+            return Err(AppError::Config("站点探测回传正文或元数据过大".into()));
         }
         Ok(ProbeBatch { responses })
     })())
@@ -201,6 +257,59 @@ pub fn parse_probe_navigation(url: &url::Url) -> Option<Result<ProbeBatch, AppEr
 
 const fn base64url_encoded_len(decoded_len: usize) -> usize {
     (decoded_len * 4).div_ceil(3)
+}
+
+/// 生成可安全落盘的探针批次摘要，不包含响应正文、令牌、Cookie 或请求头。
+pub fn probe_batch_summary(responses: &[ProbeResponse]) -> String {
+    if responses.is_empty() {
+        return "no_responses".into();
+    }
+
+    responses
+        .iter()
+        .map(|response| {
+            let candidate_id = sanitize_probe_log_value(&response.candidate_id, 64);
+            if let Some(error_kind) = response.error_kind.as_deref() {
+                return format!(
+                    "{candidate_id}(error={})",
+                    sanitize_probe_log_value(error_kind, 64)
+                );
+            }
+
+            let status = response
+                .status
+                .map(|status| status.to_string())
+                .unwrap_or_else(|| "unknown".into());
+            let content_type = response
+                .content_type
+                .as_deref()
+                .map(|value| sanitize_probe_log_value(value, 128))
+                .filter(|value| !value.is_empty())
+                .unwrap_or_else(|| "unknown".into());
+            format!(
+                "{candidate_id}(status={status},type={content_type},bytes={},json={})",
+                response.body_bytes, response.json_like
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn sanitize_probe_log_value(value: &str, max_chars: usize) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .take(max_chars)
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// 用原生 HTTP 跑候选注册表的 fast path。
@@ -271,7 +380,14 @@ pub async fn discover_site(site_origin: &str) -> Result<DetectedSite, DiscoveryE
         completed_candidate = true;
         responses.push(ProbeResponse {
             candidate_id: candidate.id.to_string(),
+            body_bytes: body.len(),
+            json_like: body
+                .iter()
+                .copied()
+                .find(|byte| !byte.is_ascii_whitespace())
+                .is_some_and(|byte| byte == b'{' || byte == b'['),
             body: String::from_utf8_lossy(&body).into_owned(),
+            ..ProbeResponse::default()
         });
     }
 
@@ -338,14 +454,7 @@ pub fn converge_probe_responses(
 
 #[cfg(test)]
 fn probe_batch_callback_url(responses: &[ProbeResponse]) -> url::Url {
-    let body = serde_json::json!(responses
-        .iter()
-        .map(|response| serde_json::json!({
-            "candidate_id": response.candidate_id,
-            "body": response.body,
-        }))
-        .collect::<Vec<_>>())
-    .to_string();
+    let body = serde_json::to_string(responses).expect("serialize test probe responses");
     let encoded = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(body);
     url::Url::parse(&format!("{PROBE_SCHEME}://response?d={encoded}"))
         .expect("test batch callback URL")
@@ -438,7 +547,8 @@ mod tests {
         assert!(script.contains(PROBE_SCHEME));
         assert!(script.contains("window.location.origin"));
         assert!(script.contains("const responses = []"));
-        assert!(script.contains("responses.push({ candidate_id: candidate.id, body })"));
+        assert!(script.contains("body: jsonLike && bodyBytes <= 65536 ? body : ''"));
+        assert!(script.contains("error_kind: safeErrorKind(error)"));
         assert!(script.contains("const batch = JSON.stringify(responses)"));
         assert!(script.contains("b64url(batch)"));
         assert_eq!(
@@ -457,6 +567,7 @@ mod tests {
         let url = probe_batch_callback_url(&[ProbeResponse {
             candidate_id: "sub2api".into(),
             body: body.into(),
+            ..ProbeResponse::default()
         }]);
         let parsed = parse_probe_navigation(&url)
             .expect("probe scheme")
@@ -472,10 +583,12 @@ mod tests {
             ProbeResponse {
                 candidate_id: "sub2api".into(),
                 body: sub2api_body().into(),
+                ..ProbeResponse::default()
             },
             ProbeResponse {
                 candidate_id: "newapi".into(),
                 body: newapi_status_body().into(),
+                ..ProbeResponse::default()
             },
         ];
         let parsed = parse_probe_navigation(&probe_batch_callback_url(&expected))
@@ -492,10 +605,12 @@ mod tests {
             ProbeResponse {
                 candidate_id: "sub2api".into(),
                 body: body.clone(),
+                ..ProbeResponse::default()
             },
             ProbeResponse {
                 candidate_id: "newapi".into(),
                 body,
+                ..ProbeResponse::default()
             },
         ];
 
@@ -504,6 +619,35 @@ mod tests {
             .expect("aggregate batch remains valid");
 
         assert_eq!(parsed.responses, expected);
+    }
+
+    #[test]
+    fn probe_batch_summary_reports_safe_metadata_without_response_body() {
+        let responses = [
+            ProbeResponse {
+                candidate_id: "sub2api".into(),
+                body: "<html>secret verification page</html>".into(),
+                status: Some(403),
+                content_type: Some("text/html; charset=UTF-8\nforged".into()),
+                body_bytes: 38,
+                json_like: false,
+                error_kind: None,
+            },
+            ProbeResponse {
+                candidate_id: "newapi".into(),
+                error_kind: Some("ProbeTimeout\nforged".into()),
+                ..ProbeResponse::default()
+            },
+        ];
+
+        let summary = probe_batch_summary(&responses);
+
+        assert_eq!(
+            summary,
+            "sub2api(status=403,type=text/html; charset=UTF-8 forged,bytes=38,json=false) newapi(error=ProbeTimeout forged)"
+        );
+        assert!(!summary.contains("secret verification page"));
+        assert!(!summary.contains('\n'));
     }
 
     #[test]
@@ -534,10 +678,12 @@ mod tests {
         let sub2api = ProbeResponse {
             candidate_id: "sub2api".into(),
             body: sub2api_body().into(),
+            ..ProbeResponse::default()
         };
         let newapi = ProbeResponse {
             candidate_id: "newapi".into(),
             body: newapi_status_body().into(),
+            ..ProbeResponse::default()
         };
 
         assert_eq!(
@@ -569,6 +715,7 @@ mod tests {
         let batch = parse_probe_navigation(&probe_batch_callback_url(&[ProbeResponse {
             candidate_id: "newapi".into(),
             body: newapi_status_body().into(),
+            ..ProbeResponse::default()
         }]))
         .unwrap()
         .unwrap();

--- a/src-tauri/src/relay/imagegen_mcp.rs
+++ b/src-tauri/src/relay/imagegen_mcp.rs
@@ -132,10 +132,18 @@ fn registration_server(exe: &str) -> McpServer {
 /// 2. **它不在协议通道上**，没有污染 stdout 的风险（那是本模块最怕的事）。
 /// 3. 自己装 logger 要么引新依赖，要么把 `tauri_plugin_log` 的初始化挪到 `run()` 之外
 ///    —— 后者恰好会把它那个 stdout target 带进 MCP 进程，即**制造**我们要防的故障。
+fn format_stderr_diagnostic(message: &str) -> String {
+    format!(
+        "[loongport-imagegen] {}",
+        crate::diagnostics::redact_log_text(message)
+    )
+}
+
 macro_rules! diag {
-    ($($arg:tt)*) => {
-        eprintln!("[loongport-imagegen] {}", format!($($arg)*))
-    };
+    ($($arg:tt)*) => {{
+        let message = format!($($arg)*);
+        eprintln!("{}", format_stderr_diagnostic(&message));
+    }};
 }
 
 /// 走哪个模型生图。
@@ -813,6 +821,17 @@ pub fn serve() -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn stderr_diagnostics_redact_credentials_and_response_bodies() {
+        let message = format_stderr_diagnostic(
+            "Authorization: Bearer sk-private-token\nresponse_body=<html>secret</html>",
+        );
+
+        assert!(!message.contains("sk-private-token"));
+        assert!(!message.contains("<html>secret</html>"));
+        assert!(message.contains("[REDACTED]"));
+    }
 
     #[test]
     fn registration_targets_supported_hosts_without_binding_a_tier() {

--- a/src-tauri/src/relay/newapi.rs
+++ b/src-tauri/src/relay/newapi.rs
@@ -47,6 +47,7 @@ pub const PROBE_ADAPTER: ProbeAdapter = ProbeAdapter {
     candidate: ProbeCandidate {
         id: "newapi",
         path: "/api/status",
+        bearer_token_storage_key: None,
     },
     detect: detect_site,
 };

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -14,6 +14,7 @@ use serde_json::Value;
 
 use crate::app_config::AppType;
 use crate::database::{validate_cost_multiplier, validate_pricing_source};
+use crate::diagnostics::{DiagnosticEvent, ResultLogExt};
 use crate::error::AppError;
 use crate::provider::{Provider, UsageResult};
 use crate::services::mcp::McpService;
@@ -3079,7 +3080,11 @@ impl ProviderService {
                     .db
                     .set_omo_provider_current(app_type.as_str(), id, enable.category)?;
                 crate::services::OmoService::write_config_to_file(state, enable)?;
-                let _ = crate::services::OmoService::delete_config_file(disable);
+                crate::services::OmoService::delete_config_file(disable).error_on_err(
+                    DiagnosticEvent::new("provider.switch.omo", "stale_config_delete_failed")
+                        .field("enabled_variant", enable.category)
+                        .field("disabled_variant", disable.category),
+                );
                 return Ok(SwitchResult::default());
             }
         }
@@ -4641,15 +4646,27 @@ impl ProviderService {
         if let Some(p) = provider {
             if p.apps.claude {
                 let claude_id = format!("universal-claude-{id}");
-                let _ = state.db.delete_provider("claude", &claude_id);
+                state.db.delete_provider("claude", &claude_id).error_on_err(
+                    DiagnosticEvent::new("provider.universal.delete", "child_delete_failed")
+                        .field("app", "claude")
+                        .field("provider_id", claude_id),
+                );
             }
             if p.apps.codex {
                 let codex_id = format!("universal-codex-{id}");
-                let _ = state.db.delete_provider("codex", &codex_id);
+                state.db.delete_provider("codex", &codex_id).error_on_err(
+                    DiagnosticEvent::new("provider.universal.delete", "child_delete_failed")
+                        .field("app", "codex")
+                        .field("provider_id", codex_id),
+                );
             }
             if p.apps.gemini {
                 let gemini_id = format!("universal-gemini-{id}");
-                let _ = state.db.delete_provider("gemini", &gemini_id);
+                state.db.delete_provider("gemini", &gemini_id).error_on_err(
+                    DiagnosticEvent::new("provider.universal.delete", "child_delete_failed")
+                        .field("app", "gemini")
+                        .field("provider_id", gemini_id),
+                );
             }
         }
 
@@ -4675,7 +4692,11 @@ impl ProviderService {
         } else {
             // 如果禁用了 Claude，删除对应的子供应商
             let claude_id = format!("universal-claude-{id}");
-            let _ = state.db.delete_provider("claude", &claude_id);
+            state.db.delete_provider("claude", &claude_id).error_on_err(
+                DiagnosticEvent::new("provider.universal.sync", "stale_child_delete_failed")
+                    .field("app", "claude")
+                    .field("provider_id", claude_id),
+            );
         }
 
         // 同步到 Codex
@@ -4689,7 +4710,11 @@ impl ProviderService {
             state.db.save_provider("codex", &codex_provider)?;
         } else {
             let codex_id = format!("universal-codex-{id}");
-            let _ = state.db.delete_provider("codex", &codex_id);
+            state.db.delete_provider("codex", &codex_id).error_on_err(
+                DiagnosticEvent::new("provider.universal.sync", "stale_child_delete_failed")
+                    .field("app", "codex")
+                    .field("provider_id", codex_id),
+            );
         }
 
         // 同步到 Gemini
@@ -4703,7 +4728,11 @@ impl ProviderService {
             state.db.save_provider("gemini", &gemini_provider)?;
         } else {
             let gemini_id = format!("universal-gemini-{id}");
-            let _ = state.db.delete_provider("gemini", &gemini_id);
+            state.db.delete_provider("gemini", &gemini_id).error_on_err(
+                DiagnosticEvent::new("provider.universal.sync", "stale_child_delete_failed")
+                    .field("app", "gemini")
+                    .field("provider_id", gemini_id),
+            );
         }
 
         Ok(true)

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -5,6 +5,7 @@
 use crate::app_config::AppType;
 use crate::config::{get_claude_settings_path, read_json_file, write_json_file};
 use crate::database::Database;
+use crate::diagnostics::{DiagnosticEvent, ResultLogExt};
 use crate::provider::Provider;
 use crate::proxy::server::ProxyServer;
 use crate::proxy::switch_lock::SwitchLockManager;
@@ -570,7 +571,10 @@ impl ProxyService {
             .persist_ephemeral_listen_port_if_needed(&config, info.port)
             .await
         {
-            let _ = server.stop().await;
+            server.stop().await.warn_on_err(
+                DiagnosticEvent::new("proxy.start.rollback", "stop_failed")
+                    .field("phase", "persist_ephemeral_port"),
+            );
             return Err(e);
         }
 
@@ -645,7 +649,10 @@ impl ProxyService {
                 log::warn!("清理 Live 备份失败: {clean_err}");
             }
             if started_proxy_before_takeover {
-                let _ = self.stop().await;
+                self.stop().await.warn_on_err(
+                    DiagnosticEvent::new("proxy.takeover.rollback", "stop_failed")
+                        .field("phase", "activate_flag"),
+                );
             }
             return Err(format!("设置接管状态失败: {e}"));
         }
@@ -656,15 +663,24 @@ impl ProxyService {
             log::error!("接管 Live 配置失败，尝试恢复原始配置: {e}");
             match self.restore_live_configs().await {
                 Ok(()) => {
-                    let _ = self.db.set_live_takeover_active(false).await;
-                    let _ = self.db.delete_all_live_backups().await;
+                    self.db.set_live_takeover_active(false).await.error_on_err(
+                        DiagnosticEvent::new("proxy.takeover.rollback", "clear_active_failed")
+                            .field("phase", "takeover_live_config"),
+                    );
+                    self.db.delete_all_live_backups().await.error_on_err(
+                        DiagnosticEvent::new("proxy.takeover.rollback", "delete_backup_failed")
+                            .field("phase", "takeover_live_config"),
+                    );
                 }
                 Err(restore_err) => {
                     log::error!("恢复原始配置失败，将保留备份以便下次启动恢复: {restore_err}");
                 }
             }
             if started_proxy_before_takeover {
-                let _ = self.stop().await;
+                self.stop().await.warn_on_err(
+                    DiagnosticEvent::new("proxy.takeover.rollback", "stop_failed")
+                        .field("phase", "takeover_live_config"),
+                );
             }
             return Err(e);
         }
@@ -677,15 +693,24 @@ impl ProxyService {
                 log::error!("代理启动失败，尝试恢复原始配置: {e}");
                 match self.restore_live_configs().await {
                     Ok(()) => {
-                        let _ = self.db.set_live_takeover_active(false).await;
-                        let _ = self.db.delete_all_live_backups().await;
+                        self.db.set_live_takeover_active(false).await.error_on_err(
+                            DiagnosticEvent::new("proxy.takeover.rollback", "clear_active_failed")
+                                .field("phase", "proxy_start"),
+                        );
+                        self.db.delete_all_live_backups().await.error_on_err(
+                            DiagnosticEvent::new("proxy.takeover.rollback", "delete_backup_failed")
+                                .field("phase", "proxy_start"),
+                        );
                     }
                     Err(restore_err) => {
                         log::error!("恢复原始配置失败，将保留备份以便下次启动恢复: {restore_err}");
                     }
                 }
                 if started_proxy_before_takeover {
-                    let _ = self.stop().await;
+                    self.stop().await.warn_on_err(
+                        DiagnosticEvent::new("proxy.takeover.rollback", "stop_failed")
+                            .field("phase", "proxy_start"),
+                    );
                 }
                 Err(e)
             }
@@ -795,7 +820,11 @@ impl ProxyService {
 
                 // 4) 同步 Live Token 到数据库（仅当前 app）
                 if let Err(e) = self.sync_live_to_provider(&app).await {
-                    let _ = self.db.delete_live_backup(app_type_str).await;
+                    self.db.delete_live_backup(app_type_str).await.error_on_err(
+                        DiagnosticEvent::new("proxy.takeover.rollback", "delete_backup_failed")
+                            .field("phase", "sync_live_to_provider")
+                            .field("app", app_type_str),
+                    );
                     return Err(e);
                 }
             }
@@ -806,7 +835,11 @@ impl ProxyService {
                 match self.restore_live_config_for_app_inner(&app).await {
                     Ok(()) => {
                         // 恢复成功才清理备份，避免失败场景下丢失唯一可回滚来源
-                        let _ = self.db.delete_live_backup(app_type_str).await;
+                        self.db.delete_live_backup(app_type_str).await.error_on_err(
+                            DiagnosticEvent::new("proxy.takeover.rollback", "delete_backup_failed")
+                                .field("phase", "takeover_app")
+                                .field("app", app_type_str),
+                        );
                     }
                     Err(restore_err) => {
                         log::error!(
@@ -829,8 +862,12 @@ impl ProxyService {
                 .await
                 .map_err(|e| format!("设置 {app_type_str} enabled 状态失败: {e}"))?;
 
-            // 7) 兼容旧逻辑：写入 any-of 标志（失败不影响功能）
-            let _ = self.db.set_live_takeover_active(true).await;
+            // 7) 兼容旧逻辑：写入 any-of 标志（失败不影响功能，但必须可诊断）
+            self.db.set_live_takeover_active(true).await.warn_on_err(
+                DiagnosticEvent::new("proxy.takeover", "persist_legacy_flag_failed")
+                    .field("phase", "enable_app")
+                    .field("app", app_type_str),
+            );
 
             self.refresh_active_target_from_current_provider(&app).await;
 
@@ -845,13 +882,18 @@ impl ProxyService {
                         )
                     {
                         if let Some(handle) = self.app_handle.read().await.as_ref() {
-                            let _ = handle.emit(
-                                "proxy-official-warning",
-                                serde_json::json!({
-                                    "appType": app_type_str,
-                                    "providerName": provider.name,
-                                }),
-                            );
+                            handle
+                                .emit(
+                                    "proxy-official-warning",
+                                    serde_json::json!({
+                                        "appType": app_type_str,
+                                        "providerName": provider.name,
+                                    }),
+                                )
+                                .warn_on_err(
+                                    DiagnosticEvent::new("proxy.takeover.warning", "emit_failed")
+                                        .field("app", app_type_str),
+                                );
                         }
                     }
                 }
@@ -912,11 +954,20 @@ impl ProxyService {
             .map_err(|e| format!("检查接管状态失败: {e}"))?;
 
         if !any_enabled {
-            let _ = self.db.set_live_takeover_active(false).await;
+            self.db.set_live_takeover_active(false).await.warn_on_err(
+                DiagnosticEvent::new("proxy.takeover", "persist_legacy_flag_failed")
+                    .field("phase", "disable_last_app")
+                    .field("app", app_type_str),
+            );
 
             if self.is_running().await {
-                // 此时没有任何 app 处于接管状态，停止服务即可
-                let _ = self.stop().await;
+                // 此时没有任何 app 处于接管状态，停止服务即可。停止失败不回滚
+                // 已完成的 Live 恢复，但必须写日志，否则 UI 看到关闭后仍可能有监听端口。
+                self.stop().await.warn_on_err(
+                    DiagnosticEvent::new("proxy.takeover", "stop_failed")
+                        .field("phase", "disable_last_app")
+                        .field("app", app_type_str),
+                );
             }
         }
 
@@ -957,8 +1008,12 @@ impl ProxyService {
         futures::executor::block_on(self.db.clear_provider_health_for_app(app_type_str))
             .map_err(|e| format!("清除 {app_type_str} 健康状态失败: {e}"))?;
 
-        // 5) 清旧标志
-        let _ = futures::executor::block_on(self.db.set_live_takeover_active(false));
+        // 5) 清旧标志。同步调用方仍以 Live 恢复为主流程，兼容标志失败只记日志。
+        futures::executor::block_on(self.db.set_live_takeover_active(false)).warn_on_err(
+            DiagnosticEvent::new("proxy.takeover", "persist_legacy_flag_failed")
+                .field("phase", "disable_app_sync")
+                .field("app", app_type_str),
+        );
 
         Ok(())
     }
@@ -1359,7 +1414,10 @@ impl ProxyService {
         //    注意：保留 proxy_config.enabled 状态，下次启动时自动恢复
         if let Ok(mut config) = self.db.get_proxy_config().await {
             config.live_takeover_active = false;
-            let _ = self.db.update_proxy_config(config).await;
+            self.db.update_proxy_config(config).await.warn_on_err(
+                DiagnosticEvent::new("proxy.shutdown", "persist_state_failed")
+                    .field("phase", "restore_keep_state"),
+            );
         }
 
         // 4. 删除备份（Live 配置已恢复，备份不再需要）
@@ -1678,18 +1736,31 @@ impl ProxyService {
         Ok(())
     }
 
-    /// 接管指定应用的 Live 配置（尽力而为：配置不存在/读取失败则跳过）
+    /// 接管指定应用的 Live 配置（尽力而为：配置不存在/读取失败则跳过并记录原因）
     async fn takeover_live_config_best_effort(&self, app_type: &AppType) -> Result<(), String> {
         let (proxy_url, proxy_codex_base_url) = self.build_proxy_urls().await?;
         let proxy_grok_base_url = format!("{}/grokbuild/v1", proxy_url.trim_end_matches('/'));
+        let app = app_type.as_str();
 
         match app_type {
-            AppType::Claude => {
-                if let Ok(mut live_config) = self.read_claude_live() {
-                    let claude_provider = self
-                        .get_current_provider_for_app(&AppType::Claude)
-                        .ok()
-                        .flatten();
+            AppType::Claude => match self.read_claude_live() {
+                Ok(mut live_config) => {
+                    let claude_provider = match self.get_current_provider_for_app(&AppType::Claude)
+                    {
+                        Ok(provider) => provider,
+                        Err(error) => {
+                            log::warn!(
+                                "{}",
+                                DiagnosticEvent::new(
+                                    "proxy.takeover.best_effort",
+                                    "current_provider_read_failed",
+                                )
+                                .field("app", app)
+                                .field("error", error)
+                            );
+                            None
+                        }
+                    };
                     if let Some(provider) = claude_provider.as_ref() {
                         let provider = self.claude_provider_with_effective_settings(provider)?;
                         Self::apply_claude_takeover_fields_for_provider(
@@ -1704,11 +1775,20 @@ impl ProxyService {
                             ClaudeTakeoverAuthPolicy::PreserveExistingOrAuthToken,
                         );
                     }
-                    let _ = self.write_claude_live(&live_config);
+                    self.write_claude_live(&live_config).warn_on_err(
+                        DiagnosticEvent::new("proxy.takeover.best_effort", "write_failed")
+                            .field("app", app),
+                    );
                 }
-            }
-            AppType::Codex => {
-                if let Ok(mut live_config) = self.read_codex_live() {
+                Err(error) => log::warn!(
+                    "{}",
+                    DiagnosticEvent::new("proxy.takeover.best_effort", "read_skipped")
+                        .field("app", app)
+                        .field("error", error)
+                ),
+            },
+            AppType::Codex => match self.read_codex_live() {
+                Ok(mut live_config) => {
                     let codex_provider = self.require_current_provider_for_app(&AppType::Codex)?;
                     Self::apply_codex_takeover_fields_for_provider(
                         &mut live_config,
@@ -1721,9 +1801,15 @@ impl ProxyService {
                         Some(&codex_provider),
                     )?;
                 }
-            }
-            AppType::Gemini => {
-                if let Ok(mut live_config) = self.read_gemini_live() {
+                Err(error) => log::warn!(
+                    "{}",
+                    DiagnosticEvent::new("proxy.takeover.best_effort", "read_skipped")
+                        .field("app", app)
+                        .field("error", error)
+                ),
+            },
+            AppType::Gemini => match self.read_gemini_live() {
+                Ok(mut live_config) => {
                     if let Some(env) = live_config.get_mut("env").and_then(|v| v.as_object_mut()) {
                         env.insert("GOOGLE_GEMINI_BASE_URL".to_string(), json!(&proxy_url));
                         env.insert("GEMINI_API_KEY".to_string(), json!(PROXY_TOKEN_PLACEHOLDER));
@@ -1734,21 +1820,44 @@ impl ProxyService {
                         });
                     }
 
-                    let _ = self.write_gemini_live(&live_config);
+                    self.write_gemini_live(&live_config).warn_on_err(
+                        DiagnosticEvent::new("proxy.takeover.best_effort", "write_failed")
+                            .field("app", app),
+                    );
                 }
-            }
-            AppType::GrokBuild => {
-                if let Ok(mut live_config) = self.read_grok_live() {
+                Err(error) => log::warn!(
+                    "{}",
+                    DiagnosticEvent::new("proxy.takeover.best_effort", "read_skipped")
+                        .field("app", app)
+                        .field("error", error)
+                ),
+            },
+            AppType::GrokBuild => match self.read_grok_live() {
+                Ok(mut live_config) => {
                     if Self::grok_live_config_supports_takeover(&live_config) {
                         Self::apply_grok_takeover_fields(&mut live_config, &proxy_grok_base_url)?;
-                        let _ = self.write_grok_live(&live_config);
+                        self.write_grok_live(&live_config).warn_on_err(
+                            DiagnosticEvent::new("proxy.takeover.best_effort", "write_failed")
+                                .field("app", app),
+                        );
                     } else {
                         log::info!(
-                            "Grok Build Live 处于官方登录态（无自定义模型表），跳过代理接管"
+                            "{}",
+                            DiagnosticEvent::new(
+                                "proxy.takeover.best_effort",
+                                "unsupported_live_config",
+                            )
+                            .field("app", app)
                         );
                     }
                 }
-            }
+                Err(error) => log::warn!(
+                    "{}",
+                    DiagnosticEvent::new("proxy.takeover.best_effort", "read_skipped")
+                        .field("app", app)
+                        .field("error", error)
+                ),
+            },
             _ => {}
         }
 
@@ -3119,7 +3228,10 @@ impl ProxyService {
                 .persist_ephemeral_listen_port_if_needed(&new_config, info.port)
                 .await
             {
-                let _ = new_server.stop().await;
+                new_server.stop().await.warn_on_err(
+                    DiagnosticEvent::new("proxy.restart.rollback", "stop_failed")
+                        .field("phase", "persist_ephemeral_port"),
+                );
                 return Err(e);
             }
 

--- a/src-tauri/src/services/s3_auto_sync.rs
+++ b/src-tauri/src/services/s3_auto_sync.rs
@@ -8,6 +8,7 @@ use tauri::{AppHandle, Emitter};
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
+use crate::diagnostics::{format_error_chain, DiagnosticEvent, ResultLogExt};
 use crate::error::AppError;
 use crate::services::s3_sync;
 use crate::settings::{self, S3SyncSettings};
@@ -58,7 +59,16 @@ pub fn should_trigger_for_table(table: &str) -> bool {
 pub(crate) fn enqueue_change_signal(tx: &Sender<String>, table: &str) -> bool {
     match tx.try_send(table.to_string()) {
         Ok(()) => true,
-        Err(TrySendError::Full(_)) | Err(TrySendError::Closed(_)) => false,
+        Err(TrySendError::Full(_)) => false,
+        Err(TrySendError::Closed(_)) => {
+            log::warn!(
+                "{}",
+                DiagnosticEvent::new("sync.auto.enqueue", "worker_unavailable")
+                    .field("backend", "s3")
+                    .field("table", table)
+            );
+            false
+        }
     }
 }
 
@@ -82,7 +92,11 @@ fn should_run_auto_sync(settings: Option<&S3SyncSettings>) -> bool {
 fn persist_auto_sync_error(settings: &mut S3SyncSettings, error: &AppError) {
     settings.status.last_error = Some(error.to_string());
     settings.status.last_error_source = Some("auto".to_string());
-    let _ = settings::update_s3_sync_status(settings.status.clone());
+    settings::update_s3_sync_status(settings.status.clone()).error_on_err(
+        DiagnosticEvent::new("sync.status", "persist_failed")
+            .field("backend", "s3")
+            .field("source", "auto"),
+    );
 }
 
 fn emit_auto_sync_status_updated(app: &AppHandle, status: &str, error: Option<&str>) {
@@ -98,9 +112,13 @@ fn emit_auto_sync_status_updated(app: &AppHandle, status: &str, error: Option<&s
         }),
     };
 
-    if let Err(err) = app.emit(crate::events::S3_SYNC_STATUS_UPDATED, payload) {
-        log::debug!("[S3] failed to emit sync status update event: {err}");
-    }
+    app.emit(crate::events::S3_SYNC_STATUS_UPDATED, payload)
+        .warn_on_err(
+            DiagnosticEvent::new("sync.status", "emit_failed")
+                .field("backend", "s3")
+                .field("source", "auto")
+                .field("status", status),
+        );
 }
 
 async fn run_auto_sync_upload(
@@ -180,11 +198,27 @@ async fn run_worker_loop(
         }
 
         log::debug!(
-            "[S3][AutoSync] Triggered by table={first_table}, merged_changes={merged_count}"
+            "{}",
+            DiagnosticEvent::new("sync.auto.upload", "started")
+                .field("backend", "s3")
+                .field("first_table", first_table)
+                .field("merged_changes", merged_count as u64)
         );
 
-        if let Err(err) = run_auto_sync_upload(&db, &app).await {
-            log::warn!("[S3][AutoSync] Upload failed: {err}");
+        match run_auto_sync_upload(&db, &app).await {
+            Ok(()) => log::debug!(
+                "{}",
+                DiagnosticEvent::new("sync.auto.upload", "completed")
+                    .field("backend", "s3")
+                    .field("merged_changes", merged_count as u64)
+            ),
+            Err(err) => log::warn!(
+                "{}",
+                DiagnosticEvent::new("sync.auto.upload", "failed")
+                    .field("backend", "s3")
+                    .field("merged_changes", merged_count as u64)
+                    .field("error_chain", format_error_chain(&err))
+            ),
         }
     }
 }

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -18,6 +18,7 @@ use tokio::time::timeout;
 use crate::app_config::{AppType, InstalledSkill, SkillApps, UnmanagedSkill};
 use crate::config::get_app_config_dir;
 use crate::database::Database;
+use crate::diagnostics::{DiagnosticEvent, ResultLogExt};
 use crate::error::format_skill_error;
 
 // ========== 数据结构 ==========
@@ -834,7 +835,11 @@ impl SkillService {
 
                 // 从所有应用目录删除
                 for app in AppType::all() {
-                    let _ = Self::remove_from_app(&directory, &app);
+                    Self::remove_from_app(&directory, &app).warn_on_err(
+                        DiagnosticEvent::new("skill.uninstall", "app_cleanup_failed")
+                            .field("app", app.as_str())
+                            .field("skill_id", id),
+                    );
                 }
 
                 // 从 SSOT 删除
@@ -974,7 +979,12 @@ impl SkillService {
 
             // 扫描仓库中的所有 Skill 目录
             let mut remote_skills: Vec<DiscoverableSkill> = Vec::new();
-            let _ = self.scan_dir_recursive(temp_dir, temp_dir, &repo, &mut remote_skills);
+            self.scan_dir_recursive(temp_dir, temp_dir, &repo, &mut remote_skills)
+                .warn_on_err(
+                    DiagnosticEvent::new("skill.update_check", "repository_scan_failed")
+                        .field("repo_owner", owner.clone())
+                        .field("repo_name", name.clone()),
+                );
 
             for skill in group_skills {
                 // 在远程仓库中找到匹配的 Skill 目录
@@ -1016,10 +1026,27 @@ impl SkillService {
                             if local_dir.exists() {
                                 match Self::compute_dir_hash(&local_dir) {
                                     Ok(h) => {
-                                        let _ = db.update_skill_hash(&skill.id, &h, 0);
+                                        db.update_skill_hash(&skill.id, &h, 0).warn_on_err(
+                                            DiagnosticEvent::new(
+                                                "skill.update_check",
+                                                "hash_persist_failed",
+                                            )
+                                            .field("skill_id", skill.id.clone()),
+                                        );
                                         Some(h)
                                     }
-                                    Err(_) => None,
+                                    Err(error) => {
+                                        log::warn!(
+                                            "{}",
+                                            DiagnosticEvent::new(
+                                                "skill.update_check",
+                                                "hash_compute_failed",
+                                            )
+                                            .field("skill_id", skill.id.clone())
+                                            .field_display("error", error)
+                                        );
+                                        None
+                                    }
                                 }
                             } else {
                                 None
@@ -1091,7 +1118,7 @@ impl SkillService {
 
         // 在解压的仓库中查找 Skill 源目录
         let mut remote_skills: Vec<DiscoverableSkill> = Vec::new();
-        let _ = self.scan_dir_recursive(temp_dir, temp_dir, &repo, &mut remote_skills);
+        self.scan_dir_recursive(temp_dir, temp_dir, &repo, &mut remote_skills)?;
 
         let remote_match = remote_skills
             .iter()
@@ -1117,8 +1144,8 @@ impl SkillService {
                 ))
             })?;
 
-        // 备份旧文件
-        let _ = Self::create_uninstall_backup(&skill);
+        // 备份旧文件。真实备份失败时停止更新，避免先删旧版本后才发现无法回滚。
+        Self::create_uninstall_backup(&skill)?;
 
         // 删除旧 SSOT 目录并复制新文件
         let dest = ssot_dir.join(&skill.directory);
@@ -1187,10 +1214,15 @@ impl SkillService {
                 continue;
             }
             match Self::compute_dir_hash(&skill_dir) {
-                Ok(hash) => {
-                    let _ = db.update_skill_hash(&skill.id, &hash, 0);
-                    count += 1;
-                }
+                Ok(hash) => match db.update_skill_hash(&skill.id, &hash, 0) {
+                    Ok(_) => count += 1,
+                    Err(error) => log::warn!(
+                        "{}",
+                        DiagnosticEvent::new("skill.hash_backfill", "persist_failed")
+                            .field("skill_id", skill.id.clone())
+                            .field_display("error", error)
+                    ),
+                },
                 Err(e) => {
                     log::warn!("补算哈希失败 {}: {e}", skill.id);
                 }
@@ -1267,7 +1299,13 @@ impl SkillService {
                 Ok(()) => result.migrated_count += 1,
                 Err(_) => match Self::copy_dir_recursive(&src, &dst) {
                     Ok(()) => {
-                        let _ = fs::remove_dir_all(&src);
+                        fs::remove_dir_all(&src).warn_on_err(
+                            DiagnosticEvent::new(
+                                "skill.storage_migration",
+                                "source_cleanup_failed",
+                            )
+                            .field_display("path", src.display()),
+                        );
                         result.migrated_count += 1;
                     }
                     Err(e) => {
@@ -1282,7 +1320,10 @@ impl SkillService {
 
         // 4. 刷新所有应用目录的 symlink（指向新 SSOT）
         for app in AppType::all() {
-            let _ = Self::sync_to_app(db, &app);
+            Self::sync_to_app(db, &app).warn_on_err(
+                DiagnosticEvent::new("skill.storage_migration", "app_sync_failed")
+                    .field("app", app.as_str()),
+            );
         }
 
         log::info!(
@@ -1402,14 +1443,23 @@ impl SkillService {
         restored_skill.content_hash = Self::compute_dir_hash(&restore_path).ok();
 
         if let Err(err) = db.save_skill(&restored_skill) {
-            let _ = fs::remove_dir_all(&restore_path);
+            fs::remove_dir_all(&restore_path).warn_on_err(
+                DiagnosticEvent::new("skill.restore.rollback", "directory_cleanup_failed")
+                    .field_display("path", restore_path.display()),
+            );
             return Err(err.into());
         }
 
         if !restored_skill.apps.is_empty() {
             if let Err(err) = Self::sync_to_app_dir(&restored_skill.directory, current_app) {
-                let _ = db.delete_skill(&restored_skill.id);
-                let _ = fs::remove_dir_all(&restore_path);
+                db.delete_skill(&restored_skill.id).error_on_err(
+                    DiagnosticEvent::new("skill.restore.rollback", "database_cleanup_failed")
+                        .field("skill_id", restored_skill.id.clone()),
+                );
+                fs::remove_dir_all(&restore_path).warn_on_err(
+                    DiagnosticEvent::new("skill.restore.rollback", "directory_cleanup_failed")
+                        .field_display("path", restore_path.display()),
+                );
                 return Err(err);
             }
         }
@@ -1792,7 +1842,11 @@ impl SkillService {
 
         let copy_result = Self::copy_dir_recursive(source, &tmp);
         if let Err(err) = copy_result {
-            let _ = Self::remove_path(&tmp);
+            Self::remove_path(&tmp).warn_on_err(
+                DiagnosticEvent::new("skill.atomic_replace", "temp_cleanup_failed")
+                    .field_display("path", tmp.display())
+                    .field("phase", "copy_failed"),
+            );
             return Err(err);
         }
 
@@ -1801,7 +1855,11 @@ impl SkillService {
         }
 
         fs::rename(&tmp, dest).with_context(|| {
-            let _ = Self::remove_path(&tmp);
+            Self::remove_path(&tmp).warn_on_err(
+                DiagnosticEvent::new("skill.atomic_replace", "temp_cleanup_failed")
+                    .field_display("path", tmp.display())
+                    .field("phase", "rename_failed"),
+            );
             format!(
                 "替换 Skill 目录失败: {} -> {}",
                 tmp.display(),
@@ -2464,8 +2522,14 @@ impl SkillService {
                 Err(e) => {
                     // 每个分支各自重算预算，所以失败后必须把上一轮的残留清掉——
                     // 否则 N 个候选分支等于 N 倍的落盘量堆在同一个目录里。
-                    let _ = fs::remove_dir_all(&temp_path);
-                    let _ = fs::create_dir_all(&temp_path);
+                    if temp_path.exists() {
+                        fs::remove_dir_all(&temp_path).with_context(|| {
+                            format!("清理失败分支下载目录失败: {}", temp_path.display())
+                        })?;
+                    }
+                    fs::create_dir_all(&temp_path).with_context(|| {
+                        format!("重建分支下载目录失败: {}", temp_path.display())
+                    })?;
                     last_error = Some(e);
                     continue;
                 }
@@ -2862,7 +2926,10 @@ impl SkillService {
         };
 
         if let Err(err) = write_backup() {
-            let _ = fs::remove_dir_all(&backup_path);
+            fs::remove_dir_all(&backup_path).warn_on_err(
+                DiagnosticEvent::new("skill.backup", "partial_cleanup_failed")
+                    .field_display("path", backup_path.display()),
+            );
             return Err(err);
         }
 
@@ -3078,7 +3145,7 @@ impl SkillService {
             // 复制到 SSOT
             let dest = ssot_dir.join(&install_name);
             if dest.exists() {
-                let _ = fs::remove_dir_all(&dest);
+                fs::remove_dir_all(&dest)?;
             }
             Self::copy_dir_recursive(&skill_dir, &dest)?;
 
@@ -3555,7 +3622,11 @@ pub fn migrate_skills_to_ssot(db: &Arc<Database>) -> Result<usize> {
         count += 1;
     }
 
-    let _ = db.set_setting("skills_ssot_migration_snapshot", "");
+    db.set_setting("skills_ssot_migration_snapshot", "")
+        .warn_on_err(DiagnosticEvent::new(
+            "skill.ssot_migration",
+            "snapshot_clear_failed",
+        ));
 
     log::info!("Skills 迁移完成，共 {count} 个");
 

--- a/src-tauri/src/services/webdav_auto_sync.rs
+++ b/src-tauri/src/services/webdav_auto_sync.rs
@@ -8,6 +8,7 @@ use tauri::{AppHandle, Emitter};
 use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
+use crate::diagnostics::{format_error_chain, DiagnosticEvent, ResultLogExt};
 use crate::error::AppError;
 use crate::services::webdav_sync as webdav_sync_service;
 use crate::settings::{self, WebDavSyncSettings};
@@ -58,7 +59,16 @@ pub fn should_trigger_for_table(table: &str) -> bool {
 pub(crate) fn enqueue_change_signal(tx: &Sender<String>, table: &str) -> bool {
     match tx.try_send(table.to_string()) {
         Ok(()) => true,
-        Err(TrySendError::Full(_)) | Err(TrySendError::Closed(_)) => false,
+        Err(TrySendError::Full(_)) => false,
+        Err(TrySendError::Closed(_)) => {
+            log::warn!(
+                "{}",
+                DiagnosticEvent::new("sync.auto.enqueue", "worker_unavailable")
+                    .field("backend", "webdav")
+                    .field("table", table)
+            );
+            false
+        }
     }
 }
 
@@ -82,7 +92,11 @@ fn should_run_auto_sync(settings: Option<&WebDavSyncSettings>) -> bool {
 fn persist_auto_sync_error(settings: &mut WebDavSyncSettings, error: &AppError) {
     settings.status.last_error = Some(error.to_string());
     settings.status.last_error_source = Some("auto".to_string());
-    let _ = settings::update_webdav_sync_status(settings.status.clone());
+    settings::update_webdav_sync_status(settings.status.clone()).error_on_err(
+        DiagnosticEvent::new("sync.status", "persist_failed")
+            .field("backend", "webdav")
+            .field("source", "auto"),
+    );
 }
 
 fn emit_auto_sync_status_updated(app: &AppHandle, status: &str, error: Option<&str>) {
@@ -98,9 +112,13 @@ fn emit_auto_sync_status_updated(app: &AppHandle, status: &str, error: Option<&s
         }),
     };
 
-    if let Err(err) = app.emit(crate::events::WEBDAV_SYNC_STATUS_UPDATED, payload) {
-        log::debug!("[WebDAV] failed to emit sync status update event: {err}");
-    }
+    app.emit(crate::events::WEBDAV_SYNC_STATUS_UPDATED, payload)
+        .warn_on_err(
+            DiagnosticEvent::new("sync.status", "emit_failed")
+                .field("backend", "webdav")
+                .field("source", "auto")
+                .field("status", status),
+        );
 }
 
 async fn run_auto_sync_upload(
@@ -184,11 +202,27 @@ async fn run_worker_loop(
         }
 
         log::debug!(
-            "[WebDAV][AutoSync] Triggered by table={first_table}, merged_changes={merged_count}"
+            "{}",
+            DiagnosticEvent::new("sync.auto.upload", "started")
+                .field("backend", "webdav")
+                .field("first_table", first_table)
+                .field("merged_changes", merged_count as u64)
         );
 
-        if let Err(err) = run_auto_sync_upload(&db, &app).await {
-            log::warn!("[WebDAV][AutoSync] Upload failed: {err}");
+        match run_auto_sync_upload(&db, &app).await {
+            Ok(()) => log::debug!(
+                "{}",
+                DiagnosticEvent::new("sync.auto.upload", "completed")
+                    .field("backend", "webdav")
+                    .field("merged_changes", merged_count as u64)
+            ),
+            Err(err) => log::warn!(
+                "{}",
+                DiagnosticEvent::new("sync.auto.upload", "failed")
+                    .field("backend", "webdav")
+                    .field("merged_changes", merged_count as u64)
+                    .field("error_chain", format_error_chain(&err))
+            ),
         }
     }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -399,7 +399,7 @@
         "title": "Application Diagnostic Logs",
         "description": "Control the output level for application diagnostic logs",
         "enabled": "Enable Diagnostic Logs",
-        "enabledDescription": "Controls cc-switch.log; request usage records and crash.log are unaffected",
+        "enabledDescription": "Controls loongport.log; request usage records and crash.log are unaffected",
         "level": "Log Level",
         "levelDescription": "Set the minimum log level to output",
         "levels": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -399,7 +399,7 @@
         "title": "アプリ診断ログ",
         "description": "アプリ診断ログの出力レベルを制御",
         "enabled": "診断ログを有効化",
-        "enabledDescription": "cc-switch.log を制御します。リクエスト使用量記録と crash.log には影響しません",
+        "enabledDescription": "loongport.log を制御します。リクエスト使用量記録と crash.log には影響しません",
         "level": "ログレベル",
         "levelDescription": "出力する最小ログレベルを設定",
         "levels": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -399,7 +399,7 @@
         "title": "應用程式診斷日誌",
         "description": "控制應用程式診斷日誌的輸出層級",
         "enabled": "啟用應用程式診斷日誌",
-        "enabledDescription": "控制 cc-switch.log；不影響請求用量記錄和 crash.log",
+        "enabledDescription": "控制 loongport.log；不影響請求用量記錄和 crash.log",
         "level": "日誌層級",
         "levelDescription": "設定輸出的最低日誌層級",
         "levels": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -399,7 +399,7 @@
         "title": "应用诊断日志",
         "description": "控制应用诊断日志的输出级别",
         "enabled": "启用应用诊断日志",
-        "enabledDescription": "控制 cc-switch.log；不影响请求用量记录和 crash.log",
+        "enabledDescription": "控制 loongport.log；不影响请求用量记录和 crash.log",
         "level": "日志级别",
         "levelDescription": "设置输出的最低日志级别",
         "levels": {

--- a/src/lib/frontendLogger.ts
+++ b/src/lib/frontendLogger.ts
@@ -1,4 +1,9 @@
-import { error as writeErrorLog } from "@tauri-apps/plugin-log";
+import {
+  debug as writeDebugLog,
+  error as writeErrorLog,
+  info as writeInfoLog,
+  warn as writeWarnLog,
+} from "@tauri-apps/plugin-log";
 
 const MAX_LOG_MESSAGE_LENGTH = 12_000;
 const MAX_RAW_LOG_INPUT_LENGTH = 16_000;
@@ -9,9 +14,9 @@ const MAX_SERIALIZATION_DEPTH = 4;
 const QUERY_VALUE_PATTERN = /([?&][A-Za-z0-9_.~-]+)=([^&#\s"'<>]*)/g;
 const URL_CREDENTIAL_PATTERN = /(https?:\/\/)[^/@\s]+@/gi;
 const QUOTED_NAMED_SECRET_PATTERN =
-  /((?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|authorization|auth|password|passwd|pwd|secret|cookie)\s*["']?\s*[:=]\s*)(["'])(.*?)\2/gi;
+  /(\b(?:api[_-]?key|access[_-]?key|secret[_-]?key|private[_-]?key|client[_-]?secret|auth[_-]?token|access[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?token|session[_-]?id|authorization|credential|password|passwd|bearer|cookie|secret|token|auth|pwd|key)s?\s*["']?\s*[:=]\s*)(["'])(.*?)\2/gi;
 const NAMED_SECRET_PATTERN =
-  /((?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|authorization|auth|password|passwd|pwd|secret|cookie)\s*["']?\s*[:=]\s*["']?)([^\s"',}]+)/gi;
+  /(\b(?:api[_-]?key|access[_-]?key|secret[_-]?key|private[_-]?key|client[_-]?secret|auth[_-]?token|access[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?token|session[_-]?id|authorization|credential|password|passwd|bearer|cookie|secret|token|auth|pwd|key)s?\s*["']?\s*[:=]\s*["']?)([^\s"',}]+)/gi;
 // 敏感键的值是数组/对象(`"tokens":[...]`、`"auth":{...}`)时，标量正则够不着里面的元素。
 // 文本层是所有入口(Error/string/对象/嵌套/前缀+JSON)最终汇聚的唯一出口，故在这里
 // 兜底：命中敏感键名后把紧跟的 `[..]`/`{..}` 整体替换。`\b` 防止匹配到 monkey 之类的后缀，
@@ -20,12 +25,19 @@ const NAMED_SECRET_CONTAINER_PATTERN =
   /((?:\\?["'])?\b(?:api[_-]?key|access[_-]?key|secret[_-]?key|private[_-]?key|client[_-]?secret|auth[_-]?token|access[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?token|session[_-]?id|authorization|credential|password|passwd|bearer|cookie|secret|token|auth|pwd|key)s?(?:\\?["'])?\s*[:=]\s*)(\[[^\]]*\]|\{[^{}]*\})/gi;
 const SENSITIVE_HEADER_LINE_PATTERN =
   /(^|[\r\n])([ \t]*(?:(?:proxy-)?authorization|cookie|set-cookie|x-api-key|api-key)\s*[:=]\s*)[^\r\n]+/gim;
+const JSON_BODY_FIELD_PATTERN =
+  /(["'](?:request[_-]?body|response[_-]?body|body|payload)["']\s*:\s*)(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\[[^\]]*\]|\{[^{}]*\}|[^,}\r\n]+)/gi;
+const BODY_FIELD_LINE_PATTERN =
+  /(^|[\r\n \t])((?:request[_-]?body|response[_-]?body|body|payload)\b\s*[:=]\s*).*$/gim;
+const HTTP_STATUS_BODY_PATTERN = /(HTTP\s+\d{3}\s*:\s*)[^\r\n]*/gim;
 const AUTH_SCHEME_PATTERN =
   /\b(Bearer|Basic|Token|ApiKey|Digest|Negotiate|AWS4-HMAC-SHA256)\s+[^\s"',}\]]+/gi;
 const SECRET_VALUE_IN_TEXT_PATTERN =
   /(^|[^A-Za-z0-9]|\\[nrt])(?:sk-[A-Za-z0-9._~+\/-]{6,}|AIza[A-Za-z0-9_-]{8,}|github_pat_[A-Za-z0-9_]{6,}|gh[pousr]_[A-Za-z0-9_]{6,}|xox[baprs]-[A-Za-z0-9-]{6,}|ya29\.[A-Za-z0-9._-]{6,}|(?:AKIA|ASIA)[A-Z0-9]{12,}|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)/gim;
 const SECRET_VALUE_WITHIN_STRING_PATTERN =
   /(?:sk-[A-Za-z0-9._~+\/-]{6,}|AIza[A-Za-z0-9_-]{8,}|github_pat_[A-Za-z0-9_]{6,}|gh[pousr]_[A-Za-z0-9_]{6,}|xox[baprs]-[A-Za-z0-9-]{6,}|ya29\.[A-Za-z0-9._-]{6,}|(?:AKIA|ASIA)[A-Z0-9]{12,}|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)/i;
+const PRIVATE_KEY_PATTERN =
+  /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----[\s\S]*?(?:-----END (?:RSA |EC |OPENSSH )?PRIVATE KEY-----|$)/gi;
 function truncateForProcessing(input: string, limit: number): string {
   if (input.length <= limit) {
     return input;
@@ -35,12 +47,16 @@ function truncateForProcessing(input: string, limit: number): string {
 
 export function redactFrontendLogText(input: string): string {
   return input
+    .replace(NAMED_SECRET_CONTAINER_PATTERN, '$1"[REDACTED]"')
     .replace(QUERY_VALUE_PATTERN, "$1=[REDACTED]")
     .replace(URL_CREDENTIAL_PATTERN, "$1[REDACTED]@")
     .replace(SENSITIVE_HEADER_LINE_PATTERN, "$1$2[REDACTED]")
     .replace(AUTH_SCHEME_PATTERN, "$1 [REDACTED]")
+    .replace(JSON_BODY_FIELD_PATTERN, '$1"[REDACTED BODY]"')
+    .replace(BODY_FIELD_LINE_PATTERN, "$1$2[REDACTED BODY]")
+    .replace(HTTP_STATUS_BODY_PATTERN, "$1[REDACTED RESPONSE BODY]")
+    .replace(PRIVATE_KEY_PATTERN, "[REDACTED PRIVATE KEY]")
     .replace(SECRET_VALUE_IN_TEXT_PATTERN, "$1[REDACTED]")
-    .replace(NAMED_SECRET_CONTAINER_PATTERN, "$1[REDACTED]")
     .replace(QUOTED_NAMED_SECRET_PATTERN, "$1$2[REDACTED]$2")
     .replace(NAMED_SECRET_PATTERN, "$1[REDACTED]");
 }
@@ -90,6 +106,10 @@ const SENSITIVE_KEY_NAMES = new Set([
   "secret",
   "credential",
   "cookie",
+  "body",
+  "requestbody",
+  "responsebody",
+  "payload",
 ]);
 
 function isSensitiveKey(key: string): boolean {
@@ -277,6 +297,9 @@ function describeError(error: unknown): string {
     );
   }
   if (typeof error === "string") {
+    if (looksLikeSecretValue(error)) {
+      return "[REDACTED]";
+    }
     const structured = redactStructuredString(error);
     if (structured !== null) {
       return structured;
@@ -291,6 +314,46 @@ function describeError(error: unknown): string {
     return "[Unserializable thrown value]";
   }
   return truncateForProcessing(structured, MAX_RAW_LOG_INPUT_LENGTH);
+}
+
+export type FrontendLogLevel = "debug" | "info" | "warn" | "error";
+
+const FRONTEND_LOG_WRITERS = {
+  debug: writeDebugLog,
+  info: writeInfoLog,
+  warn: writeWarnLog,
+  error: writeErrorLog,
+} as const;
+
+function finalizeFrontendLogMessage(raw: string): string {
+  const bounded = truncateForProcessing(raw, MAX_RAW_LOG_INPUT_LENGTH);
+  const redacted = redactFrontendLogText(bounded);
+  return redacted.length > MAX_LOG_MESSAGE_LENGTH
+    ? `${redacted.slice(0, MAX_LOG_MESSAGE_LENGTH)}\n[truncated]`
+    : redacted;
+}
+
+function persistFrontendLog(level: FrontendLogLevel, raw: string): string {
+  const message = finalizeFrontendLogMessage(raw);
+  // Web 开发/测试环境没有 Tauri invoke；落盘失败不能再写 console，否则 console bridge
+  // 会形成递归错误循环。
+  void FRONTEND_LOG_WRITERS[level](message, { file: "frontend" }).catch(
+    () => undefined,
+  );
+  return message;
+}
+
+export function reportFrontendLog(
+  level: FrontendLogLevel,
+  event: string,
+  outcome: string,
+  fields: Record<string, unknown> = {},
+): void {
+  const serialized = serializeStructured({ event, outcome, ...fields });
+  persistFrontendLog(
+    level,
+    `[frontend] ${serialized ?? "[Unserializable diagnostic event]"}`,
+  );
 }
 
 export function reportFrontendError(
@@ -311,15 +374,51 @@ export function reportFrontendError(
       .join("\n"),
     MAX_RAW_LOG_INPUT_LENGTH,
   );
-  const redacted = redactFrontendLogText(raw);
-  const message =
-    redacted.length > MAX_LOG_MESSAGE_LENGTH
-      ? `${redacted.slice(0, MAX_LOG_MESSAGE_LENGTH)}\n[truncated]`
-      : redacted;
+  persistFrontendLog("error", raw);
+}
 
-  // Web 开发/测试环境没有 Tauri invoke，日志上报失败不应再触发
-  // console.error 或未处理 Promise，否则会形成错误循环。
-  void writeErrorLog(message, { file: "frontend" }).catch(() => undefined);
+const CONSOLE_LEVELS = ["error", "warn", "info", "log", "debug"] as const;
+type BridgedConsoleLevel = (typeof CONSOLE_LEVELS)[number];
+
+function consoleLogLevel(level: BridgedConsoleLevel): FrontendLogLevel {
+  if (level === "log") return "info";
+  return level;
+}
+
+function formatConsoleArguments(args: unknown[]): string {
+  return args.map((argument) => describeError(argument)).join(" ");
+}
+
+/**
+ * 将遗留和第三方 console 调用统一送入持久化日志，并把 DevTools 输出也替换为脱敏文本。
+ * 返回卸载函数，便于测试、HMR 和未来嵌入式入口安全恢复原 console。
+ */
+export function installConsoleLogBridge(target: Console = console): () => void {
+  const originals = new Map<
+    BridgedConsoleLevel,
+    (...args: unknown[]) => void
+  >();
+
+  for (const level of CONSOLE_LEVELS) {
+    const original = target[level].bind(target) as (...args: unknown[]) => void;
+    originals.set(level, original);
+    target[level] = ((...args: unknown[]) => {
+      const message = persistFrontendLog(
+        consoleLogLevel(level),
+        `[frontend] console.${level}\n${formatConsoleArguments(args)}`,
+      );
+      original(message);
+    }) as Console[typeof level];
+  }
+
+  return () => {
+    for (const level of CONSOLE_LEVELS) {
+      const original = originals.get(level);
+      if (original) {
+        target[level] = original as Console[typeof level];
+      }
+    }
+  };
 }
 
 export function installGlobalErrorHandlers(

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,6 +16,7 @@ import { message } from "@tauri-apps/plugin-dialog";
 import { exit } from "@tauri-apps/plugin-process";
 import { FrontendErrorBoundary } from "./components/FrontendErrorBoundary";
 import {
+  installConsoleLogBridge,
   installGlobalErrorHandlers,
   reportFrontendError,
 } from "./lib/frontendLogger";
@@ -24,6 +25,7 @@ import {
   syncModelsDevPricingOnStartup,
 } from "./lib/modelsDevAutoSync";
 
+installConsoleLogBridge();
 installGlobalErrorHandlers();
 
 // 根据平台添加 body class，便于平台特定样式

--- a/tests/fixtures/browser-probe-script.txt
+++ b/tests/fixtures/browser-probe-script.txt
@@ -1,7 +1,7 @@
 
 (() => {
   const expectedOrigin = "https://relay.example";
-  const candidates = [{"id":"sub2api","path":"/api/v1/settings/public"},{"id":"newapi","path":"/api/status"}];
+  const candidates = [{"id":"sub2api","path":"/api/v1/settings/public","bearer_token_storage_key":"auth_token"},{"id":"newapi","path":"/api/status"}];
   const callbackScheme = 'loongport-probe';
   const requestTimeoutMs = 5000;
   let previousBatch = '';
@@ -12,6 +12,18 @@
     let binary = '';
     for (const byte of bytes) binary += String.fromCharCode(byte);
     return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+  }
+
+  function headersFor(candidate) {
+    const headers = { Accept: 'application/json' };
+    if (!candidate.bearer_token_storage_key) return headers;
+    try {
+      const token = localStorage.getItem(candidate.bearer_token_storage_key);
+      if (token) headers.Authorization = 'Bearer ' + token;
+    } catch (_) {
+      // Some verification pages disable storage. Cookie-only probing still remains available.
+    }
+    return headers;
   }
 
   async function probe() {
@@ -29,7 +41,7 @@
             const response = await fetch(candidate.path, {
               credentials: 'include',
               cache: 'no-store',
-              headers: { Accept: 'application/json' },
+              headers: headersFor(candidate),
               signal: controller.signal,
             });
             return response.text();

--- a/tests/fixtures/browser-probe-script.txt
+++ b/tests/fixtures/browser-probe-script.txt
@@ -26,6 +26,24 @@
     return headers;
   }
 
+  function responseContentType(response) {
+    try {
+      const value = response.headers && response.headers.get
+        ? response.headers.get('content-type')
+        : null;
+      if (typeof value !== 'string' || !value) return null;
+      return value.replace(/[\u0000-\u001f\u007f]/g, ' ').slice(0, 128);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function safeErrorKind(error) {
+    const name = error && typeof error.name === 'string' ? error.name : '';
+    const safeName = name.replace(/[^A-Za-z0-9_.-]/g, '').slice(0, 64);
+    return safeName || 'Error';
+  }
+
   async function probe() {
     if (window.location.origin !== expectedOrigin) return;
     if (probeInFlight) return;
@@ -44,27 +62,45 @@
               headers: headersFor(candidate),
               signal: controller.signal,
             });
-            return response.text();
+            const body = await response.text();
+            return { response, body };
           })();
           const timeout = new Promise((_, reject) => {
             timeoutId = setTimeout(() => {
               controller.abort();
-              reject(new Error('probe request timed out'));
+              const error = new Error('probe request timed out');
+              error.name = 'ProbeTimeout';
+              reject(error);
             }, requestTimeoutMs);
           });
-          const body = await Promise.race([request, timeout]);
+          const { response, body } = await Promise.race([request, timeout]);
+          const bodyBytes = new TextEncoder().encode(body).length;
           const trimmed = body.trim();
-          if (!trimmed || (trimmed[0] !== '{' && trimmed[0] !== '[')) continue;
-          if (new TextEncoder().encode(body).length > 65536) continue;
-          responses.push({ candidate_id: candidate.id, body });
-        } catch (_) {
-          // 页面仍可能处于验证或跳转阶段；下一轮继续，不在浏览器层解释失败原因。
+          const jsonLike = Boolean(trimmed) && (trimmed[0] === '{' || trimmed[0] === '[');
+          responses.push({
+            candidate_id: candidate.id,
+            body: jsonLike && bodyBytes <= 65536 ? body : '',
+            status: Number.isInteger(response.status) ? response.status : null,
+            content_type: responseContentType(response),
+            body_bytes: bodyBytes,
+            json_like: jsonLike,
+            error_kind: null,
+          });
+        } catch (error) {
+          responses.push({
+            candidate_id: candidate.id,
+            body: '',
+            status: null,
+            content_type: null,
+            body_bytes: 0,
+            json_like: false,
+            error_kind: safeErrorKind(error),
+          });
         } finally {
           if (timeoutId !== undefined) clearTimeout(timeoutId);
         }
       }
 
-      if (!responses.length) return;
       const batch = JSON.stringify(responses);
       if (batch === previousBatch) return;
       previousBatch = batch;

--- a/tests/lib/browserProbeScriptRuns.test.ts
+++ b/tests/lib/browserProbeScriptRuns.test.ts
@@ -108,6 +108,66 @@ describe("browser probe generated script", () => {
     ).toHaveLength(3);
   });
 
+  it("uses the page's candidate-specific bearer session for authenticated browser probes", async () => {
+    const requests: Array<{
+      path: string;
+      authorization: string | undefined;
+    }> = [];
+    const navigations: string[] = [];
+    const location = {
+      origin: "https://relay.example",
+      get href() {
+        return navigations.at(-1) ?? "https://relay.example/dashboard";
+      },
+      set href(value: string) {
+        navigations.push(value);
+      },
+    };
+
+    const sandbox = {
+      window: { location },
+      localStorage: {
+        getItem: (key: string) =>
+          key === "auth_token" ? "browser-session-token" : null,
+      },
+      fetch: (
+        path: string,
+        init: { headers?: Record<string, string> } = {},
+      ) => {
+        const authorization = init.headers?.Authorization;
+        requests.push({ path, authorization });
+        const body =
+          path === "/api/v1/settings/public" &&
+          authorization === "Bearer browser-session-token"
+            ? '{"code":0}'
+            : "<html>verification required</html>";
+        return Promise.resolve({ text: () => Promise.resolve(body) });
+      },
+      setInterval: () => 1,
+      setTimeout,
+      clearTimeout,
+      AbortController,
+      TextEncoder,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      JSON,
+    };
+
+    vm.runInNewContext(readFileSync(SCRIPT, "utf8"), sandbox, {
+      timeout: 5000,
+    });
+    await flushPromises();
+
+    expect(requests[0]).toEqual({
+      path: "/api/v1/settings/public",
+      authorization: "Bearer browser-session-token",
+    });
+    expect(requests[1]).toEqual({
+      path: "/api/status",
+      authorization: undefined,
+    });
+    expect(navigations).toHaveLength(1);
+  });
+
   it("times out one candidate, continues the batch, and emits only after settlement", async () => {
     const fetchedPaths: string[] = [];
     const navigations: string[] = [];

--- a/tests/lib/browserProbeScriptRuns.test.ts
+++ b/tests/lib/browserProbeScriptRuns.test.ts
@@ -97,8 +97,24 @@ describe("browser probe generated script", () => {
       Buffer.from(encoded!, "base64url").toString("utf8"),
     );
     expect(batch).toEqual([
-      { candidate_id: "sub2api", body: '{"code":0}' },
-      { candidate_id: "newapi", body: '{"success":true}' },
+      {
+        candidate_id: "sub2api",
+        body: '{"code":0}',
+        status: null,
+        content_type: null,
+        body_bytes: Buffer.byteLength('{"code":0}'),
+        json_like: true,
+        error_kind: null,
+      },
+      {
+        candidate_id: "newapi",
+        body: '{"success":true}',
+        status: null,
+        content_type: null,
+        body_bytes: Buffer.byteLength('{"success":true}'),
+        json_like: true,
+        error_kind: null,
+      },
     ]);
 
     intervalCallbacks[0]();
@@ -168,6 +184,75 @@ describe("browser probe generated script", () => {
     expect(navigations).toHaveLength(1);
   });
 
+  it("reports safe response metadata when a verification page is not JSON", async () => {
+    const navigations: string[] = [];
+    const verificationBody = "<html><body>verification required</body></html>";
+    const location = {
+      origin: "https://relay.example",
+      get href() {
+        return navigations.at(-1) ?? "https://relay.example/dashboard";
+      },
+      set href(value: string) {
+        navigations.push(value);
+      },
+    };
+
+    const sandbox = {
+      window: { location },
+      fetch: () =>
+        Promise.resolve({
+          status: 403,
+          headers: {
+            get: (name: string) =>
+              name.toLowerCase() === "content-type"
+                ? "text/html; charset=UTF-8"
+                : null,
+          },
+          text: () => Promise.resolve(verificationBody),
+        }),
+      setInterval: () => 1,
+      setTimeout,
+      clearTimeout,
+      AbortController,
+      TextEncoder,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      JSON,
+    };
+
+    vm.runInNewContext(readFileSync(SCRIPT, "utf8"), sandbox, {
+      timeout: 5000,
+    });
+    await flushPromises();
+
+    expect(navigations).toHaveLength(1);
+    const encoded = new URL(navigations[0]).searchParams.get("d");
+    expect(encoded).not.toBeNull();
+    const batch = JSON.parse(
+      Buffer.from(encoded!, "base64url").toString("utf8"),
+    );
+    expect(batch).toEqual([
+      {
+        candidate_id: "sub2api",
+        body: "",
+        status: 403,
+        content_type: "text/html; charset=UTF-8",
+        body_bytes: Buffer.byteLength(verificationBody),
+        json_like: false,
+        error_kind: null,
+      },
+      {
+        candidate_id: "newapi",
+        body: "",
+        status: 403,
+        content_type: "text/html; charset=UTF-8",
+        body_bytes: Buffer.byteLength(verificationBody),
+        json_like: false,
+        error_kind: null,
+      },
+    ]);
+    expect(JSON.stringify(batch)).not.toContain(verificationBody);
+  });
+
   it("times out one candidate, continues the batch, and emits only after settlement", async () => {
     const fetchedPaths: string[] = [];
     const navigations: string[] = [];
@@ -219,5 +304,26 @@ describe("browser probe generated script", () => {
     secondBody.resolve('{"success":true}');
     await flushPromises();
     expect(navigations).toHaveLength(1);
+
+    const encoded = new URL(navigations[0]).searchParams.get("d");
+    expect(encoded).not.toBeNull();
+    const batch = JSON.parse(
+      Buffer.from(encoded!, "base64url").toString("utf8"),
+    );
+    expect(batch[0]).toEqual({
+      candidate_id: "sub2api",
+      body: "",
+      status: null,
+      content_type: null,
+      body_bytes: 0,
+      json_like: false,
+      error_kind: "ProbeTimeout",
+    });
+    expect(batch[1]).toMatchObject({
+      candidate_id: "newapi",
+      body: '{"success":true}',
+      json_like: true,
+      error_kind: null,
+    });
   });
 });

--- a/tests/lib/frontendLogger.test.ts
+++ b/tests/lib/frontendLogger.test.ts
@@ -1,22 +1,34 @@
-const writeErrorLog = vi.hoisted(() =>
-  vi.fn<(message: string, options: { file: string }) => Promise<void>>(() =>
-    Promise.resolve(),
+const logWriters = vi.hoisted(() => ({
+  error: vi.fn<(message: string, options: { file: string }) => Promise<void>>(
+    () => Promise.resolve(),
   ),
-);
-
-vi.mock("@tauri-apps/plugin-log", () => ({
-  error: writeErrorLog,
+  warn: vi.fn<(message: string, options: { file: string }) => Promise<void>>(
+    () => Promise.resolve(),
+  ),
+  info: vi.fn<(message: string, options: { file: string }) => Promise<void>>(
+    () => Promise.resolve(),
+  ),
+  debug: vi.fn<(message: string, options: { file: string }) => Promise<void>>(
+    () => Promise.resolve(),
+  ),
 }));
+const writeErrorLog = logWriters.error;
+
+vi.mock("@tauri-apps/plugin-log", () => logWriters);
 
 import {
+  installConsoleLogBridge,
   installGlobalErrorHandlers,
   redactFrontendLogText,
   reportFrontendError,
+  reportFrontendLog,
 } from "@/lib/frontendLogger";
 
 describe("frontendLogger", () => {
   beforeEach(() => {
-    writeErrorLog.mockClear();
+    for (const writer of Object.values(logWriters)) {
+      writer.mockClear();
+    }
   });
 
   it("redacts URL parameters and named credentials", () => {
@@ -49,6 +61,18 @@ describe("frontendLogger", () => {
       '{"detail":"line1\\nsk-ant-api03-escaped-secret"}',
     );
     expect(escapedMultiline).not.toContain("sk-ant-api03-escaped-secret");
+  });
+
+  it("redacts the complete credential key vocabulary in ordinary console text", () => {
+    const redacted = redactFrontendLogText(
+      'client_secret="private-client" session_id=private-session private_key=private-key credential=private-credential',
+    );
+
+    expect(redacted).not.toContain("private-client");
+    expect(redacted).not.toContain("private-session");
+    expect(redacted).not.toContain("private-key");
+    expect(redacted).not.toContain("private-credential");
+    expect(redacted.match(/\[REDACTED\]/g)).toHaveLength(4);
   });
 
   it("writes bounded, redacted errors through the Tauri log plugin", () => {
@@ -295,6 +319,117 @@ describe("frontendLogger", () => {
       reportFrontendError("unhandledrejection", reason),
     ).not.toThrow();
     expect(writeErrorLog.mock.calls[0][0]).toContain("[Circular]");
+  });
+
+  it("redacts raw private keys and opaque console credentials", () => {
+    reportFrontendError(
+      "key import failed",
+      "-----BEGIN PRIVATE KEY-----\nprivate-material\n-----END PRIVATE KEY-----",
+    );
+    reportFrontendError(
+      "opaque credential failed",
+      "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789",
+    );
+
+    expect(writeErrorLog).toHaveBeenCalledTimes(2);
+    for (const [message] of writeErrorLog.mock.calls) {
+      expect(message).not.toContain("private-material");
+      expect(message).not.toContain("AbCdEfGhIjKlMnOpQrStUvWxYz0123456789");
+      expect(message).toContain("[REDACTED");
+    }
+  });
+
+  it("redacts private keys even when processing truncates before the end marker", () => {
+    reportFrontendError(
+      "key import failed",
+      new Error(
+        `-----BEGIN PRIVATE KEY-----\nprivate-material\n${"A".repeat(20_000)}`,
+      ),
+    );
+
+    expect(writeErrorLog).toHaveBeenCalledOnce();
+    const [message] = writeErrorLog.mock.calls[0];
+    expect(message).not.toContain("private-material");
+    expect(message).not.toContain("BEGIN PRIVATE KEY");
+    expect(message).toContain("[REDACTED PRIVATE KEY]");
+  });
+
+  it("redacts named request and response bodies", () => {
+    const redacted = redactFrontendLogText(
+      'response_body={"private":"html"}\npayload=<html>verification secret</html>',
+    );
+
+    expect(redacted).not.toContain("verification secret");
+    expect(redacted).not.toContain('"private":"html"');
+    expect(redacted).toContain("[REDACTED BODY]");
+  });
+
+  it("writes structured non-error diagnostics at the requested level", () => {
+    reportFrontendLog("warn", "settings.save", "failed", {
+      section: "proxy",
+      responseBody: "private server response",
+    });
+
+    expect(logWriters.warn).toHaveBeenCalledOnce();
+    const [message, options] = logWriters.warn.mock.calls[0];
+    expect(message).toContain('"event":"settings.save"');
+    expect(message).toContain('"outcome":"failed"');
+    expect(message).toContain('"section":"proxy"');
+    expect(message).not.toContain("private server response");
+    const event = JSON.parse(message.replace(/^\[frontend\] /, ""));
+    expect(event).toMatchObject({
+      event: "settings.save",
+      outcome: "failed",
+      section: "proxy",
+      responseBody: "[REDACTED BODY]",
+    });
+    expect(options).toEqual({ file: "frontend" });
+  });
+
+  it("bridges console levels into persisted logs without retaining raw secrets", () => {
+    const originalError = vi.fn();
+    const originalWarn = vi.fn();
+    const originalInfo = vi.fn();
+    const originalLog = vi.fn();
+    const originalDebug = vi.fn();
+    const target = {
+      error: originalError,
+      warn: originalWarn,
+      info: originalInfo,
+      log: originalLog,
+      debug: originalDebug,
+    } as unknown as Console;
+    const uninstall = installConsoleLogBridge(target);
+
+    target.error("request failed", {
+      authorization: "Bearer private-token",
+      responseBody: "<html>private verification page</html>",
+    });
+    target.warn("retrying", { token: "private-token" });
+    target.info("loaded", { count: 2 });
+    target.log("legacy info");
+    target.debug("details", { cookie: "private-cookie" });
+
+    expect(logWriters.error).toHaveBeenCalledOnce();
+    expect(logWriters.warn).toHaveBeenCalledOnce();
+    expect(logWriters.info).toHaveBeenCalledTimes(2);
+    expect(logWriters.debug).toHaveBeenCalledOnce();
+    for (const writer of Object.values(logWriters)) {
+      for (const [message] of writer.mock.calls) {
+        expect(message).not.toContain("private-token");
+        expect(message).not.toContain("private-cookie");
+        expect(message).not.toContain("private verification page");
+      }
+    }
+    expect(originalError.mock.calls[0][0]).not.toContain("private-token");
+    expect(originalError.mock.calls[0][0]).not.toContain(
+      "private verification page",
+    );
+
+    uninstall();
+    target.error("after uninstall");
+    expect(logWriters.error).toHaveBeenCalledOnce();
+    expect(originalError).toHaveBeenCalledTimes(2);
   });
 
   it("captures global errors and unhandled rejections and can uninstall", () => {

--- a/tests/lib/frontendLoggerBootstrap.test.ts
+++ b/tests/lib/frontendLoggerBootstrap.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const MAIN = readFileSync(resolve(__dirname, "../../src/main.tsx"), "utf8");
+
+describe("frontend diagnostics bootstrap", () => {
+  it("installs the console bridge before global error handlers", () => {
+    const bridge = MAIN.indexOf("installConsoleLogBridge();");
+    const handlers = MAIN.indexOf("installGlobalErrorHandlers();");
+
+    expect(bridge).toBeGreaterThanOrEqual(0);
+    expect(handlers).toBeGreaterThan(bridge);
+  });
+});


### PR DESCRIPTION
## Summary / 概述

- Reuse the browser-authenticated WebView session during protocol discovery. sub2api candidates read `localStorage.auth_token` inside the target origin and attach it only to that sub2api probe; the token never returns to Rust or reaches NewAPI candidates.
- Keep the browser flow protocol-neutral so Cloudflare and future verification/login pages are completed by the user before the shared candidate registry retries. NewAPI and future protocols can extend the candidate registry without changing the WebView flow.
- Return safe probe diagnostics (candidate ID, HTTP status, content type, byte count, JSON shape, error kind) while keeping strict detector boundaries so NewAPI cannot be misclassified as sub2api.
- Centralize application diagnostics across Rust, WebView, crash logging, and the image-generation MCP stderr path. The final sink redacts credentials, URL query values, auth/cookie headers, request/response bodies, payloads, private keys, and common token shapes before output.
- Bridge legacy/third-party `console.*` calls into persistent frontend diagnostics, add structured single-line diagnostic events and best-effort failure logging, and audit high-value silent failures in proxy takeover/failover, provider/skill consistency, schema migration, S3/WebDAV background sync, startup migration, crash reporting, and MCP diagnostics.
- Document the diagnostic contract in `docs/diagnostics.md` and correct the user-facing log filename to `loongport.log`.

## Root cause / 根因

The sub2api login session stores its bearer token in `localStorage.auth_token`. The old protocol probe used only `credentials: "include"`, which reused cookies but not that bearer token. The site page was logged in, while LoongPort's separate probe still received Cloudflare/verification responses and eventually timed out. Existing logs recorded only page lifecycle and the final timeout, so the missing authorization context and probe responses were invisible.

## Security / 安全边界

- No Cloudflare or verification bypass is implemented; the user completes verification/login in the visible WebView.
- Browser tokens stay inside the target origin and are attached only to the matching protocol candidate.
- Tokens, cookies, authorization headers, localStorage contents, response bodies, verification HTML, and full payloads are not returned or logged.
- Truncated private keys and credential containers are covered by regression tests; ordinary keys such as `monkey`/`hotkey` remain visible for useful diagnostics.

## Validation / 验证

- `cargo fmt --all -- --check`
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -- --skip update_current_claude_desktop_provider_syncs_profile_when_proxy_takeover_is_active`
- `npx tsc --noEmit`
- `pnpm format:check`
- `npx vitest run` — 125 files / 784 tests
- `git diff --check`

## Screenshots / 截图

N/A — protocol discovery, diagnostics infrastructure, and background error-path changes.
