### PR TITLE
chore: release 3.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-switch",
-  "version": "3.22.7",
+  "version": "3.23.0",
   "description": "All-in-One Assistant for Claude Code, Codex & Gemini CLI",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "cc-switch"
-version = "3.22.7"
+version = "3.23.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # （裁决见 CLAUDE.md「三点五」）。面向用户的二进制名走 tauri.conf.json 的
 # `mainBinaryName`（已是 `LoongPort`）。
 name = "cc-switch"
-version = "3.22.7"
+version = "3.23.0"
 description = "同样的 Codex，成本省 95% 以上 —— 填一个域名、登录一次，其余自动配好"
 authors = ["SailingLoong", "Jason Young"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LoongPort",
   "mainBinaryName": "LoongPort",
-  "version": "3.22.7",
+  "version": "3.23.0",
   "identifier": "dev.loongport.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary / 概述

- Bump the application version from `3.22.7` to `3.23.0`.
- Keep the four version sources synchronized: `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and `src-tauri/tauri.conf.json`.

## Why / 原因

The already-published `v3.23` tag was created from source whose internal application version was still `3.22.7`. This follow-up establishes the canonical SemVer release version `3.23.0` without rewriting the existing published tag or release.

After this PR is merged, a new `v3.23.0` tag will trigger the release workflow and produce packages whose embedded application version matches the release tag.

## Validation / 验证

- `cargo fmt --all -- --check`
- `cargo test the_version_is_the_same_in_all_three_manifests --lib`
- `cargo check`
- `pnpm format:check`
- `git diff --check`
