### PR TITLE
docs(config): explain Claude model tier routing

### DIFF
--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -1265,6 +1265,11 @@ export const providerPresets: ProviderPreset[] = [
         // base_url 由代理后端强制重写为 chatgpt.com/backend-api/codex
         // 用户无需配置
         ANTHROPIC_BASE_URL: "https://chatgpt.com/backend-api/codex",
+        // Quality-first on purpose: sol is the top tier (Opus-class), luna sits
+        // around Sonnet for much less. We still route the Sonnet tier to sol —
+        // GPT pricing is low enough that the quality is worth it — and reserve
+        // luna for the low-frequency Haiku tier. Not an oversight; don't
+        // "fix" Sonnet down to luna without revisiting that tradeoff.
         ANTHROPIC_MODEL: "gpt-5.6-sol",
         ANTHROPIC_DEFAULT_HAIKU_MODEL: "gpt-5.6-luna",
         ANTHROPIC_DEFAULT_SONNET_MODEL: "gpt-5.6-sol",


### PR DESCRIPTION
## What changed

- document why the Claude preset routes the Sonnet tier to `gpt-5.6-sol`
- clarify that `gpt-5.6-luna` is intentionally reserved for the Haiku tier

## Why

The current values are intentional, but without nearby context the Sonnet-to-sol mapping looks like an accidental tier mismatch and is easy to "correct" incorrectly.

## Impact

Documentation-only change; runtime configuration is unchanged.

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `pnpm exec tsc --noEmit`
- `pnpm format:check`
- `pnpm exec vitest run`
