### PR TITLE
Fix legacy NewAPI session login and token provisioning

### DIFF
--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -1633,17 +1633,25 @@ async fn load_validated_relay<R: tauri::Runtime>(
                 "站点协议已变化，已清除旧凭据，请重新添加或登录".into(),
             ))
         }
-        Err(error) if error.kind == discovery::DiscoveryErrorKind::Transport => Err(
-            AppError::Config(format!("连接站点失败，未改动已有凭据：{}", error.message)),
-        ),
-        Err(error) => {
-            let state = app_handle.state::<AppState>();
-            with_conn(&state, |conn| creds::clear_credentials(conn, relay_id))?;
-            Err(AppError::Config(format!(
-                "站点协议无法安全识别，已清除旧凭据：{}",
+        Err(error) => match error.kind {
+            discovery::DiscoveryErrorKind::Transport => Err(AppError::Config(format!(
+                "连接站点失败，未改动已有凭据：{}",
                 error.message
-            )))
-        }
+            ))),
+            discovery::DiscoveryErrorKind::UnsupportedSite => {
+                log::warn!(
+                    "站点探针暂时无法识别 {}，沿用已保存的 {} 协议和凭据：{}",
+                    op.site_origin,
+                    op.backend_kind.as_str(),
+                    error.message
+                );
+                Ok(op)
+            }
+            discovery::DiscoveryErrorKind::ProtocolConflict => Err(AppError::Config(format!(
+                "站点协议识别结果冲突，未改动已有凭据：{}",
+                error.message
+            ))),
+        },
     }
 }
 
@@ -4739,33 +4747,41 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn saved_relay_validation_clears_credentials_on_unsupported_or_conflicting_protocol() {
-        let cases = [
-            (
-                Some(serde_json::json!({ "unknown": "sub" })),
-                Some(serde_json::json!({ "unknown": "new" })),
-                "unsupported",
-            ),
-            (
-                Some(sub2api_discovery_body()),
-                Some(newapi_discovery_body()),
-                "conflict",
-            ),
-        ];
+    async fn saved_relay_validation_uses_saved_backend_when_probe_is_unsupported() {
+        let (origin, server) = spawn_discovery_server(
+            Some(serde_json::json!({ "unknown": "sub" })),
+            Some(serde_json::json!({ "unknown": "new" })),
+        )
+        .await;
+        let (app, relay_id) = saved_relay_app(&origin, discovery::BackendKind::NewApi);
 
-        for (sub2api_body, newapi_body, case_name) in cases {
-            let (origin, server) = spawn_discovery_server(sub2api_body, newapi_body).await;
-            let (app, relay_id) = saved_relay_app(&origin, discovery::BackendKind::NewApi);
+        let relay = usable_relay(app.handle(), relay_id)
+            .await
+            .expect("unsupported probe should fall back to the saved backend");
 
-            usable_relay(app.handle(), relay_id)
-                .await
-                .expect_err(case_name);
+        assert_eq!(relay.backend_kind, discovery::BackendKind::NewApi);
+        assert_eq!(relay.auth_token, "saved-access-token");
+        assert_eq!(relay.refresh_token.as_deref(), Some("saved-refresh-token"));
+        server.abort();
+    }
 
-            let relay = relay_credentials(&app, relay_id);
-            assert!(relay.auth_token.is_empty(), "{case_name}");
-            assert!(relay.refresh_token.is_none(), "{case_name}");
-            server.abort();
-        }
+    #[tokio::test]
+    async fn saved_relay_validation_preserves_credentials_on_conflicting_protocol() {
+        let (origin, server) = spawn_discovery_server(
+            Some(sub2api_discovery_body()),
+            Some(newapi_discovery_body()),
+        )
+        .await;
+        let (app, relay_id) = saved_relay_app(&origin, discovery::BackendKind::NewApi);
+
+        usable_relay(app.handle(), relay_id)
+            .await
+            .expect_err("conflicting probe must stop runtime dispatch");
+
+        let relay = relay_credentials(&app, relay_id);
+        assert_eq!(relay.auth_token, "saved-access-token");
+        assert_eq!(relay.refresh_token.as_deref(), Some("saved-refresh-token"));
+        server.abort();
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -215,6 +215,11 @@ enum BrowserLoginOutcome {
     Closed,
 }
 
+enum BrowserLoginCredential {
+    Sub2Api(login::Credentials),
+    NewApiUserId(i64),
+}
+
 enum RefreshWait<T, I> {
     Interrupted(I),
     Refreshed(Result<T, AppError>),
@@ -673,6 +678,16 @@ fn newapi_refresh_cookie_from_window(
     Ok(newapi::extract_refresh_cookie(&cookies))
 }
 
+fn newapi_session_cookie_from_window(
+    window: &tauri::WebviewWindow,
+    session_url: &url::Url,
+) -> Result<Option<String>, AppError> {
+    let cookies = window
+        .cookies_for_url(session_url.clone())
+        .map_err(|error| AppError::Config(format!("读取 NewAPI 登录会话失败: {error}")))?;
+    Ok(newapi::extract_session_cookie(&cookies))
+}
+
 async fn refresh_newapi_browser_session(
     site_origin: &str,
     refresh_cookie: &str,
@@ -736,7 +751,7 @@ async fn browser_import(
 
     let context = Arc::new(Mutex::new(initial_context));
     let last_probe_summary = Arc::new(Mutex::new(None::<String>));
-    let (creds_tx, mut creds_rx) = tokio::sync::mpsc::channel::<login::Credentials>(1);
+    let (creds_tx, mut creds_rx) = tokio::sync::mpsc::channel::<BrowserLoginCredential>(1);
     let (error_tx, mut error_rx) = tokio::sync::mpsc::channel::<RelayImportError>(1);
     let (closed_tx, mut closed_rx) = tokio::sync::mpsc::channel::<()>(1);
 
@@ -943,10 +958,23 @@ async fn browser_import(
             return false;
         }
 
+        if let Some(result) = newapi::parse_session_navigation(url) {
+            match result {
+                Ok(user_id) => {
+                    let _ = creds_tx.try_send(BrowserLoginCredential::NewApiUserId(user_id));
+                }
+                Err(error) => {
+                    log::warn!("NewAPI 登录回传解析失败: {error}");
+                    let _ = credential_error_tx.try_send(error.into());
+                }
+            }
+            return false;
+        }
+
         match login::parse_creds_navigation(url) {
             None => true,
             Some(Ok(credentials)) => {
-                let _ = creds_tx.try_send(credentials);
+                let _ = creds_tx.try_send(BrowserLoginCredential::Sub2Api(credentials));
                 false
             }
             Some(Err(error)) => {
@@ -971,13 +999,20 @@ async fn browser_import(
     let refresh_url = newapi::refresh_url(&site_origin)?;
     let outcome = tokio::time::timeout(std::time::Duration::from_secs(LOGIN_TIMEOUT_SECS), async {
         let mut cookie_poll = tokio::time::interval(std::time::Duration::from_millis(500));
+        let mut newapi_user_id = None;
         loop {
             tokio::select! {
                 biased;
                 _ = closed_rx.recv() => break BrowserLoginOutcome::Closed,
-                credentials = creds_rx.recv() => break credentials
-                    .map(BrowserLoginOutcome::Sub2ApiCredentials)
-                    .unwrap_or(BrowserLoginOutcome::Closed),
+                credentials = creds_rx.recv() => match credentials {
+                    Some(BrowserLoginCredential::Sub2Api(credentials)) => {
+                        break BrowserLoginOutcome::Sub2ApiCredentials(credentials)
+                    }
+                    Some(BrowserLoginCredential::NewApiUserId(user_id)) => {
+                        newapi_user_id = Some(user_id);
+                    }
+                    None => break BrowserLoginOutcome::Closed,
+                },
                 error = error_rx.recv() => break error
                     .map(BrowserLoginOutcome::Error)
                     .unwrap_or(BrowserLoginOutcome::Closed),
@@ -992,7 +1027,22 @@ async fn browser_import(
                     }
                     let refresh_cookie = match newapi_refresh_cookie_from_window(&window, &refresh_url) {
                         Ok(Some(refresh_cookie)) => refresh_cookie,
-                        Ok(None) => continue,
+                        Ok(None) => {
+                            let Some(user_id) = newapi_user_id else { continue };
+                            let session_url = match newapi::session_token_url(&site_origin) {
+                                Ok(url) => url,
+                                Err(error) => break BrowserLoginOutcome::Error(error.into()),
+                            };
+                            let session_cookie = match newapi_session_cookie_from_window(&window, &session_url) {
+                                Ok(Some(cookie)) => cookie,
+                                Ok(None) => continue,
+                                Err(error) => break BrowserLoginOutcome::Error(error.into()),
+                            };
+                            match newapi::exchange_session(&site_origin, &session_cookie, user_id).await {
+                                Ok(session) => break BrowserLoginOutcome::NewApiSession(session),
+                                Err(error) => break BrowserLoginOutcome::Error(error.into()),
+                            }
+                        }
                         Err(error) => break BrowserLoginOutcome::Error(error.into()),
                     };
                     let interrupt = async {
@@ -1201,7 +1251,7 @@ async fn do_login(app_handle: &tauri::AppHandle, target_id: i64) -> Result<Login
     );
 
     // 凭据经这个 channel 从导航回调回到本函数。容量 1：只需要第一份。
-    let (tx, mut rx) = tokio::sync::mpsc::channel::<login::Credentials>(1);
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<BrowserLoginCredential>(1);
     // 用户自己关掉窗口的信号。没有它就只能干等 5 分钟超时。
     let (closed_tx, mut closed_rx) = tokio::sync::mpsc::channel::<()>(1);
 
@@ -1271,7 +1321,17 @@ async fn do_login(app_handle: &tauri::AppHandle, target_id: i64) -> Result<Login
         let _ = webview;
     })
     .on_navigation(move |url| {
-        if backend_kind_for_nav != discovery::BackendKind::Sub2Api {
+        if backend_kind_for_nav == discovery::BackendKind::NewApi {
+            if let Some(result) = newapi::parse_session_navigation(url) {
+                match result {
+                    Ok(user_id) => {
+                        let _ = tx.try_send(BrowserLoginCredential::NewApiUserId(user_id));
+                    }
+                    Err(error) => log::warn!("NewAPI 登录回传解析失败: {error}"),
+                }
+                return false;
+            }
+        } else if backend_kind_for_nav != discovery::BackendKind::Sub2Api {
             return true;
         }
         match login::parse_creds_navigation(url) {
@@ -1280,7 +1340,7 @@ async fn do_login(app_handle: &tauri::AppHandle, target_id: i64) -> Result<Login
             Some(Ok(creds)) => {
                 // 用 try_send：这个回调不能 await，而我们只要第一份凭据，
                 // 满了就说明已经收到过了。
-                let _ = tx.try_send(creds);
+                let _ = tx.try_send(BrowserLoginCredential::Sub2Api(creds));
                 false
             }
             Some(Err(e)) => {
@@ -1310,17 +1370,39 @@ async fn do_login(app_handle: &tauri::AppHandle, target_id: i64) -> Result<Login
     // 邮箱验证 + 2FA；超时不是错误，用户可能就是走开了。
     let outcome = tokio::time::timeout(std::time::Duration::from_secs(LOGIN_TIMEOUT_SECS), async {
         let mut cookie_poll = tokio::time::interval(std::time::Duration::from_millis(500));
+        let mut newapi_user_id = None;
         loop {
             tokio::select! {
                 biased;
                 _ = closed_rx.recv() => break BrowserLoginOutcome::Closed,
-                creds = rx.recv() => break creds
-                    .map(BrowserLoginOutcome::Sub2ApiCredentials)
-                    .unwrap_or(BrowserLoginOutcome::Closed),
+                creds = rx.recv() => match creds {
+                    Some(BrowserLoginCredential::Sub2Api(credentials)) => {
+                        break BrowserLoginOutcome::Sub2ApiCredentials(credentials)
+                    }
+                    Some(BrowserLoginCredential::NewApiUserId(user_id)) => {
+                        newapi_user_id = Some(user_id);
+                    }
+                    None => break BrowserLoginOutcome::Closed,
+                },
                 _ = cookie_poll.tick(), if backend_kind == discovery::BackendKind::NewApi => {
                     let refresh_cookie = match newapi_refresh_cookie_from_window(&window, &refresh_url) {
                         Ok(Some(refresh_cookie)) => refresh_cookie,
-                        Ok(None) => continue,
+                        Ok(None) => {
+                            let Some(user_id) = newapi_user_id else { continue };
+                            let session_url = match newapi::session_token_url(&site_origin) {
+                                Ok(url) => url,
+                                Err(error) => break BrowserLoginOutcome::Error(error.into()),
+                            };
+                            let session_cookie = match newapi_session_cookie_from_window(&window, &session_url) {
+                                Ok(Some(cookie)) => cookie,
+                                Ok(None) => continue,
+                                Err(error) => break BrowserLoginOutcome::Error(error.into()),
+                            };
+                            match newapi::exchange_session(&site_origin, &session_cookie, user_id).await {
+                                Ok(session) => break BrowserLoginOutcome::NewApiSession(session),
+                                Err(error) => break BrowserLoginOutcome::Error(error.into()),
+                            }
+                        }
                         Err(error) => break BrowserLoginOutcome::Error(error.into()),
                     };
                     match await_refresh_preserving_rotation(
@@ -1470,8 +1552,9 @@ fn persist_newapi_login_session(
             relay_id,
             runtime_account_identity(&account),
             &refreshed.access_token,
-            Some(&refreshed.refresh_cookie),
-            Some(refreshed.access_expires_at),
+            (!refreshed.refresh_cookie.trim().is_empty())
+                .then_some(refreshed.refresh_cookie.as_str()),
+            refreshed.access_expires_at,
         )
     })?;
 
@@ -1879,7 +1962,11 @@ async fn provision_backend(op: &creds::Relay) -> Result<ManagedProvisionBatch, A
             })
         }
         discovery::BackendKind::NewApi => {
-            let client = newapi::NewApiClient::new(&op.site_origin, &op.auth_token)?;
+            let client = newapi::NewApiClient::with_optional_account_id(
+                &op.site_origin,
+                &op.auth_token,
+                op.account_id,
+            )?;
             let account = client.account().await?;
             if op.account_id.is_some() && op.account_id != Some(account.id) {
                 return Err(AppError::Config(
@@ -3950,7 +4037,7 @@ mod tests {
         .expect("save site");
         let refreshed = crate::relay::newapi::RefreshedSession {
             access_token: "new-access-token".into(),
-            access_expires_at: 1_900_000_000,
+            access_expires_at: Some(1_900_000_000),
             session_id: "session-id".into(),
             account: crate::relay::newapi::SelfAccount {
                 id: 84,
@@ -3980,6 +4067,49 @@ mod tests {
         assert_eq!(persisted.account_id, Some(84));
         assert_eq!(persisted.account_label, "NewAPI Display");
         assert_eq!(persisted.login_identifier, "newapi-login");
+    }
+
+    #[test]
+    fn persisting_legacy_newapi_session_keeps_refresh_fields_absent() {
+        let db = std::sync::Arc::new(crate::database::Database::memory().expect("init db"));
+        let state = AppState::new(db);
+        let relay_id = with_conn(&state, |conn| {
+            creds::save_site_with_backend(
+                conn,
+                "https://legacy-newapi.example",
+                "Legacy NewAPI",
+                "https://legacy-newapi.example",
+                discovery::BackendKind::NewApi,
+            )
+        })
+        .expect("save site");
+        let session = crate::relay::newapi::RefreshedSession {
+            access_token: "long-lived-access-token".into(),
+            access_expires_at: None,
+            session_id: String::new(),
+            account: crate::relay::newapi::SelfAccount {
+                id: 42,
+                username: "legacy-login".into(),
+                display_name: "Legacy User".into(),
+                email: String::new(),
+                group: "default".into(),
+                quota: 0,
+                used_quota: 0,
+            },
+            refresh_cookie: String::new(),
+        };
+
+        let (final_relay_id, account_id) =
+            persist_newapi_login_session(&state, relay_id, &session).expect("persist login");
+        let persisted = with_conn(&state, |conn| creds::get(conn, final_relay_id))
+            .expect("load relay")
+            .expect("relay exists");
+
+        assert_eq!(account_id, 42);
+        assert_eq!(persisted.auth_token, "long-lived-access-token");
+        assert_eq!(persisted.refresh_token, None);
+        assert_eq!(persisted.token_expires_at, None);
+        assert_eq!(persisted.account_id, Some(42));
     }
 
     #[test]

--- a/src-tauri/src/relay/backend.rs
+++ b/src-tauri/src/relay/backend.rs
@@ -127,9 +127,13 @@ impl<'a> RuntimeBackend<'a> {
                 })
             }
             Self::NewApi { relay } => {
-                let account = newapi::NewApiClient::new(&relay.site_origin, &relay.auth_token)?
-                    .account()
-                    .await?;
+                let account = newapi::NewApiClient::with_optional_account_id(
+                    &relay.site_origin,
+                    &relay.auth_token,
+                    relay.account_id,
+                )?
+                .account()
+                .await?;
                 Ok(newapi_runtime_account(&account))
             }
         }
@@ -148,9 +152,13 @@ impl<'a> RuntimeBackend<'a> {
                 })
             }
             Self::NewApi { relay } => {
-                let account = newapi::NewApiClient::new(&relay.site_origin, &relay.auth_token)?
-                    .account()
-                    .await?;
+                let account = newapi::NewApiClient::with_optional_account_id(
+                    &relay.site_origin,
+                    &relay.auth_token,
+                    relay.account_id,
+                )?
+                .account()
+                .await?;
                 let status = newapi::fetch_status(&relay.site_origin).await?;
                 let quota_per_unit = status.quota_per_unit.ok_or_else(|| {
                     AppError::Config("newapi status 缺少 quota_per_unit，无法换算余额".into())
@@ -192,7 +200,7 @@ impl<'a> RuntimeBackend<'a> {
                 Ok(RefreshedSession {
                     auth_token: refreshed.access_token,
                     refresh_credential: Some(refreshed.refresh_cookie),
-                    token_expires_at: Some(refreshed.access_expires_at),
+                    token_expires_at: refreshed.access_expires_at,
                     account: Some(newapi_runtime_account(&refreshed.account)),
                 })
             }
@@ -250,7 +258,7 @@ mod tests {
             None
         )
         .is_empty());
-        assert!(browser_login_script(
+        assert!(!browser_login_script(
             "https://api.example.com",
             BackendKind::NewApi,
             "",
@@ -262,7 +270,10 @@ mod tests {
         let command_source = include_str!("../commands/relay.rs");
         for protocol_detail in [
             "new_api_refresh",
+            "loongport-newapi-session",
+            "New-Api-User",
             "/api/user/auth/refresh",
+            "/api/user/token",
             "fn backend_login_url(",
             "fn import_login_script(",
         ] {

--- a/src-tauri/src/relay/newapi.rs
+++ b/src-tauri/src/relay/newapi.rs
@@ -14,6 +14,10 @@ use crate::relay::backend::{BackendKind, DetectedSite, ProbeAdapter, ProbeCandid
 
 const REFRESH_COOKIE_NAME: &str = "new_api_refresh";
 const REFRESH_PATH: &str = "/api/user/auth/refresh";
+const SESSION_COOKIE_NAME: &str = "session";
+const SESSION_TOKEN_PATH: &str = "/api/user/token";
+const NEWAPI_USER_HEADER: &str = "New-Api-User";
+const SESSION_SCHEME: &str = "loongport-newapi-session";
 
 pub fn login_url(site_origin: &str, login_identifier: &str) -> String {
     if login_identifier.is_empty() {
@@ -24,12 +28,41 @@ pub fn login_url(site_origin: &str, login_identifier: &str) -> String {
 }
 
 pub fn login_script() -> String {
-    String::new()
+    format!(
+        r#"(function () {{
+  var scheme = '{SESSION_SCHEME}';
+  var sent = false;
+  function reportUser() {{
+    if (sent) return;
+    try {{
+      var raw = localStorage.getItem('user');
+      if (!raw) return;
+      var user = JSON.parse(raw);
+      var id = Number(user && user.id);
+      if (!Number.isSafeInteger(id) || id <= 0) return;
+      sent = true;
+      window.location.href = scheme + '://ok?user_id=' + encodeURIComponent(String(id));
+    }} catch (_) {{
+      // The page may briefly contain an incomplete localStorage value during login.
+    }}
+  }}
+  reportUser();
+  window.setInterval(reportUser, 500);
+}})();"#
+    )
 }
 
 pub fn refresh_url(site_origin: &str) -> Result<url::Url, AppError> {
     url::Url::parse(&format!("{site_origin}{REFRESH_PATH}"))
         .map_err(|error| AppError::InvalidInput(format!("NewAPI refresh 地址不对: {error}")))
+}
+
+pub fn session_token_url(site_origin: &str) -> Result<url::Url, AppError> {
+    url::Url::parse(&format!(
+        "{}{SESSION_TOKEN_PATH}",
+        site_origin.trim_end_matches('/')
+    ))
+    .map_err(|error| AppError::InvalidInput(format!("NewAPI session 地址不对: {error}")))
 }
 
 pub fn extract_refresh_cookie(cookies: &[tauri::webview::Cookie<'_>]) -> Option<String> {
@@ -41,6 +74,33 @@ pub fn extract_refresh_cookie(cookies: &[tauri::webview::Cookie<'_>]) -> Option<
                 && !cookie.value().trim().is_empty()
         })
         .map(|cookie| cookie.value().to_string())
+}
+
+pub fn extract_session_cookie(cookies: &[tauri::webview::Cookie<'_>]) -> Option<String> {
+    cookies
+        .iter()
+        .find(|cookie| cookie.name() == SESSION_COOKIE_NAME && !cookie.value().trim().is_empty())
+        .map(|cookie| cookie.value().to_string())
+}
+
+pub fn parse_session_navigation(url: &url::Url) -> Option<Result<i64, AppError>> {
+    if url.scheme() != SESSION_SCHEME {
+        return None;
+    }
+    Some(
+        url.query_pairs()
+            .find(|(key, _)| key == "user_id")
+            .ok_or_else(|| AppError::Config("NewAPI 登录回传缺少 user_id".into()))
+            .and_then(|(_, value)| {
+                let user_id = value
+                    .parse::<i64>()
+                    .map_err(|_| AppError::Config("NewAPI 登录回传的 user_id 格式不对".into()))?;
+                if user_id <= 0 {
+                    return Err(AppError::Config("NewAPI 登录回传的 user_id 无效".into()));
+                }
+                Ok(user_id)
+            }),
+    )
 }
 
 pub const PROBE_ADAPTER: ProbeAdapter = ProbeAdapter {
@@ -100,9 +160,14 @@ fn parse_envelope<T: DeserializeOwned>(
 pub struct Status {
     pub version: String,
     pub system_name: String,
-    pub theme: String,
-    pub register_enabled: bool,
-    pub password_login_enabled: bool,
+    #[serde(default, rename = "_qn")]
+    pub implementation: Option<String>,
+    #[serde(default)]
+    pub theme: Option<String>,
+    #[serde(default)]
+    pub register_enabled: Option<bool>,
+    #[serde(default)]
+    pub password_login_enabled: Option<bool>,
     #[serde(default)]
     pub quota_per_unit: Option<f64>,
 }
@@ -118,8 +183,15 @@ pub fn parse_status(body: &str) -> Result<Status, AppError> {
             "newapi status 缺少非空 system_name".into(),
         ));
     }
-    if status.theme != "default" {
-        return Err(AppError::Config("newapi status theme 不是 default".into()));
+    let explicitly_identified = status
+        .implementation
+        .as_deref()
+        .is_some_and(|implementation| implementation.eq_ignore_ascii_case("new-api"));
+    let official_dashboard_shape = status.theme.as_deref() == Some("default")
+        && status.register_enabled.is_some()
+        && status.password_login_enabled.is_some();
+    if !explicitly_identified && !official_dashboard_shape {
+        return Err(AppError::Config("newapi status 缺少协议身份字段".into()));
     }
     Ok(status)
 }
@@ -307,11 +379,79 @@ pub fn parse_token_delete(body: &str) -> Result<TokenDelete, AppError> {
 
 pub struct RefreshedSession {
     pub access_token: String,
-    pub access_expires_at: i64,
+    pub access_expires_at: Option<i64>,
     #[cfg_attr(not(test), allow(dead_code))]
     pub session_id: String,
     pub account: SelfAccount,
     pub refresh_cookie: String,
+}
+
+pub async fn exchange_session(
+    site_origin: &str,
+    session_cookie: &str,
+    user_id: i64,
+) -> Result<RefreshedSession, AppError> {
+    let site_origin = site_origin.trim().trim_end_matches('/');
+    if site_origin.is_empty() {
+        return Err(AppError::InvalidInput("newapi site_origin 不能为空".into()));
+    }
+    if session_cookie.trim().is_empty() {
+        return Err(AppError::InvalidInput(
+            "newapi session cookie 不能为空".into(),
+        ));
+    }
+    if user_id <= 0 {
+        return Err(AppError::InvalidInput("newapi user id 无效".into()));
+    }
+
+    let client = crate::relay::api::build_client()?;
+    let response = client
+        .get(format!("{site_origin}{SESSION_TOKEN_PATH}"))
+        .header("Origin", site_origin)
+        .header("Cookie", format!("{SESSION_COOKIE_NAME}={session_cookie}"))
+        .header(NEWAPI_USER_HEADER, user_id.to_string())
+        .send()
+        .await
+        .map_err(|error| {
+            AppError::Config(format!(
+                "newapi session 换 token 请求失败: {}",
+                describe_send_error(&error)
+            ))
+        })?;
+    let status = response.status();
+    let body = response.text().await.map_err(|error| {
+        AppError::Config(format!("newapi session 换 token 读响应出错: {error}"))
+    })?;
+    if !status.is_success() {
+        return Err(classify_authenticated_http_status(
+            "session 换 token",
+            status,
+        ));
+    }
+
+    let access_token = parse_envelope::<String>(&body, "session 换 token", true)?
+        .expect("requires_data guarantees access token");
+    if access_token.trim().is_empty() {
+        return Err(AppError::Config(
+            "newapi session 换 token 响应缺少非空 access token".into(),
+        ));
+    }
+    let account = NewApiClient::with_account_id(site_origin, &access_token, user_id)?
+        .account()
+        .await?;
+    if account.id != user_id {
+        return Err(AppError::Config(
+            "newapi 登录回传的账号与服务端账号不一致".into(),
+        ));
+    }
+
+    Ok(RefreshedSession {
+        access_token,
+        access_expires_at: None,
+        session_id: String::new(),
+        account,
+        refresh_cookie: String::new(),
+    })
 }
 
 #[derive(Debug, Deserialize)]
@@ -390,7 +530,7 @@ pub async fn refresh_session(
 
     Ok(RefreshedSession {
         access_token: refreshed.access_token,
-        access_expires_at: refreshed.access_expires_at,
+        access_expires_at: Some(refreshed.access_expires_at),
         session_id: refreshed.session.sid,
         account: refreshed.user,
         refresh_cookie: rotated_cookie,
@@ -498,6 +638,7 @@ const TOKEN_PAGE_LIMIT: i64 = 100;
 pub struct NewApiClient {
     site_origin: String,
     access_token: String,
+    account_id: Option<i64>,
     http: reqwest::Client,
 }
 
@@ -531,8 +672,33 @@ impl NewApiClient {
         Ok(Self {
             site_origin,
             access_token: access_token.to_string(),
+            account_id: None,
             http: crate::relay::api::build_client()?,
         })
+    }
+
+    pub fn with_account_id(
+        site_origin: &str,
+        access_token: &str,
+        account_id: i64,
+    ) -> Result<Self, AppError> {
+        if account_id <= 0 {
+            return Err(AppError::InvalidInput("newapi account id 无效".into()));
+        }
+        let mut client = Self::new(site_origin, access_token)?;
+        client.account_id = Some(account_id);
+        Ok(client)
+    }
+
+    pub fn with_optional_account_id(
+        site_origin: &str,
+        access_token: &str,
+        account_id: Option<i64>,
+    ) -> Result<Self, AppError> {
+        match account_id {
+            Some(account_id) => Self::with_account_id(site_origin, access_token, account_id),
+            None => Self::new(site_origin, access_token),
+        }
     }
 
     pub async fn account(&self) -> Result<SelfAccount, AppError> {
@@ -603,7 +769,7 @@ impl NewApiClient {
     pub async fn reveal_token(&self, token_id: i64) -> Result<String, AppError> {
         let body = self
             .send(
-                self.request(reqwest::Method::POST, &format!("/api/token/{token_id}/key")),
+                self.request(reqwest::Method::GET, &format!("/api/token/{token_id}/key")),
                 "token reveal",
             )
             .await?;
@@ -622,9 +788,14 @@ impl NewApiClient {
     }
 
     fn request(&self, method: reqwest::Method, path: &str) -> reqwest::RequestBuilder {
-        self.http
+        let request = self
+            .http
             .request(method, format!("{}{}", self.site_origin, path))
-            .bearer_auth(&self.access_token)
+            .bearer_auth(&self.access_token);
+        match self.account_id {
+            Some(account_id) => request.header(NEWAPI_USER_HEADER, account_id.to_string()),
+            None => request,
+        }
     }
 
     async fn send(
@@ -690,6 +861,30 @@ mod tests {
         assert_eq!(
             extract_refresh_cookie(&cookies).as_deref(),
             Some("refresh-cookie")
+        );
+
+        let session_cookies = vec![
+            tauri::webview::Cookie::new("session", "   "),
+            tauri::webview::Cookie::new("other", "ignored"),
+            tauri::webview::Cookie::new("session", "session-cookie"),
+        ];
+        assert_eq!(
+            extract_session_cookie(&session_cookies).as_deref(),
+            Some("session-cookie")
+        );
+
+        let script = login_script();
+        assert!(script.contains("localStorage.getItem('user')"));
+        assert!(script.contains("Number.isSafeInteger(id)"));
+        assert!(!script.contains("document.cookie"));
+        assert!(!script.contains("access_token"));
+
+        let callback = url::Url::parse("loongport-newapi-session://ok?user_id=42").unwrap();
+        assert_eq!(parse_session_navigation(&callback).unwrap().unwrap(), 42);
+        let malformed = url::Url::parse("loongport-newapi-session://ok?user_id=nope").unwrap();
+        assert!(parse_session_navigation(&malformed).unwrap().is_err());
+        assert!(
+            parse_session_navigation(&url::Url::parse("https://example.com").unwrap()).is_none()
         );
     }
 
@@ -860,7 +1055,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(refreshed.access_token, "access-123");
-        assert_eq!(refreshed.access_expires_at, 1_700_000_001);
+        assert_eq!(refreshed.access_expires_at, Some(1_700_000_001));
         assert_eq!(refreshed.session_id, "sid-123");
         assert_eq!(refreshed.refresh_cookie, "sid-123.rotated-secret");
         assert_eq!(refreshed.account.username, "alice");
@@ -1113,6 +1308,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn session_exchange_uses_browser_cookie_and_newapi_user_header() {
+        let server = TestServer::spawn(vec![
+            TestResponse::json(r#"{"success":true,"message":"","data":"access-secret"}"#),
+            TestResponse::json(
+                r#"{"success":true,"message":"","data":{
+                    "id":42,"username":"erin","display_name":"Erin","email":"e@example.com",
+                    "group":"vip","quota":12,"used_quota":3
+                }}"#,
+            ),
+        ])
+        .await;
+
+        let session = exchange_session(&server.origin, "session-secret", 42)
+            .await
+            .unwrap();
+
+        assert_eq!(session.access_token, "access-secret");
+        assert_eq!(session.access_expires_at, None);
+        assert_eq!(session.refresh_cookie, "");
+        assert_eq!(session.account.id, 42);
+
+        let requests = server.requests().await;
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].path_and_query, "/api/user/token");
+        assert_eq!(requests[0].header("cookie"), Some("session=session-secret"));
+        assert_eq!(requests[0].header("new-api-user"), Some("42"));
+        assert_eq!(requests[0].header("authorization"), None);
+        assert_eq!(requests[1].path_and_query, "/api/user/self");
+        assert_eq!(
+            requests[1].header("authorization"),
+            Some("Bearer access-secret")
+        );
+        assert_eq!(requests[1].header("new-api-user"), Some("42"));
+    }
+
+    #[tokio::test]
+    async fn account_scoped_client_adds_newapi_user_to_all_protected_requests() {
+        let server = TestServer::spawn(vec![
+            TestResponse::json(
+                r#"{"success":true,"message":"","data":{
+                    "id":42,"username":"erin","display_name":"Erin","email":"e@example.com",
+                    "group":"vip","quota":12,"used_quota":3
+                }}"#,
+            ),
+            TestResponse::json(
+                r#"{"success":true,"message":"","data":{"vip":{"ratio":1.5,"desc":"paid"}}}"#,
+            ),
+            TestResponse::json(
+                r#"{"success":true,"message":"","data":{"page":1,"page_size":100,"total":0,"items":[]}}"#,
+            ),
+        ])
+        .await;
+        let client = NewApiClient::with_account_id(&server.origin, "access-secret", 42).unwrap();
+
+        client.account().await.unwrap();
+        client.groups().await.unwrap();
+        client.list_tokens().await.unwrap();
+
+        let requests = server.requests().await;
+        assert_eq!(requests.len(), 3);
+        for request in requests {
+            assert_eq!(request.header("new-api-user"), Some("42"));
+            assert_eq!(
+                request.header("authorization"),
+                Some("Bearer access-secret")
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn token_listing_starts_at_page_one_and_stops_on_empty_page() {
         let server = TestServer::spawn(vec![
             TestResponse::json(
@@ -1200,7 +1465,7 @@ mod tests {
 
         let requests = server.requests().await;
         assert_eq!(requests.len(), 2);
-        assert_eq!(requests[0].method, "POST");
+        assert_eq!(requests[0].method, "GET");
         assert_eq!(requests[0].path_and_query, "/api/token/42/key");
         assert_eq!(requests[1].method, "DELETE");
         assert_eq!(requests[1].path_and_query, "/api/token/42");
@@ -1260,12 +1525,13 @@ mod tests {
         .unwrap();
         assert_eq!(status.version, "1.2.3");
         assert_eq!(status.system_name, "New API");
-        assert!(!status.password_login_enabled);
+        assert_eq!(status.password_login_enabled, Some(false));
 
         for body in [
             r#"{"success":false,"message":"nope","data":{}}"#,
             r#"{"success":true,"data":{"version":"1","system_name":"New API","theme":"default","register_enabled":true}}"#,
             r#"{"success":true,"data":{"version":"1","system_name":"New API","theme":"classic","register_enabled":true,"password_login_enabled":true}}"#,
+            r#"{"success":true,"data":{"version":"1","system_name":"New API"}}"#,
             r#"{"success":true,"data":{"version":"","system_name":"New API","theme":"default","register_enabled":true,"password_login_enabled":true}}"#,
             r#"{"success":true,"data":{"version":"1","system_name":" ","theme":"default","register_enabled":true,"password_login_enabled":true}}"#,
             r#"{"success":true,"data":{"version":1,"system_name":"New API","theme":"default","register_enabled":true,"password_login_enabled":true}}"#,
@@ -1275,6 +1541,30 @@ mod tests {
                 "accepted invalid status: {body}"
             );
         }
+    }
+
+    #[test]
+    fn status_parser_accepts_identified_newapi_forks_without_frontend_flags() {
+        let status = parse_status(
+            r#"{
+                "success": true,
+                "message": "",
+                "data": {
+                    "_qn": "new-api",
+                    "version": "main-93a2b15",
+                    "system_name": "元衡 API",
+                    "build_branch": "main",
+                    "build_commit": "93a2b15e123ee2848bd9f1f13aef6776f566650a",
+                    "build_repository": "nanashiwang/new-api",
+                    "quota_per_unit": 500000
+                }
+            }"#,
+        )
+        .expect("an explicitly identified NewAPI fork should be detected");
+
+        assert_eq!(status.version, "main-93a2b15");
+        assert_eq!(status.system_name, "元衡 API");
+        assert_eq!(status.quota_per_unit, Some(500000.0));
     }
 
     #[test]

--- a/src-tauri/src/relay/newapi_provision.rs
+++ b/src-tauri/src/relay/newapi_provision.rs
@@ -479,7 +479,7 @@ mod tests {
                     json!({ "success": true })
                 }
             }
-            ("POST", path) if path.starts_with("/api/token/") && path.ends_with("/key") => {
+            ("GET", path) if path.starts_with("/api/token/") && path.ends_with("/key") => {
                 let id = path
                     .trim_start_matches("/api/token/")
                     .trim_end_matches("/key")


### PR DESCRIPTION
## What changed

- Loosen NewAPI probing to accept identified forks that omit frontend feature flags.
- Import legacy session-based NewAPI logins by reading only the account ID in the WebView, exchanging the HttpOnly session cookie in Rust, and persisting the resulting long-lived access token.
- Add the required `New-Api-User` header to authenticated NewAPI requests.
- Use the upstream NewAPI token reveal contract: `GET /api/token/:id/key`.
- Preserve saved relay credentials when protocol probing is inconclusive. Only a unique, positively detected different backend may clear credentials.
- Keep the existing LoongPort UI and automatic backend detection; users still enter only the site address.

## Root cause

The target NewAPI fork uses the traditional session protocol and requires `New-Api-User` on protected endpoints. Its token reveal route is `GET /api/token/:id/key`, while LoongPort called it with `POST`, causing every managed group to fail with HTTP 404.

A second bug treated `UnsupportedSite` and protocol conflicts as proof that a previously saved backend had changed. Clicking Login could therefore clear valid credentials after a temporary or incomplete probe. Persisted `backend_kind` is now retained unless probing uniquely identifies a different backend.

## Validation

- Rebased onto `origin/main` at LoongPort v3.23.1.
- `cargo test`: 2937 unit tests (2924 passed, 7 ignored) plus all integration tests passed.
- `cargo clippy --all-targets -- -D warnings` passed.
- `cargo fmt --check` passed.
- `npx tsc --noEmit` passed.
- `pnpm format:check` passed.
- `npx vitest run`: 125 files / 785 tests passed.
- Release `LoongPort.app` built successfully; bundle identity, icon hash, and code signature were verified.
- Real-site login against `https://cn.meta-api.vip` succeeded through legacy session exchange.
- Real-site provisioning produced 21 tiers for each of Claude, Codex, and Gemini (63 provider rows total).
- Remote managed token inventory remained at 26, confirming reconciliation did not create duplicates.
- Token listing and `GET` reveal succeeded; no cookies, access tokens, or revealed keys were logged.
