### PR TITLE
fix(relay): complete browser-assisted import after Cloudflare verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-switch",
-  "version": "3.23.0",
+  "version": "3.23.1",
   "description": "All-in-One Assistant for Claude Code, Codex & Gemini CLI",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "cc-switch"
-version = "3.23.0"
+version = "3.23.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # （裁决见 CLAUDE.md「三点五」）。面向用户的二进制名走 tauri.conf.json 的
 # `mainBinaryName`（已是 `LoongPort`）。
 name = "cc-switch"
-version = "3.23.0"
+version = "3.23.1"
 description = "同样的 Codex，成本省 95% 以上 —— 填一个域名、登录一次，其余自动配好"
 authors = ["SailingLoong", "Jason Young"]
 license = "MIT"

--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -608,22 +608,34 @@ fn browser_entry_is_origin(url: &url::Url) -> bool {
     url.path() == "/" && url.query().is_none() && url.fragment().is_none()
 }
 
+fn browser_entry_is_auth_page(url: &url::Url) -> bool {
+    let path = url.path().trim_end_matches('/');
+    if matches!(path, "/login" | "/register") {
+        return true;
+    }
+    url.fragment()
+        .map(|fragment| fragment.trim_end_matches('/'))
+        .is_some_and(|fragment| matches!(fragment, "/login" | "/register"))
+}
+
 /// 选择共用导入 WebView 的首次地址。
 ///
-/// 用户显式给出的 path/query/fragment 始终优先保留；只有输入是裸 origin 且原生 fast
-/// path 已经识别出协议时，才使用该协议的默认注册/登录入口。
+/// 登录/注册链接属于明确的可交互页面，保留其 path/query/fragment；其它业务/API 路径
+/// 不能假定能在 WebView 中展示。协议未知时先打开 origin 让用户完成任意网页验证，识别后
+/// 再由协议适配层导航到登录/注册页；协议已知时直接使用该协议入口。
 fn browser_start_url(
     input: &str,
     site_origin: &str,
     detected: Option<&discovery::DetectedSite>,
 ) -> Result<url::Url, AppError> {
     let entry = browser_entry_url(input)?;
-    if !browser_entry_is_origin(&entry) {
+    if browser_entry_is_auth_page(&entry) {
         return Ok(entry);
     }
 
     let Some(detected) = detected else {
-        return Ok(entry);
+        return url::Url::parse(site_origin)
+            .map_err(|error| AppError::InvalidInput(format!("站点 origin 地址不对: {error}")));
     };
 
     let url = backend::browser_login_url(site_origin, detected.backend_kind, "");
@@ -692,6 +704,9 @@ async fn browser_import(
     let navigate_after_detection =
         initial_detected.is_none() && browser_entry_is_origin(&entry_url);
 
+    let initial_backend = initial_detected
+        .as_ref()
+        .map(|detected| format!("{:?}", detected.backend_kind));
     let initial_context = match initial_detected {
         Some(detected) => Some(browser_login_context(
             app_handle,
@@ -703,10 +718,20 @@ async fn browser_import(
         None => None,
     };
 
+    let entry_source = if browser_entry_is_auth_page(&entry_url) {
+        "supplied_auth_page"
+    } else if initial_backend.is_some() {
+        "protocol_login_page"
+    } else {
+        "site_origin"
+    };
     log::info!(
-        "打开浏览器辅助站点导入窗：{}（保留用户路径={}）",
-        crate::url_for_log(entry_url.as_str()),
-        !navigate_after_detection
+        "{}",
+        crate::diagnostics::DiagnosticEvent::new("relay.browser_import", "window_opening")
+            .field_display("site", crate::url_for_log(&site_origin))
+            .field_display("entry", crate::url_for_log(entry_url.as_str()))
+            .field_display("initial_backend", format_args!("{initial_backend:?}"))
+            .field("entry_source", entry_source)
     );
 
     let context = Arc::new(Mutex::new(initial_context));
@@ -873,24 +898,47 @@ async fn browser_import(
                 return false;
             };
 
-            let next_step = if navigate_after_detection {
-                url::Url::parse(&backend::browser_login_url(
-                    &site_origin_for_nav,
-                    backend_kind,
-                    "",
-                ))
-                .map_err(|error| format!("登录页地址不对: {error}"))
-                .and_then(|url| window.navigate(url).map_err(|error| error.to_string()))
+            let (next_action, next_step) = if navigate_after_detection {
+                let login_url = backend::browser_login_url(&site_origin_for_nav, backend_kind, "");
+                let result = url::Url::parse(&login_url)
+                    .map_err(|error| format!("登录页地址不对: {error}"))
+                    .and_then(|url| window.navigate(url).map_err(|error| error.to_string()));
+                ("navigate_login_page", result)
             } else if !login_script.is_empty() {
-                window
-                    .eval(&login_script)
-                    .map_err(|error| error.to_string())
+                (
+                    "inject_login_script",
+                    window
+                        .eval(&login_script)
+                        .map_err(|error| error.to_string()),
+                )
             } else {
-                Ok(())
+                ("await_page_login", Ok(()))
             };
-            if let Err(error) = next_step {
-                log::warn!("已识别站点，但无法在当前会话继续登录: {error}");
-                let _ = probe_error_tx.try_send(RelayImportError::message(error));
+            match next_step {
+                Ok(()) => log::info!(
+                    "{}",
+                    crate::diagnostics::DiagnosticEvent::new(
+                        "relay.browser_import.continue",
+                        "completed",
+                    )
+                    .field_display("site", crate::url_for_log(&site_origin_for_nav))
+                    .field_display("backend", format_args!("{backend_kind:?}"))
+                    .field("action", next_action)
+                ),
+                Err(error) => {
+                    log::warn!(
+                        "{}",
+                        crate::diagnostics::DiagnosticEvent::new(
+                            "relay.browser_import.continue",
+                            "failed",
+                        )
+                        .field_display("site", crate::url_for_log(&site_origin_for_nav))
+                        .field_display("backend", format_args!("{backend_kind:?}"))
+                        .field("action", next_action)
+                        .field("error", error.clone())
+                    );
+                    let _ = probe_error_tx.try_send(RelayImportError::message(error));
+                }
             }
             return false;
         }
@@ -3744,6 +3792,43 @@ mod tests {
             site_name: "NewAPI".into(),
             api_base_url: String::new(),
         }
+    }
+
+    #[test]
+    fn browser_start_url_uses_origin_when_protocol_is_unknown_even_for_non_page_path() {
+        let url = browser_start_url(
+            "https://api.example.com/custom/subscription-token",
+            "https://api.example.com",
+            None,
+        )
+        .expect("valid browser start URL");
+
+        assert_eq!(url.as_str(), "https://api.example.com/");
+    }
+
+    #[test]
+    fn browser_start_url_preserves_auth_link_while_protocol_is_unknown() {
+        let url = browser_start_url(
+            "https://api.example.com/register?aff=ABC123",
+            "https://api.example.com",
+            None,
+        )
+        .expect("valid browser start URL");
+
+        assert_eq!(url.as_str(), "https://api.example.com/register?aff=ABC123");
+    }
+
+    #[test]
+    fn browser_start_url_replaces_non_page_path_after_native_detection() {
+        let detected = detected_sub2api();
+        let url = browser_start_url(
+            "https://api.example.com/custom/subscription-token",
+            "https://api.example.com",
+            Some(&detected),
+        )
+        .expect("valid browser start URL");
+
+        assert_eq!(url.as_str(), "https://api.example.com/register");
     }
 
     #[test]

--- a/src-tauri/src/relay/api.rs
+++ b/src-tauri/src/relay/api.rs
@@ -47,6 +47,15 @@ pub const PROBE_ADAPTER: ProbeAdapter = ProbeAdapter {
         id: "sub2api",
         path: "/api/v1/settings/public",
         bearer_token_storage_key: Some("auth_token"),
+        detector_json_paths: &[
+            "code",
+            "data.site_name",
+            "data.version",
+            "data.api_base_url",
+            "data.registration_enabled",
+            "data.promo_code_enabled",
+            "data.invitation_code_enabled",
+        ],
     },
     detect: detect_site,
 };

--- a/src-tauri/src/relay/backend.rs
+++ b/src-tauri/src/relay/backend.rs
@@ -30,6 +30,9 @@ pub struct ProbeCandidate {
     /// 令牌不回传 Rust、不写日志，也不与其它协议候选共享。
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bearer_token_storage_key: Option<&'static str>,
+    /// JSON paths required by this adapter's strict detector when a public response is too large
+    /// to return verbatim through the bounded WebView callback.
+    pub detector_json_paths: &'static [&'static str],
 }
 
 #[derive(Clone, Copy)]

--- a/src-tauri/src/relay/discovery.rs
+++ b/src-tauri/src/relay/discovery.rs
@@ -14,7 +14,13 @@ use futures::StreamExt;
 use std::fmt;
 
 pub const PROBE_SCHEME: &str = "loongport-probe";
+// Some protocol registries include large, user-visible configuration arrays in their public
+// settings response. Keep the callback bounded, but do not discard a valid detector payload
+// merely because unrelated settings make the response larger than the old 64 KiB limit.
 const MAX_PROBE_BODY_BYTES: usize = 64 * 1024;
+// Only compact source responses up to this size. The browser fetch API materializes text before
+// this check, while the cross-process callback remains capped by MAX_PROBE_BODY_BYTES.
+const MAX_PROBE_COMPACT_SOURCE_BYTES: usize = 2 * 1024 * 1024;
 const MAX_PROBE_RESPONSE_OVERHEAD_BYTES: usize = 512;
 
 pub const PROBE_CANDIDATES: &[ProbeCandidate] = &[
@@ -72,6 +78,8 @@ pub struct ProbeResponse {
     #[serde(default)]
     pub body_bytes: usize,
     #[serde(default)]
+    pub detector_body_bytes: usize,
+    #[serde(default)]
     pub json_like: bool,
     #[serde(default)]
     pub error_kind: Option<String>,
@@ -87,6 +95,7 @@ pub struct ProbeBatch {
 /// 脚本只在目标 origin 上工作；验证页、注册页、登录页都走同一份代码。它不认识任何
 /// 验证产品，也不在浏览器层判断协议。每轮回传安全的响应元数据；只有 JSON-like 且大小
 /// 合规的正文才交给 Rust detector，验证页正文、令牌、Cookie 和请求头都不会离开 WebView。
+/// 对不超过 2 MiB 的大 JSON 响应先做协议无关投影，再把最多 64 KiB 的正文交给 Rust detector。
 pub fn browser_probe_script(site_origin: &str, candidates: &[ProbeCandidate]) -> String {
     let expected_origin = serde_json::to_string(site_origin).expect("origin can be JSON encoded");
     let candidates =
@@ -99,6 +108,7 @@ pub fn browser_probe_script(site_origin: &str, candidates: &[ProbeCandidate]) ->
   const candidates = {candidates};
   const callbackScheme = '{PROBE_SCHEME}';
   const requestTimeoutMs = 5000;
+  const maxCompactSourceBytes = {MAX_PROBE_COMPACT_SOURCE_BYTES};
   let previousBatch = '';
   let probeInFlight = false;
 
@@ -139,6 +149,52 @@ pub fn browser_probe_script(site_origin: &str, candidates: &[ProbeCandidate]) ->
     return safeName || 'Error';
   }}
 
+  function byteLength(value) {{
+    return new TextEncoder().encode(value).length;
+  }}
+
+  function setProjectedPath(target, path, value) {{
+    const segments = path.split('.').filter(Boolean);
+    if (segments.length === 0) return;
+    let cursor = target;
+    for (let index = 0; index < segments.length - 1; index += 1) {{
+      const segment = segments[index];
+      if (!cursor[segment] || typeof cursor[segment] !== 'object') cursor[segment] = {{}};
+      cursor = cursor[segment];
+    }}
+    cursor[segments[segments.length - 1]] = value;
+  }}
+
+  function readJsonPath(source, path) {{
+    const segments = path.split('.').filter(Boolean);
+    let cursor = source;
+    for (const segment of segments) {{
+      if (!cursor || typeof cursor !== 'object'
+          || !Object.prototype.hasOwnProperty.call(cursor, segment)) {{
+        return {{ found: false, value: null }};
+      }}
+      cursor = cursor[segment];
+    }}
+    return {{ found: true, value: cursor }};
+  }}
+
+  function detectorBody(candidate, body, bodyBytes) {{
+    if (bodyBytes > maxCompactSourceBytes) return '';
+    if (bodyBytes <= {MAX_PROBE_BODY_BYTES}) return body;
+    try {{
+      const parsed = JSON.parse(body);
+      const projected = {{}};
+      for (const path of candidate.detector_json_paths || []) {{
+        const selected = readJsonPath(parsed, path);
+        if (selected.found) setProjectedPath(projected, path, selected.value);
+      }}
+      const compact = JSON.stringify(projected);
+      return byteLength(compact) <= {MAX_PROBE_BODY_BYTES} ? compact : '';
+    }} catch (_) {{
+      return '';
+    }}
+  }}
+
   async function probe() {{
     if (window.location.origin !== expectedOrigin) return;
     if (probeInFlight) return;
@@ -158,7 +214,8 @@ pub fn browser_probe_script(site_origin: &str, candidates: &[ProbeCandidate]) ->
               signal: controller.signal,
             }});
             const body = await response.text();
-            return {{ response, body }};
+            const bodyBytes = byteLength(body);
+            return {{ response, body, bodyBytes }};
           }})();
           const timeout = new Promise((_, reject) => {{
             timeoutId = setTimeout(() => {{
@@ -168,16 +225,17 @@ pub fn browser_probe_script(site_origin: &str, candidates: &[ProbeCandidate]) ->
               reject(error);
             }}, requestTimeoutMs);
           }});
-          const {{ response, body }} = await Promise.race([request, timeout]);
-          const bodyBytes = new TextEncoder().encode(body).length;
+          const {{ response, body, bodyBytes }} = await Promise.race([request, timeout]);
           const trimmed = body.trim();
           const jsonLike = Boolean(trimmed) && (trimmed[0] === '{{' || trimmed[0] === '[');
+          const bodyForDetector = jsonLike ? detectorBody(candidate, body, bodyBytes) : '';
           responses.push({{
             candidate_id: candidate.id,
-            body: jsonLike && bodyBytes <= {MAX_PROBE_BODY_BYTES} ? body : '',
+            body: bodyForDetector,
             status: Number.isInteger(response.status) ? response.status : null,
             content_type: responseContentType(response),
             body_bytes: bodyBytes,
+            detector_body_bytes: byteLength(bodyForDetector),
             json_like: jsonLike,
             error_kind: null,
           }});
@@ -188,6 +246,7 @@ pub fn browser_probe_script(site_origin: &str, candidates: &[ProbeCandidate]) ->
             status: null,
             content_type: null,
             body_bytes: 0,
+            detector_body_bytes: 0,
             json_like: false,
             error_kind: safeErrorKind(error),
           }});
@@ -287,8 +346,8 @@ pub fn probe_batch_summary(responses: &[ProbeResponse]) -> String {
                 .filter(|value| !value.is_empty())
                 .unwrap_or_else(|| "unknown".into());
             format!(
-                "{candidate_id}(status={status},type={content_type},bytes={},json={})",
-                response.body_bytes, response.json_like
+                "{candidate_id}(status={status},type={content_type},bytes={},detector_bytes={},json={})",
+                response.body_bytes, response.detector_body_bytes, response.json_like
             )
         })
         .collect::<Vec<_>>()
@@ -381,6 +440,7 @@ pub async fn discover_site(site_origin: &str) -> Result<DetectedSite, DiscoveryE
         responses.push(ProbeResponse {
             candidate_id: candidate.id.to_string(),
             body_bytes: body.len(),
+            detector_body_bytes: body.len(),
             json_like: body
                 .iter()
                 .copied()
@@ -515,11 +575,13 @@ mod tests {
                     id: "sub2api",
                     path: "/api/v1/settings/public",
                     bearer_token_storage_key: Some("auth_token"),
+                    detector_json_paths: api::PROBE_ADAPTER.candidate.detector_json_paths,
                 },
                 ProbeCandidate {
                     id: "newapi",
                     path: "/api/status",
                     bearer_token_storage_key: None,
+                    detector_json_paths: newapi::PROBE_ADAPTER.candidate.detector_json_paths,
                 },
             ]
         );
@@ -532,11 +594,13 @@ mod tests {
                 id: "sub2api",
                 path: "/api/v1/settings/public",
                 bearer_token_storage_key: Some("auth_token"),
+                detector_json_paths: &["code", "data.version"],
             },
             ProbeCandidate {
                 id: "future",
                 path: "/api/status",
                 bearer_token_storage_key: None,
+                detector_json_paths: &["success", "data.system_name"],
             },
         ];
         let script = browser_probe_script("https://relay.example", &candidates);
@@ -547,7 +611,9 @@ mod tests {
         assert!(script.contains(PROBE_SCHEME));
         assert!(script.contains("window.location.origin"));
         assert!(script.contains("const responses = []"));
-        assert!(script.contains("body: jsonLike && bodyBytes <= 65536 ? body : ''"));
+        assert!(script.contains("function detectorBody(candidate, body, bodyBytes)"));
+        assert!(script.contains("candidate.detector_json_paths"));
+        assert!(script.contains("const maxCompactSourceBytes = 2097152;"));
         assert!(script.contains("error_kind: safeErrorKind(error)"));
         assert!(script.contains("const batch = JSON.stringify(responses)"));
         assert!(script.contains("b64url(batch)"));
@@ -630,6 +696,7 @@ mod tests {
                 status: Some(403),
                 content_type: Some("text/html; charset=UTF-8\nforged".into()),
                 body_bytes: 38,
+                detector_body_bytes: 0,
                 json_like: false,
                 error_kind: None,
             },
@@ -644,7 +711,7 @@ mod tests {
 
         assert_eq!(
             summary,
-            "sub2api(status=403,type=text/html; charset=UTF-8 forged,bytes=38,json=false) newapi(error=ProbeTimeout forged)"
+            "sub2api(status=403,type=text/html; charset=UTF-8 forged,bytes=38,detector_bytes=0,json=false) newapi(error=ProbeTimeout forged)"
         );
         assert!(!summary.contains("secret verification page"));
         assert!(!summary.contains('\n'));

--- a/src-tauri/src/relay/newapi.rs
+++ b/src-tauri/src/relay/newapi.rs
@@ -48,6 +48,15 @@ pub const PROBE_ADAPTER: ProbeAdapter = ProbeAdapter {
         id: "newapi",
         path: "/api/status",
         bearer_token_storage_key: None,
+        detector_json_paths: &[
+            "success",
+            "data.version",
+            "data.system_name",
+            "data.theme",
+            "data.register_enabled",
+            "data.password_login_enabled",
+            "data.quota_per_unit",
+        ],
     },
     detect: detect_site,
 };

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LoongPort",
   "mainBinaryName": "LoongPort",
-  "version": "3.23.0",
+  "version": "3.23.1",
   "identifier": "dev.loongport.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/tests/fixtures/browser-probe-script.txt
+++ b/tests/fixtures/browser-probe-script.txt
@@ -1,9 +1,10 @@
 
 (() => {
   const expectedOrigin = "https://relay.example";
-  const candidates = [{"id":"sub2api","path":"/api/v1/settings/public","bearer_token_storage_key":"auth_token"},{"id":"newapi","path":"/api/status"}];
+  const candidates = [{"id":"sub2api","path":"/api/v1/settings/public","bearer_token_storage_key":"auth_token","detector_json_paths":["code","data.site_name","data.version","data.api_base_url","data.registration_enabled","data.promo_code_enabled","data.invitation_code_enabled"]},{"id":"newapi","path":"/api/status","detector_json_paths":["success","data.version","data.system_name","data.theme","data.register_enabled","data.password_login_enabled","data.quota_per_unit"]}];
   const callbackScheme = 'loongport-probe';
   const requestTimeoutMs = 5000;
+  const maxCompactSourceBytes = 2097152;
   let previousBatch = '';
   let probeInFlight = false;
 
@@ -44,6 +45,52 @@
     return safeName || 'Error';
   }
 
+  function byteLength(value) {
+    return new TextEncoder().encode(value).length;
+  }
+
+  function setProjectedPath(target, path, value) {
+    const segments = path.split('.').filter(Boolean);
+    if (segments.length === 0) return;
+    let cursor = target;
+    for (let index = 0; index < segments.length - 1; index += 1) {
+      const segment = segments[index];
+      if (!cursor[segment] || typeof cursor[segment] !== 'object') cursor[segment] = {};
+      cursor = cursor[segment];
+    }
+    cursor[segments[segments.length - 1]] = value;
+  }
+
+  function readJsonPath(source, path) {
+    const segments = path.split('.').filter(Boolean);
+    let cursor = source;
+    for (const segment of segments) {
+      if (!cursor || typeof cursor !== 'object'
+          || !Object.prototype.hasOwnProperty.call(cursor, segment)) {
+        return { found: false, value: null };
+      }
+      cursor = cursor[segment];
+    }
+    return { found: true, value: cursor };
+  }
+
+  function detectorBody(candidate, body, bodyBytes) {
+    if (bodyBytes > maxCompactSourceBytes) return '';
+    if (bodyBytes <= 65536) return body;
+    try {
+      const parsed = JSON.parse(body);
+      const projected = {};
+      for (const path of candidate.detector_json_paths || []) {
+        const selected = readJsonPath(parsed, path);
+        if (selected.found) setProjectedPath(projected, path, selected.value);
+      }
+      const compact = JSON.stringify(projected);
+      return byteLength(compact) <= 65536 ? compact : '';
+    } catch (_) {
+      return '';
+    }
+  }
+
   async function probe() {
     if (window.location.origin !== expectedOrigin) return;
     if (probeInFlight) return;
@@ -63,7 +110,8 @@
               signal: controller.signal,
             });
             const body = await response.text();
-            return { response, body };
+            const bodyBytes = byteLength(body);
+            return { response, body, bodyBytes };
           })();
           const timeout = new Promise((_, reject) => {
             timeoutId = setTimeout(() => {
@@ -73,16 +121,17 @@
               reject(error);
             }, requestTimeoutMs);
           });
-          const { response, body } = await Promise.race([request, timeout]);
-          const bodyBytes = new TextEncoder().encode(body).length;
+          const { response, body, bodyBytes } = await Promise.race([request, timeout]);
           const trimmed = body.trim();
           const jsonLike = Boolean(trimmed) && (trimmed[0] === '{' || trimmed[0] === '[');
+          const bodyForDetector = jsonLike ? detectorBody(candidate, body, bodyBytes) : '';
           responses.push({
             candidate_id: candidate.id,
-            body: jsonLike && bodyBytes <= 65536 ? body : '',
+            body: bodyForDetector,
             status: Number.isInteger(response.status) ? response.status : null,
             content_type: responseContentType(response),
             body_bytes: bodyBytes,
+            detector_body_bytes: byteLength(bodyForDetector),
             json_like: jsonLike,
             error_kind: null,
           });
@@ -93,6 +142,7 @@
             status: null,
             content_type: null,
             body_bytes: 0,
+            detector_body_bytes: 0,
             json_like: false,
             error_kind: safeErrorKind(error),
           });

--- a/tests/lib/browserProbeScriptRuns.test.ts
+++ b/tests/lib/browserProbeScriptRuns.test.ts
@@ -103,6 +103,7 @@ describe("browser probe generated script", () => {
         status: null,
         content_type: null,
         body_bytes: Buffer.byteLength('{"code":0}'),
+        detector_body_bytes: Buffer.byteLength('{"code":0}'),
         json_like: true,
         error_kind: null,
       },
@@ -112,6 +113,7 @@ describe("browser probe generated script", () => {
         status: null,
         content_type: null,
         body_bytes: Buffer.byteLength('{"success":true}'),
+        detector_body_bytes: Buffer.byteLength('{"success":true}'),
         json_like: true,
         error_kind: null,
       },
@@ -122,6 +124,88 @@ describe("browser probe generated script", () => {
       fetchedPaths,
       "a finished round releases the next interval",
     ).toHaveLength(3);
+  });
+
+  it("keeps a valid oversized JSON detector response within the callback limit", async () => {
+    const navigations: string[] = [];
+    const location = {
+      origin: "https://relay.example",
+      get href() {
+        return navigations.at(-1) ?? "https://relay.example/";
+      },
+      set href(value: string) {
+        navigations.push(value);
+      },
+    };
+    const oversizedBody = JSON.stringify({
+      code: 0,
+      data: {
+        site_name: "Large Sub2API",
+        version: "1.2.3",
+        api_base_url: "",
+        registration_enabled: true,
+        promo_code_enabled: true,
+        invitation_code_enabled: true,
+        announcements: Array.from({ length: 5000 }, (_, index) => ({
+          id: index,
+          content: "x".repeat(80),
+        })),
+      },
+    });
+    expect(Buffer.byteLength(oversizedBody)).toBeGreaterThan(300_000);
+
+    const sandbox = {
+      window: { location },
+      fetch: (path: string) => {
+        const body =
+          path === "/api/v1/settings/public"
+            ? oversizedBody
+            : '{"success":false}';
+        return Promise.resolve({
+          status: 200,
+          headers: { get: () => "application/json" },
+          text: () => Promise.resolve(body),
+        });
+      },
+      setInterval: () => 1,
+      setTimeout,
+      clearTimeout,
+      AbortController,
+      TextEncoder,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      JSON,
+    };
+
+    vm.runInNewContext(readFileSync(SCRIPT, "utf8"), sandbox, {
+      timeout: 5000,
+    });
+    await flushPromises();
+
+    expect(navigations).toHaveLength(1);
+    const encoded = new URL(navigations[0]).searchParams.get("d");
+    expect(encoded).not.toBeNull();
+    const batch = JSON.parse(
+      Buffer.from(encoded!, "base64url").toString("utf8"),
+    );
+    expect(Buffer.byteLength(batch[0].body)).toBeLessThanOrEqual(64 * 1024);
+    expect(JSON.parse(batch[0].body)).toEqual({
+      code: 0,
+      data: {
+        site_name: "Large Sub2API",
+        version: "1.2.3",
+        api_base_url: "",
+        registration_enabled: true,
+        promo_code_enabled: true,
+        invitation_code_enabled: true,
+      },
+    });
+    expect(batch[0]).toMatchObject({
+      candidate_id: "sub2api",
+      body_bytes: Buffer.byteLength(oversizedBody),
+      detector_body_bytes: Buffer.byteLength(batch[0].body),
+      json_like: true,
+      error_kind: null,
+    });
   });
 
   it("uses the page's candidate-specific bearer session for authenticated browser probes", async () => {
@@ -237,6 +321,7 @@ describe("browser probe generated script", () => {
         status: 403,
         content_type: "text/html; charset=UTF-8",
         body_bytes: Buffer.byteLength(verificationBody),
+        detector_body_bytes: 0,
         json_like: false,
         error_kind: null,
       },
@@ -246,6 +331,7 @@ describe("browser probe generated script", () => {
         status: 403,
         content_type: "text/html; charset=UTF-8",
         body_bytes: Buffer.byteLength(verificationBody),
+        detector_body_bytes: 0,
         json_like: false,
         error_kind: null,
       },
@@ -316,6 +402,7 @@ describe("browser probe generated script", () => {
       status: null,
       content_type: null,
       body_bytes: 0,
+      detector_body_bytes: 0,
       json_like: false,
       error_kind: "ProbeTimeout",
     });


### PR DESCRIPTION
## What changed
- keep the shared browser session on the site origin while protocol discovery is unknown, instead of opening `/custom/...` subscription paths as a page
- preserve user-supplied registration/invitation links, and navigate to the adapter login page only after native protocol detection
- keep oversized JSON detector responses bounded by projecting only fields declared by the Sub2API/NewAPI adapters
- add structured browser import/probe continuation diagnostics and regression coverage
- bump the application version to `3.23.1`

## Root cause
Cloudflare verification was completing in the WebView, but the Sub2API public settings response was about 333 KB. The old 64 KiB browser callback limit discarded its body, so Rust never received the detector fields and the import remained stuck waiting for a response. The browser callback also opened `/custom/...` as the initial page even though that path is an API/subscription endpoint rather than a human-facing page.

## Validation
- `cargo test` — 2922 passed, 7 ignored
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm test:unit` — 125 files / 785 tests passed
- `git diff --check`
- local macOS `.app` bundle built and launched from this worktree; updater artifact signing is unavailable on this machine because `TAURI_SIGNING_PRIVATE_KEY` is not configured

The same origin WebView flow remains protocol-neutral and extensible for future site adapters.
