### PR TITLE
fix(relay): 修好 Cloudflare 站点登录，并让 live 配置只覆盖自己的键

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -279,7 +279,7 @@ pub fn write_codex_live_atomic(
     } else {
         None
     };
-    let _old_config = if config_path.exists() {
+    let old_config = if config_path.exists() {
         Some(fs::read(&config_path).map_err(|e| AppError::io(&config_path, e))?)
     } else {
         None
@@ -298,7 +298,17 @@ pub fn write_codex_live_atomic(
     write_json_file(&auth_path, auth)?;
 
     // 第二步：写 config.toml（失败则回滚 auth.json）
-    if let Err(e) = write_text_file(&config_path, &cfg_text) {
+    //
+    // 与切换供应商同样只覆盖自己 own 的键：这条路径同样是「投影」，
+    // 不该把用户手写的 approval_policy / plugins 等一起冲掉。
+    let merged = merge_codex_owned_keys(
+        &old_config
+            .as_deref()
+            .map(|bytes| String::from_utf8_lossy(bytes).into_owned())
+            .unwrap_or_default(),
+        &cfg_text,
+    );
+    if let Err(e) = write_text_file(&config_path, &merged) {
         // 回滚 auth.json
         if let Some(bytes) = old_auth {
             let _ = atomic_write(&auth_path, &bytes);
@@ -309,6 +319,80 @@ pub fn write_codex_live_atomic(
     }
 
     Ok(())
+}
+
+/// LoongPort 在 `~/.codex/config.toml` 里**唯一拥有**的顶层键。
+///
+/// ## 为什么要有这份名单
+///
+/// 这个文件是「投影产物」：DB 是 **provider 路由**这件事的唯一数据源。但 DB **不是整个
+/// 文件**的 owner —— 用户手写的 `approval_policy`、`sandbox_mode`、`[plugins]`、
+/// `[features]` 等属于另一个 owner，投影不该越界删它们。
+///
+/// 从前写 live 走的是全文覆盖，于是用户手写的配置**每切一次供应商就被静默抹掉一次**
+/// （2026-08-12 实测：维护者为让 codex 免审批而手写的三个键就是这么消失的）。
+///
+/// ## 为什么是白名单而不是黑名单
+///
+/// 黑名单要跟着上游 codex 版本持续维护：它明天新增一个配置项、不在名单里就照样被抹。
+/// 白名单对未知键**天然免疫** —— 边界由「我们 own 什么」定义，那是我们自己说了算的事实。
+const CODEX_OWNED_TOP_LEVEL_KEYS: &[&str] = &[
+    "model_provider",
+    "model",
+    "model_providers",
+    "experimental_bearer_token",
+    "model_catalog_json",
+    "profiles",
+    "mcp_servers",
+    // 旧形态 `[mcp.servers]`：与 `mcp_servers` 同源，`strip_codex_mcp_servers_from_settings`
+    // 一直是两种一起处理的。漏掉它会让上一个供应商的 legacy 段被当成用户数据留下来，
+    // 传播进下一个供应商的 live（`provider_service.rs` 有测试专门钉这条）。
+    "mcp",
+    // `wire_api` / `base_url` 在没有 `model_provider` 时会**回落写顶层**
+    // （见 `update_codex_toml_field` 的 `"base_url" | "wire_api"` 分支）。
+    // 它们描述的是「这个供应商用什么协议、打哪个地址」⇒ 必须跟着供应商走：
+    // 留下上一个供应商的值会改写下一个的协议（`provider_service.rs` 钉了这条）。
+    "wire_api",
+    "base_url",
+    "web_search",
+];
+
+/// 把 `incoming`（投影产物）合进 `existing`（磁盘现状），**只动本模块 own 的键**。
+///
+/// 语义：
+/// - 白名单内的键：`incoming` 有则覆盖，`incoming` 没有则从结果中**删除**
+///   （切到不带该键的供应商时旧值必须清掉，否则残留串台）。
+/// - 白名单外的键：原样保留，连注释和键顺序一起（`toml_edit` 的本职能力）。
+///
+/// ## 解析不了就整体覆盖
+///
+/// `existing` 为空或语法坏掉时直接返回 `incoming`：用户把 TOML 写坏了不该**卡死切换**，
+/// 那会让人连「切回一个能用的供应商」都做不到。
+///
+/// ⚠️ **备份恢复不能走这里** —— 恢复要的是精确还原，若也做合并，接管时写进去的键
+/// 就永远删不掉，会残留一条指向本地代理的死配置。恢复路径保持全文覆盖。
+fn merge_codex_owned_keys(existing: &str, incoming: &str) -> String {
+    if existing.trim().is_empty() {
+        return incoming.to_string();
+    }
+    let Ok(mut doc) = existing.parse::<DocumentMut>() else {
+        return incoming.to_string();
+    };
+    let incoming_doc = match incoming.parse::<DocumentMut>() {
+        Ok(parsed) => parsed,
+        // incoming 来自 DB 且调用方已做语法校验，走到这里只可能是空串。
+        Err(_) => return incoming.to_string(),
+    };
+
+    for key in CODEX_OWNED_TOP_LEVEL_KEYS {
+        match incoming_doc.get(key) {
+            Some(item) => doc[*key] = item.clone(),
+            None => {
+                doc.as_table_mut().remove(key);
+            }
+        }
+    }
+    doc.to_string()
 }
 
 /// 读取 `~/.codex/config.toml`，若不存在返回空字符串
@@ -370,7 +454,8 @@ pub fn write_codex_live_config_atomic(config_text_opt: Option<&str>) -> Result<(
         toml::from_str::<toml::Table>(&cfg_text).map_err(|e| AppError::toml(&config_path, e))?;
     }
 
-    write_text_file(&config_path, &cfg_text)
+    let merged = merge_codex_owned_keys(&read_codex_config_text().unwrap_or_default(), &cfg_text);
+    write_text_file(&config_path, &merged)
 }
 
 pub fn extract_codex_auth_api_key(auth: &Value) -> Option<String> {
@@ -2535,6 +2620,76 @@ requires_openai_auth = true
             Some("")
         );
         assert!(settings.pointer("/auth/tokens/access_token").is_some());
+    }
+
+    /// 用户手写的键必须活过供应商切换。
+    ///
+    /// 这条钉的是本次修复的核心：DB 是 provider 路由的 owner，不是整个文件的 owner。
+    #[test]
+    fn merge_keeps_user_authored_keys_outside_the_whitelist() {
+        let existing = concat!(
+            "# 用户自己加的\n",
+            "approval_policy = \"never\"\n",
+            "sandbox_mode = \"workspace-write\"\n",
+            "model = \"old-model\"\n",
+            "\n[sandbox_workspace_write]\nnetwork_access = true\n",
+            "\n[plugins.\"browser@openai-bundled\"]\nenabled = true\n",
+        );
+        let incoming = "model_provider = \"custom\"\nmodel = \"new-model\"\n";
+
+        let merged = merge_codex_owned_keys(existing, incoming);
+
+        assert!(
+            merged.contains("approval_policy = \"never\""),
+            "got: {merged}"
+        );
+        assert!(merged.contains("sandbox_mode = \"workspace-write\""));
+        assert!(merged.contains("[sandbox_workspace_write]"));
+        assert!(merged.contains("network_access = true"));
+        assert!(merged.contains("[plugins.\"browser@openai-bundled\"]"));
+        assert!(merged.contains("# 用户自己加的"), "注释也该留着");
+        // own 的键按 incoming 覆盖
+        assert!(merged.contains("model = \"new-model\""));
+        assert!(!merged.contains("old-model"));
+        assert!(merged.contains("model_provider = \"custom\""));
+    }
+
+    /// incoming 没有的 own 键必须删掉 —— 否则切到不带该键的供应商会残留串台。
+    #[test]
+    fn merge_removes_owned_keys_absent_from_incoming() {
+        let existing = concat!(
+            "model_provider = \"custom\"\n",
+            "model_catalog_json = \"loongport-model-catalog.json\"\n",
+            "approval_policy = \"never\"\n",
+            "\n[model_providers.custom]\nbase_url = \"https://old.example.com\"\n",
+        );
+        let incoming = "model = \"gpt-5.5\"\n";
+
+        let merged = merge_codex_owned_keys(existing, incoming);
+
+        assert!(
+            !merged.contains("model_provider"),
+            "旧路由必须清掉: {merged}"
+        );
+        assert!(!merged.contains("model_catalog_json"));
+        assert!(!merged.contains("model_providers"));
+        assert!(!merged.contains("old.example.com"));
+        // 用户的键不受影响
+        assert!(merged.contains("approval_policy = \"never\""));
+        assert!(merged.contains("model = \"gpt-5.5\""));
+    }
+
+    /// 用户把 TOML 写坏时不能卡死切换，否则他连切回一个能用的供应商都做不到。
+    #[test]
+    fn merge_falls_back_to_incoming_when_existing_is_unparsable() {
+        let incoming = "model = \"gpt-5.5\"\n";
+
+        for broken in ["这不是 TOML [[[", "model = \"unterminated\n"] {
+            assert_eq!(merge_codex_owned_keys(broken, incoming), incoming);
+        }
+        // 空盘同理
+        assert_eq!(merge_codex_owned_keys("", incoming), incoming);
+        assert_eq!(merge_codex_owned_keys("   \n", incoming), incoming);
     }
 
     #[test]

--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -776,7 +776,6 @@ async fn browser_import(
     // 一次导入只使用这一份纯内存会话：网页验证、协议探测、注册/登录都不换窗口，
     // 同时也不复用上一次导入的站点 cookie 或 token。
     .incognito(true)
-    .user_agent(login::WEBVIEW_USER_AGENT)
     // 所有导入都统一注入协议无关的候选抓取器。脚本不认识 Cloudflare、HTTP 403
     // 或任何其它验证产品；协议未知时，用户验证完成后它自然会在同源会话里读到候选响应。
     // fast path 已识别时，Rust context 已有值，重复探测回传会被忽略。
@@ -1300,7 +1299,6 @@ async fn do_login(app_handle: &tauri::AppHandle, target_id: i64) -> Result<Login
     // 中转站、以及 app 内其它 WebView 的登录态一起冲掉；而且它是异步的，
     // 没有完成回调可等 ⇒ 存在「还没清完页面就加载了」的竞态。
     .incognito(true)
-    .user_agent(login::WEBVIEW_USER_AGENT)
     // sub2api 的 localStorage 回传脚本只注入到 sub2api 窗口。NewAPI 的 HttpOnly
     // refresh cookie 由外层 async 循环原生读取，绝不交给 JavaScript。
     .initialization_script(initialization_script)
@@ -1514,10 +1512,15 @@ async fn persist_login_credentials(
 ) -> Result<(i64, i64), AppError> {
     // 先拉一次 profile 拿账号身份 —— 去重键是「域名 + 账号」，而账号只有登录后才知道。
     // `account_id` 传 `None`：这次只读请求的目的就是取得它，不需要幂等键。
-    let account = api::Client::new(site_origin, &credentials.auth_token, None)?
-        .account()
-        .await
-        .map_err(|e| AppError::Config(format!("登录成功但读取账号信息失败：{e}。请重试登录。")))?;
+    let account = api::Client::new(
+        site_origin,
+        &credentials.auth_token,
+        None,
+        credentials.user_agent.as_deref(),
+    )?
+    .account()
+    .await
+    .map_err(|e| AppError::Config(format!("登录成功但读取账号信息失败：{e}。请重试登录。")))?;
     let account_id = account.id;
 
     let state = app_handle.state::<AppState>();
@@ -1534,6 +1537,7 @@ async fn persist_login_credentials(
             &credentials.auth_token,
             credentials.refresh_token.as_deref(),
             credentials.token_expires_at,
+            credentials.user_agent.as_deref(),
         )
     })?;
 
@@ -1555,6 +1559,7 @@ fn persist_newapi_login_session(
             (!refreshed.refresh_cookie.trim().is_empty())
                 .then_some(refreshed.refresh_cookie.as_str()),
             refreshed.access_expires_at,
+            None,
         )
     })?;
 
@@ -1926,7 +1931,12 @@ fn newapi_reconcile_stage(stage: newapi_provision::ReconcileStage) -> &'static s
 async fn provision_backend(op: &creds::Relay) -> Result<ManagedProvisionBatch, AppError> {
     match op.backend_kind {
         discovery::BackendKind::Sub2Api => {
-            let client = api::Client::new(&op.site_origin, &op.auth_token, op.account_id)?;
+            let client = api::Client::new(
+                &op.site_origin,
+                &op.auth_token,
+                op.account_id,
+                op.user_agent.as_deref(),
+            )?;
             let mut result = provision::provision(&client).await?;
             provision::sort_tiers(&mut result.tiers);
             let keys_created = result
@@ -3478,7 +3488,12 @@ async fn open_purchase_window(
     // 先取账号档案。**必须在开窗之前** —— 站点的 router 守卫在页面启动那一刻就读
     // localStorage，注入脚本必须在那之前就带着完整的值。拿不到就别开窗：
     // 开一个注定落到登录页的窗口，用户只会以为「点了充值却要我重新登录」。
-    let client = api::Client::new(&op.site_origin, &op.auth_token, op.account_id)?;
+    let client = api::Client::new(
+        &op.site_origin,
+        &op.auth_token,
+        op.account_id,
+        op.user_agent.as_deref(),
+    )?;
     let public_settings = client.public_settings().await?;
     let auth_user = purchase::auth_user_from_profile(client.profile_raw().await?)?;
 
@@ -3535,10 +3550,6 @@ async fn open_purchase_window(
             // 它**不影响**注入：`initialization_script` 是 WKUserScript(AtDocumentStart)、
             // 与页面同一个 JS 世界，而 incognito 只决定这份 localStorage 落不落盘。
             .incognito(true)
-            // 与 HTTP 客户端共用同一个 UA：sub2api 的会话绑定（可选，默认关）会把
-            // `SHA256(clientIP + "\n" + UA)[:16]` 编进 token，UA 不一致会 401 并
-            // **撤销整个会话家族**（连网页登录态一起踢）。
-            .user_agent(login::WEBVIEW_USER_AGENT)
             .initialization_script(purchase::inject_script(
                 &op.site_origin,
                 &op.auth_token,
@@ -4600,6 +4611,7 @@ mod tests {
             auth_token: "access-token".into(),
             refresh_token: None,
             token_expires_at: None,
+            user_agent: None,
             sort_index: 0,
         }
     }
@@ -4694,6 +4706,7 @@ mod tests {
                 },
                 "saved-access-token",
                 Some("saved-refresh-token"),
+                None,
                 None,
             )
             .expect("save relay credentials");
@@ -5744,6 +5757,7 @@ mod tests {
                 "token",
                 None,
                 None,
+                None,
             )
         })
         .expect("save credentials");
@@ -6092,6 +6106,7 @@ mod tests {
                 "tok",
                 None,
                 None,
+                None,
             )
         })
         .expect("save credentials");
@@ -6290,6 +6305,7 @@ mod tests {
                 "stale-access",
                 Some("old-refresh"),
                 Some(1),
+                None,
             )
         })
         .expect("save credentials");
@@ -6354,6 +6370,7 @@ mod tests {
                 "stale-access",
                 Some("old-refresh"),
                 Some(1),
+                None,
             )
         })
         .expect("save credentials");

--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -678,6 +678,25 @@ fn newapi_refresh_cookie_from_window(
     Ok(newapi::extract_refresh_cookie(&cookies))
 }
 
+/// 从登录窗读 Cloudflare 放行 cookie。
+///
+/// 与相邻两个 NewAPI cookie 读取函数受同一条约束：`cookies_for_url` 只能在外层 async
+/// 循环里调，不能在同步的导航/窗口回调里调（Tauri 记录了 Windows 上的死锁）。
+///
+/// **读不到不算错**：绝大多数站没开托管挑战，`None` 是正常结果，
+/// 绝不能因此把一次成功的登录判失败。读 cookie 本身出错也只降级成 `None` ——
+/// 凭据已经到手了，为一个可选的加速项让整次登录失败不划算。
+fn cf_clearance_from_window(window: &tauri::WebviewWindow, site_origin: &str) -> Option<String> {
+    let url = url::Url::parse(site_origin).ok()?;
+    match window.cookies_for_url(url) {
+        Ok(cookies) => login::extract_cf_clearance(&cookies),
+        Err(error) => {
+            log::warn!("读取 Cloudflare 放行 cookie 失败（不影响登录）: {error}");
+            None
+        }
+    }
+}
+
 fn newapi_session_cookie_from_window(
     window: &tauri::WebviewWindow,
     session_url: &url::Url,
@@ -1004,7 +1023,10 @@ async fn browser_import(
                 biased;
                 _ = closed_rx.recv() => break BrowserLoginOutcome::Closed,
                 credentials = creds_rx.recv() => match credentials {
-                    Some(BrowserLoginCredential::Sub2Api(credentials)) => {
+                    Some(BrowserLoginCredential::Sub2Api(mut credentials)) => {
+                        // 趁窗口还在，把 CF 放行 cookie 一并收走：登录之后所有 API 都走
+                        // reqwest，而它过不了托管挑战，只能靠这个 cookie 放行。
+                        credentials.cf_clearance = cf_clearance_from_window(&window, &site_origin);
                         break BrowserLoginOutcome::Sub2ApiCredentials(credentials)
                     }
                     Some(BrowserLoginCredential::NewApiUserId(user_id)) => {
@@ -1374,7 +1396,10 @@ async fn do_login(app_handle: &tauri::AppHandle, target_id: i64) -> Result<Login
                 biased;
                 _ = closed_rx.recv() => break BrowserLoginOutcome::Closed,
                 creds = rx.recv() => match creds {
-                    Some(BrowserLoginCredential::Sub2Api(credentials)) => {
+                    Some(BrowserLoginCredential::Sub2Api(mut credentials)) => {
+                        // 趁窗口还在，把 CF 放行 cookie 一并收走：登录之后所有 API 都走
+                        // reqwest，而它过不了托管挑战，只能靠这个 cookie 放行。
+                        credentials.cf_clearance = cf_clearance_from_window(&window, &site_origin);
                         break BrowserLoginOutcome::Sub2ApiCredentials(credentials)
                     }
                     Some(BrowserLoginCredential::NewApiUserId(user_id)) => {
@@ -1517,6 +1542,7 @@ async fn persist_login_credentials(
         &credentials.auth_token,
         None,
         credentials.user_agent.as_deref(),
+        credentials.cf_clearance.as_deref(),
     )?
     .account()
     .await
@@ -1537,7 +1563,10 @@ async fn persist_login_credentials(
             &credentials.auth_token,
             credentials.refresh_token.as_deref(),
             credentials.token_expires_at,
-            credentials.user_agent.as_deref(),
+            creds::SessionEnvironment {
+                user_agent: credentials.user_agent.as_deref(),
+                cf_clearance: credentials.cf_clearance.as_deref(),
+            },
         )
     })?;
 
@@ -1559,7 +1588,8 @@ fn persist_newapi_login_session(
             (!refreshed.refresh_cookie.trim().is_empty())
                 .then_some(refreshed.refresh_cookie.as_str()),
             refreshed.access_expires_at,
-            None,
+            // NewAPI 登录不走 sub2api 那条 WebView 回传，两个字段都没有可写的值。
+            creds::SessionEnvironment::default(),
         )
     })?;
 
@@ -1936,6 +1966,7 @@ async fn provision_backend(op: &creds::Relay) -> Result<ManagedProvisionBatch, A
                 &op.auth_token,
                 op.account_id,
                 op.user_agent.as_deref(),
+                op.cf_clearance.as_deref(),
             )?;
             let mut result = provision::provision(&client).await?;
             provision::sort_tiers(&mut result.tiers);
@@ -3493,6 +3524,7 @@ async fn open_purchase_window(
         &op.auth_token,
         op.account_id,
         op.user_agent.as_deref(),
+        op.cf_clearance.as_deref(),
     )?;
     let public_settings = client.public_settings().await?;
     let auth_user = purchase::auth_user_from_profile(client.profile_raw().await?)?;
@@ -4612,6 +4644,7 @@ mod tests {
             refresh_token: None,
             token_expires_at: None,
             user_agent: None,
+            cf_clearance: None,
             sort_index: 0,
         }
     }
@@ -4707,7 +4740,7 @@ mod tests {
                 "saved-access-token",
                 Some("saved-refresh-token"),
                 None,
-                None,
+                creds::SessionEnvironment::default(),
             )
             .expect("save relay credentials");
             relay_id
@@ -5757,7 +5790,7 @@ mod tests {
                 "token",
                 None,
                 None,
-                None,
+                creds::SessionEnvironment::default(),
             )
         })
         .expect("save credentials");
@@ -6106,7 +6139,7 @@ mod tests {
                 "tok",
                 None,
                 None,
-                None,
+                creds::SessionEnvironment::default(),
             )
         })
         .expect("save credentials");
@@ -6305,7 +6338,7 @@ mod tests {
                 "stale-access",
                 Some("old-refresh"),
                 Some(1),
-                None,
+                creds::SessionEnvironment::default(),
             )
         })
         .expect("save credentials");
@@ -6370,7 +6403,7 @@ mod tests {
                 "stale-access",
                 Some("old-refresh"),
                 Some(1),
-                None,
+                creds::SessionEnvironment::default(),
             )
         })
         .expect("save credentials");

--- a/src-tauri/src/commands/vendor.rs
+++ b/src-tauri/src/commands/vendor.rs
@@ -308,7 +308,6 @@ async fn do_login(
     // **同一个厂商永远只能挂第一个登录过的账号**，而多账号正是本表唯一索引
     // `(vendor_id, account_id)` 特意支持的能力。
     .incognito(true)
-    .user_agent(crate::relay::login::WEBVIEW_USER_AGENT)
     .initialization_script(deepseek::login_script(login_hint))
     .on_navigation(move |url| {
         match deepseek::parse_creds_navigation(url) {

--- a/src-tauri/src/database/loongport_schema.rs
+++ b/src-tauri/src/database/loongport_schema.rs
@@ -48,7 +48,7 @@ use crate::error::AppError;
 /// LoongPort 自己的 schema 版本。加迁移时 +1。
 ///
 /// **与 `SCHEMA_VERSION`（上游那个）无关**，两者各自独立计数。
-pub(crate) const LOONGPORT_SCHEMA_VERSION: i32 = 9;
+pub(crate) const LOONGPORT_SCHEMA_VERSION: i32 = 10;
 
 /// 存版本号的表。**只有一行**（`id = 1`）。
 ///
@@ -176,6 +176,12 @@ pub(crate) fn apply(conn: &Connection) -> Result<(), AppError> {
                 add_relay_backend_kind_column(conn)?;
                 set_version(conn, 9)?;
             }
+            // v9 → v10：记录登录时的真实 User-Agent（不再伪造）。
+            9 => {
+                log::info!("LoongPort 数据迁移 v9 → v10（loongport_relay 加 user_agent 列）");
+                add_relay_user_agent_column(conn)?;
+                set_version(conn, 10)?;
+            }
             other => {
                 return Err(AppError::Database(format!(
                     "未知的 LoongPort 数据版本 {other}，无法迁移到 {LOONGPORT_SCHEMA_VERSION}"
@@ -203,6 +209,20 @@ fn add_relay_backend_kind_column(conn: &Connection) -> Result<(), AppError> {
         [],
     )
     .map_err(|e| AppError::Database(format!("给 loongport_relay 加 backend_kind 列失败: {e}")))?;
+    Ok(())
+}
+
+fn add_relay_user_agent_column(conn: &Connection) -> Result<(), AppError> {
+    if !crate::Database::table_exists(conn, "loongport_relay")? {
+        return Ok(());
+    }
+
+    if crate::Database::has_column(conn, "loongport_relay", "user_agent")? {
+        return Ok(());
+    }
+
+    conn.execute("ALTER TABLE loongport_relay ADD COLUMN user_agent TEXT", [])
+        .map_err(|e| AppError::Database(format!("给 loongport_relay 加 user_agent 列失败: {e}")))?;
     Ok(())
 }
 
@@ -658,7 +678,7 @@ mod tests {
             ),
             "迁移必须保留旧行，并把历史 relay 明确归为 sub2api"
         );
-        assert_eq!(current_version(&conn).unwrap(), 9);
+        assert_eq!(current_version(&conn).unwrap(), 10);
     }
 
     #[test]

--- a/src-tauri/src/database/loongport_schema.rs
+++ b/src-tauri/src/database/loongport_schema.rs
@@ -48,7 +48,7 @@ use crate::error::AppError;
 /// LoongPort 自己的 schema 版本。加迁移时 +1。
 ///
 /// **与 `SCHEMA_VERSION`（上游那个）无关**，两者各自独立计数。
-pub(crate) const LOONGPORT_SCHEMA_VERSION: i32 = 10;
+pub(crate) const LOONGPORT_SCHEMA_VERSION: i32 = 11;
 
 /// 存版本号的表。**只有一行**（`id = 1`）。
 ///
@@ -182,6 +182,12 @@ pub(crate) fn apply(conn: &Connection) -> Result<(), AppError> {
                 add_relay_user_agent_column(conn)?;
                 set_version(conn, 10)?;
             }
+            // v10 → v11：存下 Cloudflare 放行 cookie，让 reqwest 也能过托管挑战。
+            10 => {
+                log::info!("LoongPort 数据迁移 v10 → v11（loongport_relay 加 cf_clearance 列）");
+                add_relay_cf_clearance_column(conn)?;
+                set_version(conn, 11)?;
+            }
             other => {
                 return Err(AppError::Database(format!(
                     "未知的 LoongPort 数据版本 {other}，无法迁移到 {LOONGPORT_SCHEMA_VERSION}"
@@ -223,6 +229,23 @@ fn add_relay_user_agent_column(conn: &Connection) -> Result<(), AppError> {
 
     conn.execute("ALTER TABLE loongport_relay ADD COLUMN user_agent TEXT", [])
         .map_err(|e| AppError::Database(format!("给 loongport_relay 加 user_agent 列失败: {e}")))?;
+    Ok(())
+}
+
+fn add_relay_cf_clearance_column(conn: &Connection) -> Result<(), AppError> {
+    if !crate::Database::table_exists(conn, "loongport_relay")? {
+        return Ok(());
+    }
+
+    if crate::Database::has_column(conn, "loongport_relay", "cf_clearance")? {
+        return Ok(());
+    }
+
+    conn.execute(
+        "ALTER TABLE loongport_relay ADD COLUMN cf_clearance TEXT",
+        [],
+    )
+    .map_err(|e| AppError::Database(format!("给 loongport_relay 加 cf_clearance 列失败: {e}")))?;
     Ok(())
 }
 
@@ -678,7 +701,21 @@ mod tests {
             ),
             "迁移必须保留旧行，并把历史 relay 明确归为 sub2api"
         );
-        assert_eq!(current_version(&conn).unwrap(), 10);
+        // 断言的是「迁到最新版」而不是某个具体数字：写死版本号会让每加一次迁移
+        // 都得回来改这行（而它想钉的事实从来没变过）。
+        assert_eq!(current_version(&conn).unwrap(), LOONGPORT_SCHEMA_VERSION);
+    }
+
+    /// v10 → v11 加上 cf_clearance 列，且重复跑不炸（幂等）。
+    #[test]
+    fn v10_to_v11_adds_cf_clearance_column_idempotently() {
+        let conn = mem();
+        apply(&conn).expect("initial migrate");
+        assert!(crate::Database::has_column(&conn, "loongport_relay", "cf_clearance").unwrap());
+
+        // 迁移必须可重入：启动时会无条件跑一遍。
+        apply(&conn).expect("second migrate must be a no-op");
+        assert_eq!(current_version(&conn).unwrap(), LOONGPORT_SCHEMA_VERSION);
     }
 
     #[test]

--- a/src-tauri/src/grok_config.rs
+++ b/src-tauri/src/grok_config.rs
@@ -389,7 +389,51 @@ pub fn write_grok_provider_live(provider: &Provider) -> Result<(), AppError> {
         validate_config_toml(config)?;
     }
 
-    write_grok_live_settings(&json!({ "config": config }))
+    // 切换供应商是「投影」：只覆盖自己 own 的键，用户手写的其余内容原样保留。
+    // 不复用 `write_grok_live_settings` —— 那条是备份恢复用的，必须保持精确还原。
+    validate_config_toml_syntax(config)?;
+    let path = get_grok_config_path();
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+    write_text_file(&path, &merge_grok_owned_keys(&existing, config))
+}
+
+/// LoongPort 在 `~/.grok/config.toml` 里**唯一拥有**的顶层键。
+///
+/// 理由与 Codex 那份（`codex_config::CODEX_OWNED_TOP_LEVEL_KEYS`）逐字相同：
+/// DB 是 **provider 路由**的 owner，不是整个文件的 owner，投影不该越界删用户手写的键。
+/// 同样用白名单而非黑名单 —— 黑名单要跟着上游 Grok CLI 版本跑，新增配置项照样会被抹。
+///
+/// 核对依据：`extract_model_config` / `validate_config_toml` 只读 `models.default` 与
+/// `model.<profile>`；MCP 投影写顶层 `mcp_servers`，`strip_grok_mcp_servers_from_settings`
+/// 同时处理旧形态 `mcp.servers`。`api_key` / `base_url` 是**嵌套**在 `model.<profile>`
+/// 表里的字段，随 `model` 整体覆盖，不必单列。
+const GROK_OWNED_TOP_LEVEL_KEYS: &[&str] = &["models", "model", "mcp_servers", "mcp"];
+
+/// 把 `incoming`（投影产物）合进 `existing`（磁盘现状），只动本模块 own 的键。
+///
+/// 语义与 `codex_config::merge_codex_owned_keys` 一致：白名单内按 `incoming` 覆盖或删除，
+/// 白名单外原样保留；`existing` 空或语法坏掉时整体回落成 `incoming`（不能因为用户把
+/// TOML 写坏就卡死切换，那会让人连切回一个能用的供应商都做不到）。
+fn merge_grok_owned_keys(existing: &str, incoming: &str) -> String {
+    if existing.trim().is_empty() {
+        return incoming.to_string();
+    }
+    let Ok(mut document) = existing.parse::<toml_edit::DocumentMut>() else {
+        return incoming.to_string();
+    };
+    let Ok(incoming_document) = incoming.parse::<toml_edit::DocumentMut>() else {
+        return incoming.to_string();
+    };
+
+    for key in GROK_OWNED_TOP_LEVEL_KEYS {
+        match incoming_document.get(key) {
+            Some(item) => document[*key] = item.clone(),
+            None => {
+                document.as_table_mut().remove(key);
+            }
+        }
+    }
+    document.to_string()
 }
 
 /// Raw live-file writer, mirroring `read_grok_live_settings` (syntax-only).
@@ -586,6 +630,56 @@ context_window = 500000
         match original_unset {
             Some(value) => std::env::set_var("GROK_TEST_DEFINITELY_UNSET_VAR", value),
             None => std::env::remove_var("GROK_TEST_DEFINITELY_UNSET_VAR"),
+        }
+    }
+
+    /// 用户手写的键必须活过供应商切换（本次修复的核心）。
+    #[test]
+    fn merge_keeps_user_authored_keys_outside_the_whitelist() {
+        let existing = concat!(
+            "# 用户自己加的\n",
+            "telemetry = false\n",
+            "\n[models]\ndefault = \"old\"\n",
+            "\n[ui]\ntheme = \"dark\"\n",
+        );
+        let incoming = "[models]\ndefault = \"new\"\n";
+
+        let merged = merge_grok_owned_keys(existing, incoming);
+
+        assert!(merged.contains("telemetry = false"), "got: {merged}");
+        assert!(merged.contains("[ui]"));
+        assert!(merged.contains("theme = \"dark\""));
+        assert!(merged.contains("# 用户自己加的"), "注释也该留着");
+        assert!(merged.contains("default = \"new\""));
+        assert!(!merged.contains("\"old\""));
+    }
+
+    /// incoming 没有的 own 键必须删掉，否则旧投影会串到下一个供应商。
+    #[test]
+    fn merge_removes_owned_keys_absent_from_incoming() {
+        let existing = concat!(
+            "telemetry = false\n",
+            "\n[mcp_servers.echo]\ncommand = \"echo\"\n",
+            "\n[models]\ndefault = \"old\"\n",
+        );
+        let incoming = "[models]\ndefault = \"new\"\n";
+
+        let merged = merge_grok_owned_keys(existing, incoming);
+
+        assert!(
+            !merged.contains("mcp_servers"),
+            "旧 MCP 投影必须清掉: {merged}"
+        );
+        assert!(!merged.contains("echo"));
+        assert!(merged.contains("telemetry = false"), "用户键不受影响");
+    }
+
+    /// 用户把 TOML 写坏时不能卡死切换。
+    #[test]
+    fn merge_falls_back_to_incoming_when_existing_is_unparsable() {
+        let incoming = "[models]\ndefault = \"new\"\n";
+        for broken in ["这不是 TOML [[[", "", "   \n"] {
+            assert_eq!(merge_grok_owned_keys(broken, incoming), incoming);
         }
     }
 

--- a/src-tauri/src/relay/api.rs
+++ b/src-tauri/src/relay/api.rs
@@ -543,9 +543,10 @@ impl Client {
         token: impl Into<String>,
         account_id: Option<i64>,
         user_agent: Option<&str>,
+        cf_clearance: Option<&str>,
     ) -> Result<Self, AppError> {
         Ok(Self {
-            http: build_client_with_user_agent(user_agent)?,
+            http: build_client_with_session(user_agent, cf_clearance)?,
             site_origin: site_origin.into(),
             token: token.into(),
             account_id,
@@ -1082,9 +1083,37 @@ fn describe_send_error(e: &reqwest::Error) -> String {
 pub(crate) fn build_client_with_user_agent(
     user_agent: Option<&str>,
 ) -> Result<reqwest::Client, AppError> {
+    build_client_with_session(user_agent, None)
+}
+
+/// 建一个带登录会话特征的客户端。
+///
+/// `cf_clearance` 是 Cloudflare 托管挑战的放行 cookie：本 app 登录走 WebView（能执行 JS
+/// ⇒ 过得了挑战），之后 API 全走 reqwest（**永远过不了**）。把 WebView 拿到的那个 cookie
+/// 带上，reqwest 才不会在开了挑战的站上撞 403 `Just a moment...`。
+///
+/// ⚠️ 该 cookie 绑定 IP + UA ⇒ 必须与 `user_agent` 成对使用，两者都取自同一次登录。
+/// 任一为空就不设对应的头，绝不伪造。
+pub(crate) fn build_client_with_session(
+    user_agent: Option<&str>,
+    cf_clearance: Option<&str>,
+) -> Result<reqwest::Client, AppError> {
     let mut builder = reqwest::Client::builder().timeout(std::time::Duration::from_secs(30));
     if let Some(ua) = user_agent {
         builder = builder.user_agent(ua);
+    }
+    if let Some(clearance) = cf_clearance.map(str::trim).filter(|v| !v.is_empty()) {
+        let mut headers = reqwest::header::HeaderMap::new();
+        let cookie = format!("cf_clearance={clearance}");
+        // 值来自服务端下发的 cookie，理论上都是合法 header 值；解析不了就不设它 ——
+        // 那只是回到「没有放行 cookie」的状态，不该让整个客户端建不起来。
+        match reqwest::header::HeaderValue::from_str(&cookie) {
+            Ok(value) => {
+                headers.insert(reqwest::header::COOKIE, value);
+                builder = builder.default_headers(headers);
+            }
+            Err(error) => log::warn!("Cloudflare 放行 cookie 不是合法的 header 值: {error}"),
+        }
     }
     builder
         .build()
@@ -1098,6 +1127,16 @@ pub(crate) fn build_client() -> Result<reqwest::Client, AppError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// 有无放行 cookie 都要能建出客户端；无值时**不发空 Cookie 头**。
+    #[test]
+    fn client_builds_with_and_without_cf_clearance() {
+        assert!(build_client_with_session(Some("UA/1.0"), Some("tok")).is_ok());
+        assert!(build_client_with_session(Some("UA/1.0"), None).is_ok());
+        assert!(build_client_with_session(None, None).is_ok());
+        // 空白值等同于没有：不该拼出 `cf_clearance=` 这种空头。
+        assert!(build_client_with_session(None, Some("   ")).is_ok());
+    }
 
     #[test]
     fn normalize_site_origin_accepts_bare_host_and_strips_path() {
@@ -1463,7 +1502,8 @@ mod tests {
                 .expect("serve settings response");
         });
 
-        let client = Client::new(origin, "account-secret", Some(7), None).expect("build client");
+        let client =
+            Client::new(origin, "account-secret", Some(7), None, None).expect("build client");
         let settings = client
             .public_settings()
             .await
@@ -1666,7 +1706,7 @@ mod tests {
     /// **调用点** —— 把请求组装处的 `self.account_id` 换成 `None`（等于修法作废、
     /// 409 复发），它们一条都不会红。所以这条必须走 [`Client`]。
     fn idempotency_header_on_request(account_id: Option<i64>, name: &str) -> String {
-        let req = Client::new("https://example.com", "token", account_id, None)
+        let req = Client::new("https://example.com", "token", account_id, None, None)
             .expect("构造 client 不该失败")
             .create_key_request(name, 8)
             .build()

--- a/src-tauri/src/relay/api.rs
+++ b/src-tauri/src/relay/api.rs
@@ -513,11 +513,9 @@ pub fn base_url_for(app_type: &AppType, site_origin: &str, api_base_url: &str) -
 
 /// 带 Bearer token 的 sub2api 客户端。
 ///
-/// **User-Agent 必须与登录 WebView 一致**：sub2api 有可选的会话绑定
-/// （`session_binding_enabled`，默认关），开启后 access token 里带
-/// `SHA256(clientIP + "\n" + UA)[:16]`，每个请求重算比对，不符即**撤销整个会话家族**
-/// 并返 401 `SESSION_BINDING_MISMATCH`。UA 不一致的后果不是单次失败，是连网页登录态
-/// 一起被踢掉。
+/// 会话绑定开启时，UA 必须与登录 WebView 一致。当前设计以引擎真实 UA 为唯一
+/// 数据源：登录时从 `navigator.userAgent` 回传并持久化，HTTP 客户端跟随它。
+/// 值为空时不设（不再伪造默认值）。
 pub struct Client {
     http: reqwest::Client,
     site_origin: String,
@@ -544,9 +542,10 @@ impl Client {
         site_origin: impl Into<String>,
         token: impl Into<String>,
         account_id: Option<i64>,
+        user_agent: Option<&str>,
     ) -> Result<Self, AppError> {
         Ok(Self {
-            http: build_client()?,
+            http: build_client_with_user_agent(user_agent)?,
             site_origin: site_origin.into(),
             token: token.into(),
             account_id,
@@ -1080,12 +1079,20 @@ fn describe_send_error(e: &reqwest::Error) -> String {
     out
 }
 
-pub(crate) fn build_client() -> Result<reqwest::Client, AppError> {
-    reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .user_agent(crate::relay::login::WEBVIEW_USER_AGENT)
+pub(crate) fn build_client_with_user_agent(
+    user_agent: Option<&str>,
+) -> Result<reqwest::Client, AppError> {
+    let mut builder = reqwest::Client::builder().timeout(std::time::Duration::from_secs(30));
+    if let Some(ua) = user_agent {
+        builder = builder.user_agent(ua);
+    }
+    builder
         .build()
         .map_err(|e| AppError::Config(format!("创建 HTTP 客户端失败: {e}")))
+}
+
+pub(crate) fn build_client() -> Result<reqwest::Client, AppError> {
+    build_client_with_user_agent(None)
 }
 
 #[cfg(test)]
@@ -1456,7 +1463,7 @@ mod tests {
                 .expect("serve settings response");
         });
 
-        let client = Client::new(origin, "account-secret", Some(7)).expect("build client");
+        let client = Client::new(origin, "account-secret", Some(7), None).expect("build client");
         let settings = client
             .public_settings()
             .await
@@ -1659,7 +1666,7 @@ mod tests {
     /// **调用点** —— 把请求组装处的 `self.account_id` 换成 `None`（等于修法作废、
     /// 409 复发），它们一条都不会红。所以这条必须走 [`Client`]。
     fn idempotency_header_on_request(account_id: Option<i64>, name: &str) -> String {
-        let req = Client::new("https://example.com", "token", account_id)
+        let req = Client::new("https://example.com", "token", account_id, None)
             .expect("构造 client 不该失败")
             .create_key_request(name, 8)
             .build()

--- a/src-tauri/src/relay/backend.rs
+++ b/src-tauri/src/relay/backend.rs
@@ -116,10 +116,14 @@ impl<'a> RuntimeBackend<'a> {
     pub async fn account(&self) -> Result<RuntimeAccount, AppError> {
         match self {
             Self::Sub2Api { relay } => {
-                let account =
-                    api::Client::new(&relay.site_origin, &relay.auth_token, relay.account_id)?
-                        .account()
-                        .await?;
+                let account = api::Client::new(
+                    &relay.site_origin,
+                    &relay.auth_token,
+                    relay.account_id,
+                    relay.user_agent.as_deref(),
+                )?
+                .account()
+                .await?;
                 Ok(RuntimeAccount {
                     id: account.id,
                     label: account.display_name(),
@@ -142,10 +146,14 @@ impl<'a> RuntimeBackend<'a> {
     pub async fn balance(&self) -> Result<RuntimeBalance, AppError> {
         match self {
             Self::Sub2Api { relay } => {
-                let balance =
-                    api::Client::new(&relay.site_origin, &relay.auth_token, relay.account_id)?
-                        .balance()
-                        .await?;
+                let balance = api::Client::new(
+                    &relay.site_origin,
+                    &relay.auth_token,
+                    relay.account_id,
+                    relay.user_agent.as_deref(),
+                )?
+                .balance()
+                .await?;
                 Ok(RuntimeBalance {
                     balance: balance.balance,
                     frozen_balance: balance.frozen_balance,
@@ -300,6 +308,7 @@ mod tests {
             auth_token: "access-token".into(),
             refresh_token: Some("stored-refresh".into()),
             token_expires_at: Some(1),
+            user_agent: None,
             sort_index: 0,
         }
     }

--- a/src-tauri/src/relay/backend.rs
+++ b/src-tauri/src/relay/backend.rs
@@ -121,6 +121,7 @@ impl<'a> RuntimeBackend<'a> {
                     &relay.auth_token,
                     relay.account_id,
                     relay.user_agent.as_deref(),
+                    relay.cf_clearance.as_deref(),
                 )?
                 .account()
                 .await?;
@@ -151,6 +152,7 @@ impl<'a> RuntimeBackend<'a> {
                     &relay.auth_token,
                     relay.account_id,
                     relay.user_agent.as_deref(),
+                    relay.cf_clearance.as_deref(),
                 )?
                 .balance()
                 .await?;
@@ -309,6 +311,7 @@ mod tests {
             refresh_token: Some("stored-refresh".into()),
             token_expires_at: Some(1),
             user_agent: None,
+            cf_clearance: None,
             sort_index: 0,
         }
     }

--- a/src-tauri/src/relay/creds.rs
+++ b/src-tauri/src/relay/creds.rs
@@ -136,6 +136,18 @@ pub struct Relay {
     /// Unix 秒。`None` 表示服务端没给（降级态：可用但不可续期）。
     pub token_expires_at: Option<i64>,
     pub user_agent: Option<String>,
+    /// Cloudflare 托管挑战通过后种下的放行 cookie。
+    ///
+    /// 本 app 有两套 HTTP 栈：登录走 WebView（能执行 JS ⇒ 过得了挑战），之后所有 API
+    /// 调用走 reqwest（**永远过不了**，它不是浏览器）。开了挑战的站上实测表现是
+    /// 「登录成功，紧接着读账号信息 403 + `Just a moment...`」—— 卡在登录完成的下一步。
+    /// 把 WebView 已经拿到的这个 cookie 交给 reqwest 就能放行。
+    ///
+    /// ⚠️ 它**绑定 IP + User-Agent** ⇒ 依赖 [`Relay::user_agent`] 如实记录真实 UA。
+    ///
+    /// `None` = 这个站没开挑战（绝大多数站如此），不是错误态。
+    /// 过期后请求会再次 403，走重新登录即可覆盖。
+    pub cf_clearance: Option<String>,
     /// 用户手工拖动决定的行序，越小越靠前。
     ///
     /// ## 为什么需要一列专门存序
@@ -216,7 +228,8 @@ pub fn create_table(conn: &Connection) -> Result<(), AppError> {
             sort_index INTEGER NOT NULL DEFAULT 0,
             updated_at INTEGER NOT NULL DEFAULT 0,
             backend_kind TEXT NOT NULL DEFAULT 'sub2api',
-            user_agent TEXT
+            user_agent TEXT,
+            cf_clearance TEXT
         )",
         [],
     )
@@ -242,7 +255,8 @@ pub fn create_table(conn: &Connection) -> Result<(), AppError> {
 /// 由 [`select_cols_match_the_row_reader`] 钉住两者的列数一致。
 const SELECT_COLS: &str =
     "id, site_origin, site_name, api_base_url, account_id, account_label, login_identifier, \
-     auth_token, refresh_token, token_expires_at, sort_index, backend_kind, user_agent";
+     auth_token, refresh_token, token_expires_at, sort_index, backend_kind, user_agent, \
+     cf_clearance";
 
 fn row_to_relay(row: &rusqlite::Row<'_>) -> rusqlite::Result<Relay> {
     Ok(Relay {
@@ -259,6 +273,7 @@ fn row_to_relay(row: &rusqlite::Row<'_>) -> rusqlite::Result<Relay> {
         sort_index: row.get(10)?,
         backend_kind: row.get(11)?,
         user_agent: row.get(12)?,
+        cf_clearance: row.get(13)?,
     })
 }
 
@@ -406,6 +421,22 @@ pub struct AccountIdentity<'a> {
     pub login_identifier: &'a str,
 }
 
+/// 这次登录所处的**客户端环境**。
+///
+/// 两个字段必须成对：Cloudflare 的放行 cookie 绑定 IP + User-Agent，UA 对不上它就失效。
+/// 把它们收成一个概念而不是并列的散参数 —— 既表达了这层耦合，也避免了
+/// `save_credentials` 的参数列表继续变长（clippy 的 too_many_arguments 已经在提醒了）。
+///
+/// 两个字段都可能是 `None`：NewAPI 那条登录路径不经过 sub2api 的 WebView 回传，
+/// 而绝大多数站没开 Cloudflare 托管挑战。
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SessionEnvironment<'a> {
+    /// 登录时 WebView 的真实 User-Agent。见 [`Relay::user_agent`]。
+    pub user_agent: Option<&'a str>,
+    /// Cloudflare 放行 cookie。见 [`Relay::cf_clearance`]。
+    pub cf_clearance: Option<&'a str>,
+}
+
 /// 写入登录凭据与账号身份，并在发现重复时合并。
 ///
 /// 返回**最终生效的那一行的 id** —— 可能不是传进来的 `id`：如果这个站上已经有同一个账号的
@@ -417,8 +448,12 @@ pub fn save_credentials(
     auth_token: &str,
     refresh_token: Option<&str>,
     token_expires_at: Option<i64>,
-    user_agent: Option<&str>,
+    session: SessionEnvironment<'_>,
 ) -> Result<i64, AppError> {
+    let SessionEnvironment {
+        user_agent,
+        cf_clearance,
+    } = session;
     let AccountIdentity {
         id: account_id,
         label: account_label,
@@ -461,8 +496,9 @@ pub fn save_credentials(
             "UPDATE loongport_relay
          SET site_name = ?1, api_base_url = ?2, backend_kind = ?3,
              account_id = ?4, account_label = ?5, login_identifier = ?6, auth_token = ?7,
-             refresh_token = ?8, token_expires_at = ?9, user_agent = ?10, updated_at = ?11
-         WHERE id = ?12",
+             refresh_token = ?8, token_expires_at = ?9, user_agent = ?10, cf_clearance = ?11,
+             updated_at = ?12
+         WHERE id = ?13",
             params![
                 site_name,
                 api_base_url,
@@ -474,6 +510,7 @@ pub fn save_credentials(
                 refresh_token,
                 token_expires_at,
                 user_agent,
+                cf_clearance,
                 now_unix(),
                 target
             ],
@@ -650,7 +687,7 @@ mod tests {
             "tok",
             Some("ref"),
             Some(123),
-            None,
+            SessionEnvironment::default(),
         )
         .unwrap();
 
@@ -780,7 +817,7 @@ mod tests {
             "tok1",
             None,
             None,
-            None,
+            SessionEnvironment::default(),
         )
         .unwrap();
 
@@ -794,7 +831,7 @@ mod tests {
             "tok2",
             None,
             None,
-            None,
+            SessionEnvironment::default(),
         )
         .unwrap();
         assert_eq!(final_id, second);
@@ -814,7 +851,7 @@ mod tests {
             "old-token",
             None,
             None,
-            None,
+            SessionEnvironment::default(),
         )
         .unwrap();
 
@@ -827,7 +864,7 @@ mod tests {
             "new-token",
             None,
             None,
-            None,
+            SessionEnvironment::default(),
         )
         .unwrap();
 
@@ -857,7 +894,7 @@ mod tests {
             "old-token",
             Some("old-refresh"),
             Some(100),
-            None,
+            SessionEnvironment::default(),
         )
         .unwrap();
         conn.execute(
@@ -881,7 +918,7 @@ mod tests {
             "fresh-token",
             Some("fresh-refresh"),
             Some(200),
-            None,
+            SessionEnvironment::default(),
         )
         .unwrap();
 
@@ -916,7 +953,7 @@ mod tests {
             "old-token",
             Some("old-refresh"),
             Some(100),
-            None,
+            SessionEnvironment::default(),
         )
         .unwrap();
         let source = save_site_with_backend(
@@ -941,7 +978,7 @@ mod tests {
             "fresh-token",
             Some("fresh-refresh"),
             Some(200),
-            None,
+            SessionEnvironment::default(),
         )
         .expect_err("delete failure must roll the merge back");
 
@@ -966,7 +1003,7 @@ mod tests {
             "tok",
             Some("ref"),
             Some(123),
-            None,
+            SessionEnvironment::default(),
         )
         .unwrap();
         clear_credentials(&conn, a).unwrap();
@@ -1013,7 +1050,7 @@ mod tests {
             "tok",
             None,
             None,
-            None,
+            SessionEnvironment::default(),
         )
         .unwrap_err();
         assert!(err.to_string().contains("站点记录不存在"));
@@ -1030,7 +1067,7 @@ mod tests {
             "tok",
             None,
             Some(1000),
-            None,
+            SessionEnvironment::default(),
         )
         .unwrap();
         let base = get(&conn, a).unwrap().unwrap();
@@ -1076,7 +1113,7 @@ mod tests {
             "tok",
             None,
             Some(1000),
-            None,
+            SessionEnvironment::default(),
         )
         .unwrap();
         let stale = get(&conn, a).unwrap().unwrap();
@@ -1124,7 +1161,7 @@ mod tests {
             "tok",
             None,
             None,
-            None,
+            SessionEnvironment::default(),
         )
         .unwrap();
         let order: Vec<i64> = list(&conn).unwrap().into_iter().map(|o| o.id).collect();
@@ -1138,7 +1175,7 @@ mod tests {
             "tok",
             None,
             None,
-            None,
+            SessionEnvironment::default(),
         )
         .unwrap();
         let order: Vec<i64> = list(&conn).unwrap().into_iter().map(|o| o.id).collect();
@@ -1165,7 +1202,7 @@ mod tests {
             "tok",
             None,
             None,
-            None,
+            SessionEnvironment::default(),
         )
         .unwrap();
         let order: Vec<i64> = list(&conn).unwrap().into_iter().map(|o| o.id).collect();
@@ -1185,7 +1222,7 @@ mod tests {
             "tok",
             None,
             None,
-            None,
+            SessionEnvironment::default(),
         )
         .unwrap();
 
@@ -1206,7 +1243,7 @@ mod tests {
             "tok",
             None,
             None,
-            None,
+            SessionEnvironment::default(),
         )
         .unwrap();
 
@@ -1234,7 +1271,7 @@ mod tests {
             "tok",
             None,
             None,
-            None,
+            SessionEnvironment::default(),
         )
         .unwrap();
 

--- a/src-tauri/src/relay/creds.rs
+++ b/src-tauri/src/relay/creds.rs
@@ -135,6 +135,7 @@ pub struct Relay {
     pub refresh_token: Option<String>,
     /// Unix 秒。`None` 表示服务端没给（降级态：可用但不可续期）。
     pub token_expires_at: Option<i64>,
+    pub user_agent: Option<String>,
     /// 用户手工拖动决定的行序，越小越靠前。
     ///
     /// ## 为什么需要一列专门存序
@@ -214,7 +215,8 @@ pub fn create_table(conn: &Connection) -> Result<(), AppError> {
             token_expires_at INTEGER,
             sort_index INTEGER NOT NULL DEFAULT 0,
             updated_at INTEGER NOT NULL DEFAULT 0,
-            backend_kind TEXT NOT NULL DEFAULT 'sub2api'
+            backend_kind TEXT NOT NULL DEFAULT 'sub2api',
+            user_agent TEXT
         )",
         [],
     )
@@ -240,7 +242,7 @@ pub fn create_table(conn: &Connection) -> Result<(), AppError> {
 /// 由 [`select_cols_match_the_row_reader`] 钉住两者的列数一致。
 const SELECT_COLS: &str =
     "id, site_origin, site_name, api_base_url, account_id, account_label, login_identifier, \
-     auth_token, refresh_token, token_expires_at, sort_index, backend_kind";
+     auth_token, refresh_token, token_expires_at, sort_index, backend_kind, user_agent";
 
 fn row_to_relay(row: &rusqlite::Row<'_>) -> rusqlite::Result<Relay> {
     Ok(Relay {
@@ -256,6 +258,7 @@ fn row_to_relay(row: &rusqlite::Row<'_>) -> rusqlite::Result<Relay> {
         token_expires_at: row.get(9)?,
         sort_index: row.get(10)?,
         backend_kind: row.get(11)?,
+        user_agent: row.get(12)?,
     })
 }
 
@@ -414,6 +417,7 @@ pub fn save_credentials(
     auth_token: &str,
     refresh_token: Option<&str>,
     token_expires_at: Option<i64>,
+    user_agent: Option<&str>,
 ) -> Result<i64, AppError> {
     let AccountIdentity {
         id: account_id,
@@ -457,8 +461,8 @@ pub fn save_credentials(
             "UPDATE loongport_relay
          SET site_name = ?1, api_base_url = ?2, backend_kind = ?3,
              account_id = ?4, account_label = ?5, login_identifier = ?6, auth_token = ?7,
-             refresh_token = ?8, token_expires_at = ?9, updated_at = ?10
-         WHERE id = ?11",
+             refresh_token = ?8, token_expires_at = ?9, user_agent = ?10, updated_at = ?11
+         WHERE id = ?12",
             params![
                 site_name,
                 api_base_url,
@@ -469,6 +473,7 @@ pub fn save_credentials(
                 auth_token,
                 refresh_token,
                 token_expires_at,
+                user_agent,
                 now_unix(),
                 target
             ],
@@ -645,6 +650,7 @@ mod tests {
             "tok",
             Some("ref"),
             Some(123),
+            None,
         )
         .unwrap();
 
@@ -774,6 +780,7 @@ mod tests {
             "tok1",
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -785,6 +792,7 @@ mod tests {
             second,
             ident(200, "alt@x.com", "alt@x.com"),
             "tok2",
+            None,
             None,
             None,
         )
@@ -806,6 +814,7 @@ mod tests {
             "old-token",
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -816,6 +825,7 @@ mod tests {
             second,
             ident(100, "me@x.com", "me@x.com"),
             "new-token",
+            None,
             None,
             None,
         )
@@ -847,6 +857,7 @@ mod tests {
             "old-token",
             Some("old-refresh"),
             Some(100),
+            None,
         )
         .unwrap();
         conn.execute(
@@ -870,6 +881,7 @@ mod tests {
             "fresh-token",
             Some("fresh-refresh"),
             Some(200),
+            None,
         )
         .unwrap();
 
@@ -904,6 +916,7 @@ mod tests {
             "old-token",
             Some("old-refresh"),
             Some(100),
+            None,
         )
         .unwrap();
         let source = save_site_with_backend(
@@ -928,6 +941,7 @@ mod tests {
             "fresh-token",
             Some("fresh-refresh"),
             Some(200),
+            None,
         )
         .expect_err("delete failure must roll the merge back");
 
@@ -952,6 +966,7 @@ mod tests {
             "tok",
             Some("ref"),
             Some(123),
+            None,
         )
         .unwrap();
         clear_credentials(&conn, a).unwrap();
@@ -998,6 +1013,7 @@ mod tests {
             "tok",
             None,
             None,
+            None,
         )
         .unwrap_err();
         assert!(err.to_string().contains("站点记录不存在"));
@@ -1014,6 +1030,7 @@ mod tests {
             "tok",
             None,
             Some(1000),
+            None,
         )
         .unwrap();
         let base = get(&conn, a).unwrap().unwrap();
@@ -1059,6 +1076,7 @@ mod tests {
             "tok",
             None,
             Some(1000),
+            None,
         )
         .unwrap();
         let stale = get(&conn, a).unwrap().unwrap();
@@ -1099,12 +1117,30 @@ mod tests {
         );
 
         // 给最后那行登录 —— 行序仍然不能变（这正是用户报的那个 bug 的形态）。
-        save_credentials(&conn, c, ident(1, "c@x.com", "c@x.com"), "tok", None, None).unwrap();
+        save_credentials(
+            &conn,
+            c,
+            ident(1, "c@x.com", "c@x.com"),
+            "tok",
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         let order: Vec<i64> = list(&conn).unwrap().into_iter().map(|o| o.id).collect();
         assert_eq!(order, vec![a, b, c], "登录某一行不该让它跳到最前");
 
         // 给第一行登录也一样。
-        save_credentials(&conn, a, ident(2, "a@x.com", "a@x.com"), "tok", None, None).unwrap();
+        save_credentials(
+            &conn,
+            a,
+            ident(2, "a@x.com", "a@x.com"),
+            "tok",
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         let order: Vec<i64> = list(&conn).unwrap().into_iter().map(|o| o.id).collect();
         assert_eq!(order, vec![a, b, c], "任何登录都不该改变行序");
     }
@@ -1122,7 +1158,16 @@ mod tests {
         assert_eq!(order, vec![c, a, b]);
 
         // 拖完之后登录其中一行，顺序仍不变 —— 两件事互不干扰。
-        save_credentials(&conn, b, ident(1, "b@x.com", "b@x.com"), "tok", None, None).unwrap();
+        save_credentials(
+            &conn,
+            b,
+            ident(1, "b@x.com", "b@x.com"),
+            "tok",
+            None,
+            None,
+            None,
+        )
+        .unwrap();
         let order: Vec<i64> = list(&conn).unwrap().into_iter().map(|o| o.id).collect();
         assert_eq!(order, vec![c, a, b], "登录不该动用户拖出来的顺序");
     }
@@ -1133,7 +1178,16 @@ mod tests {
         // —— 拿它去预填登录框就填错了（sub2api 那个框要邮箱格式）。
         let conn = mem();
         let a = save_site(&conn, "https://a.dev", "A", "https://a.dev/v1").unwrap();
-        save_credentials(&conn, a, ident(7, "张三", "me@x.com"), "tok", None, None).unwrap();
+        save_credentials(
+            &conn,
+            a,
+            ident(7, "张三", "me@x.com"),
+            "tok",
+            None,
+            None,
+            None,
+        )
+        .unwrap();
 
         let op = get(&conn, a).unwrap().unwrap();
         assert_eq!(op.account_label, "张三", "给人看的是昵称");
@@ -1145,7 +1199,16 @@ mod tests {
         // clear_credentials 正是「重登前的那一步」，把预填值一起清掉等于让用户重新输邮箱。
         let conn = mem();
         let a = save_site(&conn, "https://a.dev", "A", "https://a.dev/v1").unwrap();
-        save_credentials(&conn, a, ident(7, "张三", "me@x.com"), "tok", None, None).unwrap();
+        save_credentials(
+            &conn,
+            a,
+            ident(7, "张三", "me@x.com"),
+            "tok",
+            None,
+            None,
+            None,
+        )
+        .unwrap();
 
         clear_credentials(&conn, a).unwrap();
 
@@ -1164,7 +1227,16 @@ mod tests {
         // 只有展示与预填要跟上。续期路径靠这个函数刷，否则站点选择器一直挂旧标签。
         let conn = mem();
         let a = save_site(&conn, "https://a.dev", "A", "https://a.dev/v1").unwrap();
-        save_credentials(&conn, a, ident(7, "老名字", "old@x.com"), "tok", None, None).unwrap();
+        save_credentials(
+            &conn,
+            a,
+            ident(7, "老名字", "old@x.com"),
+            "tok",
+            None,
+            None,
+            None,
+        )
+        .unwrap();
 
         // 传一个**不同的** account_id（99）：已有值非空 ⇒ 必须不被覆盖。
         refresh_account_identity(&conn, a, ident(99, "新名字", "new@x.com")).unwrap();

--- a/src-tauri/src/relay/discovery.rs
+++ b/src-tauri/src/relay/discovery.rs
@@ -405,9 +405,13 @@ pub async fn discover_site(site_origin: &str) -> Result<DetectedSite, DiscoveryE
             continue;
         }
 
+        // 上限按**压缩前的源大小**算，与浏览器那条路径一致（见 `detectorBody`）：
+        // 站点把大段用户可见配置塞进公共设置里是常事（实测 bestapi.store 已 143 KiB），
+        // 在 64 KiB 就丢弃会把一个完全正常的 sub2api 站误判成「协议无法识别」。
+        // 真正的指纹只有几个字段，读完再投影即可。
         if response
             .content_length()
-            .is_some_and(|length| length > MAX_PROBE_BODY_BYTES as u64)
+            .is_some_and(|length| length > MAX_PROBE_COMPACT_SOURCE_BYTES as u64)
         {
             completed_candidate = true;
             continue;
@@ -418,7 +422,7 @@ pub async fn discover_site(site_origin: &str) -> Result<DetectedSite, DiscoveryE
         let mut body_failed = false;
         while let Some(chunk) = stream.next().await {
             match chunk {
-                Ok(chunk) if body.len() + chunk.len() <= MAX_PROBE_BODY_BYTES => {
+                Ok(chunk) if body.len() + chunk.len() <= MAX_PROBE_COMPACT_SOURCE_BYTES => {
                     body.extend_from_slice(&chunk);
                 }
                 Ok(_) => {
@@ -816,6 +820,46 @@ mod tests {
         server.abort();
     }
 
+    /// 公共设置里塞了大段无关配置的站，原生探针也必须认得出来。
+    ///
+    /// 回归 bestapi.store：它的 `/api/v1/settings/public` 实测 143 KiB（用户可见的
+    /// 配置数组），旧上限 64 KiB 会在读之前就丢弃这个候选 ⇒ 明明是正常 sub2api 站，
+    /// 却报「无法识别该站点支持的中转协议」。浏览器那条路径一直能识别（它压缩后再判），
+    /// 两条路径对同一站点得出不同结论本身就是 bug。
+    #[tokio::test]
+    async fn native_discovery_accepts_sites_with_large_public_settings() {
+        let mut body: serde_json::Value = serde_json::from_str(sub2api_body()).expect("parse");
+        // 撑到远超旧的 64 KiB 上限，但仍在源大小上限之内。
+        let filler: Vec<String> = (0..4000).map(|i| format!("filler-value-{i:06}")).collect();
+        body["data"]["unrelated_large_setting"] = serde_json::json!(filler);
+        assert!(
+            serde_json::to_string(&body).expect("serialize").len() > MAX_PROBE_BODY_BYTES,
+            "样本必须真的超过旧上限，否则这条测试什么都没钉住"
+        );
+
+        let app = Router::new().route(
+            "/api/v1/settings/public",
+            get(move || {
+                let body = body.clone();
+                async move { Json(body) }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let origin = format!("http://{}", listener.local_addr().expect("local address"));
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve test app");
+        });
+
+        let detected = probe_site(&origin)
+            .await
+            .expect("large settings must still detect");
+
+        assert_eq!(detected.backend_kind, BackendKind::Sub2Api);
+        server.abort();
+    }
+
     #[tokio::test]
     async fn native_discovery_rejects_oversized_stream_without_waiting_for_eof() {
         use axum::body::Body;
@@ -827,7 +871,11 @@ mod tests {
             "/api/v1/settings/public",
             get(|| async {
                 let stream = async_stream::stream! {
-                    yield Ok::<_, Infallible>(Bytes::from(vec![b'x'; MAX_PROBE_BODY_BYTES + 1]));
+                    // 超的是**源大小**上限 —— 这条测试钉的是「超限当场中断，不挂着等 EOF」，
+                    // 阈值本身换成哪个常量不影响它要守的不变量。
+                    yield Ok::<_, Infallible>(Bytes::from(
+                        vec![b'x'; MAX_PROBE_COMPACT_SOURCE_BYTES + 1],
+                    ));
                     std::future::pending::<()>().await;
                 };
                 Response::new(Body::from_stream(stream))

--- a/src-tauri/src/relay/login.rs
+++ b/src-tauri/src/relay/login.rs
@@ -44,45 +44,6 @@ pub const LOGIN_WINDOW_LABEL: &str = "loongport-login";
 /// 我们认得的 scheme，就会被误当成凭据回传。
 const CREDS_SCHEME: &str = "loongport-creds";
 
-/// 登录 WebView 的 User-Agent。**按平台取值，必须与本机真实的 WebView 引擎一致。**
-///
-/// **Rust 侧的 HTTP 客户端必须用同一个值**（见 [`crate::relay::api::Client`]）：sub2api
-/// 有可选的会话绑定（默认关），开启后 access token 里带 `SHA256(clientIP + "\n" + UA)[:16]`，
-/// UA 不一致会 401 且**撤销整个会话家族**（连网页登录态一起踢）。
-///
-/// 显式写死而不是让两边各用默认值：WebView 与 reqwest 的默认 UA 天差地别，靠默认值必然
-/// 不一致。写死之后两边引用同一个常量，改一处两边都跟。
-///
-/// ## ⚠️ 为什么必须**按平台**分，不能一个值走天下（2026-08-03 实测）
-///
-/// 原来全平台共用一个 macOS Safari 的 UA。**Windows 上登录页的 Cloudflare 验证
-/// 永远过不去**（一直「验证失败」，不是超时也不是网络问题）—— 因为 Turnstile
-/// 会拿 UA 声明的浏览器与**真实的 JS 引擎指纹**对照：
-///
-/// | | UA 声称 | 实际引擎 |
-/// |---|---|---|
-/// | macOS | Safari 17.4 / AppleWebKit 605 | WKWebView（就是 Safari 内核）✅ |
-/// | Windows | Safari 17.4 / AppleWebKit 605 | **WebView2 = Chromium 150** ❌ |
-///
-/// Windows 上那是个自相矛盾的组合（Chromium 引擎冒充 Mac 上的 Safari），
-/// 属于典型的机器人特征 ⇒ Cloudflare 直接判失败，而且**重试多少次都一样**。
-///
-/// 所以取值规则是：**跟着本平台 WebView 的真实引擎写**，别追求跨平台统一。
-/// 会话绑定要的是「同一台机器上 WebView 与 HTTP 客户端一致」，
-/// 从来不要求「不同机器之间一致」—— 按 `cfg` 分不破坏它。
-///
-/// 末尾保留 `LoongPort` 标记：便于中转站在日志里认出本客户端，且不影响引擎指纹比对。
-#[cfg(target_os = "windows")]
-pub const WEBVIEW_USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) \
-     AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36 \
-     Edg/150.0.0.0 LoongPort";
-
-/// 见 Windows 那份的说明 —— macOS 上 WebView 就是 WKWebView（Safari 内核），
-/// 所以这里声明 Safari 才是与引擎一致的那个。
-#[cfg(not(target_os = "windows"))]
-pub const WEBVIEW_USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
-     AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15 LoongPort";
-
 /// sub2api 存 access token 的 localStorage 键名。
 ///
 /// ## 为什么提成常量（登录窗只读、充值窗要写）
@@ -122,6 +83,7 @@ pub struct Credentials {
     pub auth_token: String,
     pub refresh_token: Option<String>,
     pub token_expires_at: Option<i64>,
+    pub user_agent: Option<String>,
 }
 
 /// 凭据到手后浮在登录页顶部的提示条。
@@ -315,7 +277,8 @@ pub fn login_script(
     var payload = JSON.stringify({{
       auth_token: token,
       refresh_token: window.localStorage.getItem(K_REFRESH),
-      token_expires_at: window.localStorage.getItem(K_EXPIRES)
+      token_expires_at: window.localStorage.getItem(K_EXPIRES),
+      user_agent: navigator.userAgent,
     }});
 
     // 改 window.location 发这次跳转。
@@ -759,6 +722,7 @@ fn decode_creds(url: &url::Url) -> Result<Credentials, AppError> {
         auth_token: Option<String>,
         refresh_token: Option<String>,
         token_expires_at: Option<String>,
+        user_agent: Option<String>,
     }
     let raw: Raw = serde_json::from_str(&json)
         .map_err(|e| AppError::Config(format!("凭据回传的格式不对: {e}")))?;
@@ -777,6 +741,7 @@ fn decode_creds(url: &url::Url) -> Result<Credentials, AppError> {
             .token_expires_at
             .and_then(|s| s.trim().parse::<i64>().ok())
             .map(|ms| if ms > 100_000_000_000 { ms / 1000 } else { ms }),
+        user_agent: raw.user_agent.filter(|s| !s.is_empty()),
     })
 }
 
@@ -1478,57 +1443,6 @@ mod tests {
             login_url("https://x.com", "me@x.com"),
             "标识的有无必须真的改变落点"
         );
-    }
-
-    #[test]
-    fn user_agent_is_shared_with_the_http_client() {
-        // 会话绑定开启时 UA 不一致会 401 并撤销整个会话家族。这条钉住「两边用同一个常量」。
-        assert!(!WEBVIEW_USER_AGENT.is_empty());
-        assert!(WEBVIEW_USER_AGENT.contains("LoongPort"));
-    }
-
-    /// **UA 声称的浏览器必须与本平台 WebView 的真实引擎一致。**
-    ///
-    /// 守的是 2026-08-03 实测到的那个故障：Windows 上原来发的是 macOS Safari 的 UA，
-    /// 而引擎是 WebView2（Chromium）⇒ Cloudflare Turnstile 拿 UA 与 JS 引擎指纹
-    /// 对照发现自相矛盾 ⇒ 登录页**永远**「验证失败」，重试无效。
-    ///
-    /// 断言按平台分开写而不是只判「非空」：那个 bug 的形态恰恰是「值有、但不对」。
-    #[test]
-    fn the_user_agent_matches_this_platforms_real_webview_engine() {
-        if cfg!(target_os = "windows") {
-            // WebView2 是 Chromium 内核，必须声明 Chrome/Edge，且不能自称 Mac。
-            assert!(
-                WEBVIEW_USER_AGENT.contains("Windows NT"),
-                "Windows 上必须声明 Windows 平台：{WEBVIEW_USER_AGENT}"
-            );
-            assert!(
-                WEBVIEW_USER_AGENT.contains("Chrome/"),
-                "WebView2 是 Chromium，UA 必须声明 Chrome：{WEBVIEW_USER_AGENT}"
-            );
-            assert!(
-                !WEBVIEW_USER_AGENT.contains("Macintosh"),
-                "Windows 上自称 Macintosh 会被 Cloudflare 判成机器人：{WEBVIEW_USER_AGENT}"
-            );
-            assert!(
-                !WEBVIEW_USER_AGENT.contains("Version/"),
-                "`Version/x` 是 Safari 专有标记，Chromium 的 UA 里不该有：{WEBVIEW_USER_AGENT}"
-            );
-        } else {
-            // macOS 的 WKWebView 就是 Safari 内核，声明 Safari 才与引擎一致。
-            assert!(
-                WEBVIEW_USER_AGENT.contains("Macintosh"),
-                "macOS 上必须声明 Mac 平台：{WEBVIEW_USER_AGENT}"
-            );
-            assert!(
-                WEBVIEW_USER_AGENT.contains("Safari/"),
-                "WKWebView 是 Safari 内核：{WEBVIEW_USER_AGENT}"
-            );
-            assert!(
-                !WEBVIEW_USER_AGENT.contains("Windows NT"),
-                "macOS 上不该自称 Windows：{WEBVIEW_USER_AGENT}"
-            );
-        }
     }
 
     #[test]

--- a/src-tauri/src/relay/login.rs
+++ b/src-tauri/src/relay/login.rs
@@ -84,6 +84,11 @@ pub struct Credentials {
     pub refresh_token: Option<String>,
     pub token_expires_at: Option<i64>,
     pub user_agent: Option<String>,
+    /// Cloudflare 放行 cookie（`cf_clearance`），没开挑战的站是 `None`。
+    ///
+    /// 由原生 API 从 WebView 读出 —— 它是 HttpOnly，注入脚本读不到，
+    /// 所以不走 `trySend()` 那条 JSON 回传，见 `commands::relay` 的取用点。
+    pub cf_clearance: Option<String>,
 }
 
 /// 凭据到手后浮在登录页顶部的提示条。
@@ -697,6 +702,24 @@ pub fn login_url(site_origin: &str, login_identifier: &str) -> String {
     }
 }
 
+/// Cloudflare 托管挑战通过后种下的放行 cookie 名。
+const CF_CLEARANCE_COOKIE_NAME: &str = "cf_clearance";
+
+/// 从 WebView 的 cookie 列表里挑出 `cf_clearance`。
+///
+/// 它是 **HttpOnly**，注入脚本读不到 ⇒ 必须走原生 `cookies_for_url`，
+/// 不能像 access token 那样从 localStorage 回传。
+///
+/// 没有该 cookie 是**正常情况**（绝大多数站没开托管挑战），返回 `None`。
+pub fn extract_cf_clearance(cookies: &[tauri::webview::Cookie<'_>]) -> Option<String> {
+    cookies
+        .iter()
+        .find(|cookie| {
+            cookie.name() == CF_CLEARANCE_COOKIE_NAME && !cookie.value().trim().is_empty()
+        })
+        .map(|cookie| cookie.value().to_string())
+}
+
 /// 判断一次导航是不是凭据回传，是则解出凭据。
 ///
 /// 返回 `None` 表示这是普通导航（放行）；返回 `Some` 表示这是回传（调用方应拦下）。
@@ -734,6 +757,8 @@ fn decode_creds(url: &url::Url) -> Result<Credentials, AppError> {
 
     Ok(Credentials {
         auth_token,
+        // 由原生 cookie 读取补上（HttpOnly，脚本回传里没有它）。
+        cf_clearance: None,
         refresh_token: raw.refresh_token.filter(|t| !t.is_empty()),
         // sub2api 存的是毫秒时间戳字符串。解不出来不算错 —— 那就是「可用但不知何时过期」，
         // 与「没登录」是两件事，不该因此把整份凭据扔掉。
@@ -776,6 +801,26 @@ fn decode_b64url(s: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn cf_clearance_is_extracted_only_when_present_and_non_empty() {
+        let mut valid = tauri::webview::Cookie::new("cf_clearance", "pass-token");
+        assert_eq!(
+            extract_cf_clearance(std::slice::from_ref(&valid)),
+            Some("pass-token".to_string())
+        );
+
+        // 空值等于没有：CF 没种下有效 cookie 时不该发一个空的出去。
+        valid.set_value("   ");
+        assert_eq!(extract_cf_clearance(std::slice::from_ref(&valid)), None);
+
+        // 没开挑战的站压根没有这个 cookie —— 正常情况，不是错误。
+        let others = [
+            tauri::webview::Cookie::new("session", "s"),
+            tauri::webview::Cookie::new("other", "o"),
+        ];
+        assert_eq!(extract_cf_clearance(&others), None);
+    }
+
     use super::*;
 
     /// 不关心优惠码那一维的用例走这个（等价于「这个站没有优惠码」）。

--- a/src-tauri/src/services/config.rs
+++ b/src-tauri/src/services/config.rs
@@ -213,6 +213,63 @@ impl ConfigService {
         Ok(())
     }
 
+    /// 把 provider 的投影 `incoming` 合进磁盘现状 `existing`，只动 LoongPort own 的键。
+    ///
+    /// ## 为什么 Claude 这条要单独写一份（而不是照抄 Codex 的白名单）
+    ///
+    /// Codex 的 live 是 TOML、own 的是一组**顶层键**；Claude 的 live 是 JSON，
+    /// own 的东西分两层：
+    ///
+    /// - **顶层**：provider 的 `settings_config` 里有什么就 own 什么（实测是
+    ///   `env` / `model` / `skipDangerousModePermissionPrompt`，测试里还有 `permissions`）。
+    ///   这份名单**跟着 provider 走**而不是写死 —— 用户新建的 provider 带什么字段，
+    ///   那些字段就归它管，写死的名单会漏。
+    /// - **`env` 内部**：`ANTHROPIC_*` 与 `CLAUDE_CODE_*` 是我们写的，其余是用户自己加的。
+    ///   所以 `env` 必须**键级合并**，不能整个替换 —— 后者会抹掉用户的自定义变量。
+    ///
+    /// 我们写的那些 env 前缀里，`incoming` 没有的要**删掉**：否则切到不带
+    /// `ANTHROPIC_DEFAULT_OPUS_MODEL` 的供应商时，上一个的值会留下来串台。
+    fn merge_claude_owned_keys(existing: &Value, incoming: &Value) -> Value {
+        let (Some(existing_map), Some(incoming_map)) = (existing.as_object(), incoming.as_object())
+        else {
+            // 磁盘上没有可用的 JSON 对象（首次写入 / 用户写坏了）：整体以投影为准。
+            return incoming.clone();
+        };
+
+        let mut merged = existing_map.clone();
+        for (key, value) in incoming_map {
+            if key == "env" {
+                continue;
+            }
+            merged.insert(key.clone(), value.clone());
+        }
+
+        let incoming_env = incoming_map.get("env").and_then(Value::as_object);
+        let existing_env = existing_map.get("env").and_then(Value::as_object);
+        if incoming_env.is_some() || existing_env.is_some() {
+            let mut env = existing_env.cloned().unwrap_or_default();
+            // 先清掉我们拥有的前缀，再按 incoming 重新写入 —— 这样「上一个供应商有、
+            // 这一个没有」的变量不会残留，而用户自己加的变量原样留着。
+            env.retain(|key, _| !Self::is_claude_owned_env_key(key));
+            if let Some(incoming_env) = incoming_env {
+                for (key, value) in incoming_env {
+                    env.insert(key.clone(), value.clone());
+                }
+            }
+            merged.insert("env".to_string(), Value::Object(env));
+        }
+
+        Value::Object(merged)
+    }
+
+    /// 这个 env 变量是 LoongPort 写的吗。
+    ///
+    /// 判前缀而不是列举全名：模型档位那组（`ANTHROPIC_DEFAULT_*_MODEL`）会随上游
+    /// 新增档位而变长，列全名必然漏。
+    fn is_claude_owned_env_key(key: &str) -> bool {
+        key.starts_with("ANTHROPIC_") || key.starts_with("CLAUDE_CODE_")
+    }
+
     fn sync_claude_live(
         config: &mut MultiAppConfig,
         provider_id: &str,
@@ -225,8 +282,19 @@ impl ConfigService {
             fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
         }
 
+        // 切换供应商是「投影」：只覆盖 provider 拥有的键，用户手写的其余内容原样保留。
+        //
+        // 此前这里全量覆盖 settings.json，于是用户自己加的顶层键（实测本机有 `language`）
+        // 以及 `env` 里非 `ANTHROPIC_*` 的自定义变量，每切一次供应商就被静默抹掉。
+        //
+        // ⚠️ 合并只加在这条切换路径上。代理接管与备份恢复走 `ProxyService::write_claude_live`，
+        // 那条必须保持全量覆盖 —— 恢复要精确还原，做合并会让接管写进去的键永远删不掉。
         let settings = sanitize_claude_settings_for_live(&provider.settings_config);
-        write_json_file(&settings_path, &settings)?;
+        let existing = read_json_file::<serde_json::Value>(&settings_path).unwrap_or(Value::Null);
+        write_json_file(
+            &settings_path,
+            &Self::merge_claude_owned_keys(&existing, &settings),
+        )?;
 
         let live_after = read_json_file::<serde_json::Value>(&settings_path)?;
         if let Some(manager) = config.get_manager_mut(&AppType::Claude) {
@@ -267,5 +335,93 @@ impl ConfigService {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// 用户手写的顶层键与自定义 env 变量必须活过供应商切换（本次修复的核心）。
+    #[test]
+    fn merge_keeps_user_authored_keys_and_custom_env() {
+        let existing = json!({
+            "language": "zh-CN",
+            "hooks": { "Stop": "notify" },
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://old.example",
+                "MY_OWN_VAR": "keep-me"
+            }
+        });
+        let incoming = json!({
+            "env": { "ANTHROPIC_BASE_URL": "https://new.example" }
+        });
+
+        let merged = ConfigService::merge_claude_owned_keys(&existing, &incoming);
+
+        assert_eq!(
+            merged.get("language").and_then(|v| v.as_str()),
+            Some("zh-CN")
+        );
+        assert!(
+            merged.get("hooks").is_some(),
+            "用户的 hooks 必须留着: {merged}"
+        );
+        assert_eq!(
+            merged.pointer("/env/MY_OWN_VAR").and_then(|v| v.as_str()),
+            Some("keep-me"),
+            "用户自定义 env 变量必须留着: {merged}"
+        );
+        assert_eq!(
+            merged
+                .pointer("/env/ANTHROPIC_BASE_URL")
+                .and_then(|v| v.as_str()),
+            Some("https://new.example"),
+            "我们拥有的 env 要按投影覆盖"
+        );
+    }
+
+    /// 上一个供应商有、这一个没有的 ANTHROPIC_* 必须清掉，否则模型名串台。
+    #[test]
+    fn merge_drops_owned_env_keys_absent_from_incoming() {
+        let existing = json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": "https://old.example",
+                "ANTHROPIC_DEFAULT_OPUS_MODEL": "stale-opus",
+                "CLAUDE_CODE_SUBAGENT_MODEL": "stale-subagent",
+                "MY_OWN_VAR": "keep-me"
+            }
+        });
+        let incoming = json!({
+            "env": { "ANTHROPIC_BASE_URL": "https://new.example" }
+        });
+
+        let merged = ConfigService::merge_claude_owned_keys(&existing, &incoming);
+
+        assert!(
+            merged
+                .pointer("/env/ANTHROPIC_DEFAULT_OPUS_MODEL")
+                .is_none(),
+            "got: {merged}"
+        );
+        assert!(merged.pointer("/env/CLAUDE_CODE_SUBAGENT_MODEL").is_none());
+        assert_eq!(
+            merged.pointer("/env/MY_OWN_VAR").and_then(|v| v.as_str()),
+            Some("keep-me")
+        );
+    }
+
+    /// 磁盘上没有可用 JSON 对象时整体以投影为准，不能卡死切换。
+    #[test]
+    fn merge_falls_back_to_incoming_without_usable_existing() {
+        let incoming = json!({ "env": { "ANTHROPIC_BASE_URL": "https://new.example" } });
+
+        for existing in [Value::Null, json!("not an object"), json!([1, 2])] {
+            assert_eq!(
+                ConfigService::merge_claude_owned_keys(&existing, &incoming),
+                incoming
+            );
+        }
     }
 }

--- a/src-tauri/src/vendor/deepseek.rs
+++ b/src-tauri/src/vendor/deepseek.rs
@@ -19,10 +19,6 @@
 //! 实测裸 curl UA、无 cookie、不带那五个 `x-client-*` 头照样 200 ⇒ 用普通
 //! HTTP 客户端直连即可，WebView 只用于登录那一步。
 //!
-//! ⚠️ **不要照抄 `relay::login::WEBVIEW_USER_AGENT` 的「必须写死」那条理由** ——
-//! 那是因为 **sub2api 有会话绑定**（token 里带 `SHA256(clientIP + UA)`，可选特性、
-//! 默认关）。DeepSeek 没有这个约束。
-
 use serde::{de::DeserializeOwned, Deserialize};
 
 use crate::app_config::AppType;
@@ -458,13 +454,9 @@ fn round_decimal_string(raw: &str) -> Option<String> {
 
 /// 鉴权只要 Bearer（见模块文档），所以是个普通 HTTP 客户端。
 ///
-/// UA 复用 `relay::login::WEBVIEW_USER_AGENT`（现在是按平台的 `cfg` 常量）。
-/// ⚠️ **别照抄 sub2api 那条「必须与 WebView 一字不差否则撤销整个会话家族」的理由** ——
-/// 那是它的会话绑定特性，DeepSeek 没有。这里复用只是为了不再多一份 UA 字面量。
 fn build_client() -> Result<reqwest::Client, AppError> {
     reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
-        .user_agent(crate::relay::login::WEBVIEW_USER_AGENT)
         .build()
         .map_err(|e| AppError::Config(format!("创建 HTTP 客户端失败: {e}")))
 }


### PR DESCRIPTION
## 起因

维护者点「登录贾维斯」（`api.aijws.com`）一直失败，一路查下去牵出 4 个各自独立的根因。

## 改了什么

### 1. WebView 不再伪装 User-Agent（886eae3a）

原设计为满足 sub2api 会话绑定（token 含 `SHA256(clientIP + "\n" + UA)`）要求
「WebView 与 HTTP 客户端 UA 一致」，做法是编一个假 UA 强加给两边。方向反了：
一致性该由引擎真实值提供，而不是两边共用一个伪造值 —— 于是每撞一家风控就调一次那个假值
（此前已为 Windows 分叉出第二份）。

改为登录时回传 `navigator.userAgent` 并持久化，HTTP 客户端读它；没有值就不设。
`WEBVIEW_USER_AGENT` 及其平台分叉整个删除。

### 2/3/4. live 配置只覆盖自己 own 的键（d9f055c7 / f55011e4 / cf72ef5b）

Codex / Grok / Claude 三条路径同一个根：live 文件是投影产物，但 DB 只是 **provider 路由**
的 owner，不是**整个文件**的 owner。此前全文覆盖，用户手写的配置每切一次供应商就被静默抹掉
（实测维护者为让 codex 免审批而手写的 `approval_policy` 等就是这么消失的）。

改为白名单式合并。用白名单而非黑名单：黑名单要跟着上游版本跑，新增配置项照样会被抹。

**备份恢复路径一律保持全文覆盖** —— 恢复要精确还原，做合并会让接管写入的键永远删不掉。

### 5. 带上 Cloudflare 放行 cookie（010275a8）

真正让贾维斯登录失败的根因：本 app 有两套 HTTP 栈，登录走 WebView（能执行 JS ⇒ 过得了
CF 托管挑战），之后所有 API 走 reqwest（**永远过不了**）。表现为「登录成功但读取账号信息
失败：HTTP 403 Just a moment...」。

改 UA 治不了这个（已实测证伪）。正解是把 WebView 已拿到的 `cf_clearance` 交给 reqwest。

### 6. 探针体积上限对齐（0d8dae66）

`bestapi.store` 的公共设置有 143 KiB，原生探针在 64 KiB 就丢弃候选 ⇒ 正常 sub2api 站被判
「无法识别协议」。而浏览器那条路径一直识别得出来 —— 同一份判据两条路径结论不同本身就是 bug。

## 验证

- `cargo test`：**3068 passed / 0 failed**（基线 3055，新增 13 条）
- `cargo clippy --all-targets`：0 warning / 0 error
- `cargo fmt --check` / `tsc --noEmit`：通过
- 端到端：UA 版已装到本机验证过登录窗行为

🤖 Generated with [Claude Code](https://claude.com/claude-code)