### PR TITLE
chore(release): bump version to 3.23.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-switch",
-  "version": "3.23.1",
+  "version": "3.23.2",
   "description": "All-in-One Assistant for Claude Code, Codex & Gemini CLI",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "cc-switch"
-version = "3.23.1"
+version = "3.23.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # （裁决见 CLAUDE.md「三点五」）。面向用户的二进制名走 tauri.conf.json 的
 # `mainBinaryName`（已是 `LoongPort`）。
 name = "cc-switch"
-version = "3.23.1"
+version = "3.23.2"
 description = "同样的 Codex，成本省 95% 以上 —— 填一个域名、登录一次，其余自动配好"
 authors = ["SailingLoong", "Jason Young"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LoongPort",
   "mainBinaryName": "LoongPort",
-  "version": "3.23.1",
+  "version": "3.23.2",
   "identifier": "dev.loongport.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
为 #93 那批修复发版。三处版本号 + `Cargo.lock` 的 `cc-switch` 条目一并更新。

合并后打 `v3.23.2` tag 触发 release。

## 本版内容（均已在 #93 合并）

- WebView 不再伪装 User-Agent，改以引擎真实 UA 为唯一数据源
- Codex / Grok / Claude 的 live 配置改为只覆盖自己 own 的键，不再抹掉用户手写内容
- 登录时收下 Cloudflare 的 `cf_clearance` 并在 HTTP 请求中带上，修复开了托管挑战的站
  「登录成功但读取账号信息失败 403」
- 原生探针体积上限与浏览器路径对齐，修复公共设置较大的站被误判为「无法识别协议」

CHANGELOG.md 按惯例 patch 版本不写。

Generated with [Claude Code](https://claude.com/claude-code)
