### PR TITLE
fix(relay): prevent blank window on first relay import

### DIFF
--- a/src-tauri/src/relay/discovery.rs
+++ b/src-tauri/src/relay/discovery.rs
@@ -264,8 +264,18 @@ pub fn browser_probe_script(site_origin: &str, candidates: &[ProbeCandidate]) ->
     }}
   }}
 
-  void probe();
-  setInterval(() => void probe(), 1500);
+  function startProbing() {{
+    void probe();
+    setInterval(() => void probe(), 1500);
+  }}
+
+  // A custom-scheme callback before the first remote document commits can leave WebKit on its
+  // blank initial document even when Rust rejects that navigation. Start only after DOM readiness.
+  if (document.readyState === 'loading') {{
+    document.addEventListener('DOMContentLoaded', startProbing, {{ once: true }});
+  }} else {{
+    startProbing();
+  }}
 }})();
 "#
     )

--- a/tests/fixtures/browser-probe-script.txt
+++ b/tests/fixtures/browser-probe-script.txt
@@ -160,6 +160,16 @@
     }
   }
 
-  void probe();
-  setInterval(() => void probe(), 1500);
+  function startProbing() {
+    void probe();
+    setInterval(() => void probe(), 1500);
+  }
+
+  // A custom-scheme callback before the first remote document commits can leave WebKit on its
+  // blank initial document even when Rust rejects that navigation. Start only after DOM readiness.
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', startProbing, { once: true });
+  } else {
+    startProbing();
+  }
 })();

--- a/tests/lib/browserProbeScriptRuns.test.ts
+++ b/tests/lib/browserProbeScriptRuns.test.ts
@@ -24,6 +24,66 @@ async function flushPromises(): Promise<void> {
 }
 
 describe("browser probe generated script", () => {
+  it("waits for the initial document to finish loading before probing", async () => {
+    const documentListeners = new Map<string, () => void>();
+    const intervalCallbacks: Array<() => void> = [];
+    const fetchedPaths: string[] = [];
+    const navigations: string[] = [];
+    const location = {
+      origin: "https://relay.example",
+      get href() {
+        return navigations.at(-1) ?? "https://relay.example/";
+      },
+      set href(value: string) {
+        navigations.push(value);
+      },
+    };
+
+    const sandbox = {
+      window: { location },
+      document: {
+        readyState: "loading",
+        addEventListener: (event: string, listener: () => void) => {
+          documentListeners.set(event, listener);
+        },
+      },
+      fetch: (path: string) => {
+        fetchedPaths.push(path);
+        return Promise.resolve({
+          text: () => Promise.resolve('{"success":true}'),
+        });
+      },
+      setInterval: (callback: () => void) => {
+        intervalCallbacks.push(callback);
+        return 1;
+      },
+      setTimeout,
+      clearTimeout,
+      AbortController,
+      TextEncoder,
+      btoa: (value: string) => Buffer.from(value, "binary").toString("base64"),
+      JSON,
+    };
+
+    vm.runInNewContext(readFileSync(SCRIPT, "utf8"), sandbox, {
+      timeout: 5000,
+    });
+    await flushPromises();
+
+    expect(fetchedPaths).toHaveLength(0);
+    expect(navigations).toHaveLength(0);
+    expect(intervalCallbacks).toHaveLength(0);
+
+    const onDocumentReady = documentListeners.get("DOMContentLoaded");
+    expect(onDocumentReady).toBeDefined();
+    onDocumentReady!();
+    await flushPromises();
+
+    expect(fetchedPaths).toEqual(["/api/v1/settings/public", "/api/status"]);
+    expect(navigations).toHaveLength(1);
+    expect(intervalCallbacks).toHaveLength(1);
+  });
+
   it("serializes delayed rounds and emits one complete callback", async () => {
     const intervalCallbacks: Array<() => void> = [];
     const responseBodies: Array<Deferred<string>> = [];
@@ -41,6 +101,7 @@ describe("browser probe generated script", () => {
 
     const sandbox = {
       window: { location },
+      document: { readyState: "complete" },
       fetch: (path: string) => {
         fetchedPaths.push(path);
         const body = deferred<string>();
@@ -156,6 +217,7 @@ describe("browser probe generated script", () => {
 
     const sandbox = {
       window: { location },
+      document: { readyState: "complete" },
       fetch: (path: string) => {
         const body =
           path === "/api/v1/settings/public"
@@ -226,6 +288,7 @@ describe("browser probe generated script", () => {
 
     const sandbox = {
       window: { location },
+      document: { readyState: "complete" },
       localStorage: {
         getItem: (key: string) =>
           key === "auth_token" ? "browser-session-token" : null,
@@ -283,6 +346,7 @@ describe("browser probe generated script", () => {
 
     const sandbox = {
       window: { location },
+      document: { readyState: "complete" },
       fetch: () =>
         Promise.resolve({
           status: 403,
@@ -356,6 +420,7 @@ describe("browser probe generated script", () => {
 
     const sandbox = {
       window: { location },
+      document: { readyState: "complete" },
       fetch: (path: string) => {
         fetchedPaths.push(path);
         if (path === "/api/v1/settings/public") {


### PR DESCRIPTION
## Summary / 概述

- Delay the browser-assisted relay probe until the initial remote document reaches DOM readiness.
- Keep the generated JavaScript fixture synchronized with the Rust generator.
- Add a VM regression test proving that no fetch, callback navigation, or polling timer starts before document readiness.

## Root Cause / 根因

The initialization script started probing immediately at document start. Its custom-scheme callback could race the first WKWebView navigation commit; rejecting that callback did not guarantee WebKit would continue committing the intended remote page, leaving the first add-relay window on the blank initial document.

## User Impact / 用户影响

The first relay-service import now waits for the page to load before probing, so the login or registration page remains visible instead of opening as a white window.

## Related Issue / 关联 Issue

None.

## Screenshots / 截图

Not applicable; this fixes a WebView lifecycle race.

## Checklist / 检查清单

- [x] pnpm typecheck passes / 通过 TypeScript 类型检查
- [x] pnpm format:check passes / 通过代码格式检查
- [x] pnpm test:unit passes / 通过前端单元测试
- [x] cargo test passes / 通过 Rust 测试
- [x] cargo clippy --all-targets -- -D warnings passes / 通过 Clippy 检查
- [x] cargo fmt --check passes / 通过 Rust 格式检查
- [x] No user-facing text changed; i18n files are unaffected / 未修改用户可见文本，无需更新国际化