### PR TITLE
ci(release): Release notes 取自 tag message，并加一道发版前的说明闸

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,58 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # 「这一版干了啥」的**唯一源是 annotated tag 的 message 正文**（见仓 CLAUDE.md §五）。
+  # 这个 job 既是闸也是取值：读一次，下面 publish-release 直接用它的 output ——
+  # 不让「闸校验的」和「页面显示的」变成两份，那种分叉不报错、只会悄悄不一致
+  # （同 CLAUDE.md 三点六）。
+  #
+  # 放在 release **之前**是有意的：忘了写说明时几秒钟就红，而不是编完 40 分钟的包
+  # 才在最后一步发现（macOS 那格还是 10× 计费）。
+  tag-notes:
+    name: Read tag notes
+    runs-on: ubuntu-22.04
+    outputs:
+      notes: ${{ steps.read.outputs.notes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # 要读的是 annotated tag 对象本身，浅 clone 未必带得到它的 message。
+          # 本仓 .git 才 82M，全量 fetch 多几秒换一个确定的结果。
+          fetch-depth: 0
+
+      - name: Read tag annotation
+        id: read
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="$GITHUB_REF_NAME"
+          # `%(contents:subject)` 是首行标题，`%(contents:body)` 是空行之后的正文。
+          # **只判正文**：历史上的 tag message 全是「LoongPort v3.23.2」这种一行标题，
+          # 那等于什么也没说，必须拦住 —— 否则 Release 页又退回「每版长得一模一样」。
+          # 轻量 tag（非 annotated）没有 message，contents 为空，同样落在这条判据里。
+          NOTES="$(git tag -l --format='%(contents:body)' "$TAG")"
+          if [ -z "$(printf '%s' "$NOTES" | tr -d '[:space:]')" ]; then
+            echo "❌ tag $TAG 只有标题、没有变更说明 —— 发版中止（还没开始编包）。" >&2
+            echo "   Release 页的「本次更新」就是取这段正文，缺了发出去等于没说明。" >&2
+            echo "" >&2
+            echo "   修复（删旧 tag 重打）：" >&2
+            echo "     git tag -d $TAG && git push origin :refs/tags/$TAG" >&2
+            echo "     git tag -a $TAG -F notes.md   # 首行标题，空一行，再写条目" >&2
+            echo "     git push origin $TAG" >&2
+            exit 1
+          fi
+          # 多行值走 heredoc 语法写进 GITHUB_OUTPUT。分隔符取一个正文里不可能出现的串。
+          {
+            echo "notes<<LOONGPORT_TAG_NOTES_EOF"
+            printf '%s\n' "$NOTES"
+            echo "LOONGPORT_TAG_NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "✅ 读到本版变更说明："
+          printf '%s\n' "$NOTES"
+
   release:
+    needs: tag-notes
     runs-on: ${{ matrix.os }}
     environment: release
     strategy:
@@ -29,7 +80,7 @@ jobs:
           #   - os: ubuntu-22.04-arm
           #     arch: arm64
           #
-          # 不能「留着让它失败」—— publish-release 是 `needs: release` 且没有
+          # 不能「留着让它失败」—— publish-release 的 needs 里有 `release` 且没有
           # `if: always()`，任一 matrix 分支失败就会把它 skip 掉 ⇒ 连已经编好的
           # Windows / macOS 包也发不出去（fail-fast: false 只保证其它分支跑完，
           # 不改变汇总那步的 skip 行为）。
@@ -738,7 +789,9 @@ jobs:
   publish-release:
     name: Publish GitHub Release
     runs-on: ubuntu-22.04
-    needs: release
+    # 直接 needs `tag-notes` 是为了拿它的 output —— job output 只能从**直接** needs 取，
+    # 隔着 `release` 传不过来。
+    needs: [release, tag-notes]
     permissions:
       contents: write
     steps:
@@ -765,6 +818,11 @@ jobs:
           # GitHub 不把预发布算作 Latest ⇒ `releases/latest` 拿不到它，而 README 的
           # 下载指引正是让人去 Releases 页拿最新版。
           prerelease: ${{ contains(github.ref_name, '-') }}
+          # GitHub 按两个 tag 之间的 PR 自动生成 "What's Changed" + Full Changelog 链接，
+          # 追加在下面 body 之后（`body` 是 pre-pend，不是覆盖）。本仓 main 只接受 PR
+          # 进入（见 CLAUDE.md §四），所以那份自动列表天然完整 —— 人写的 tag 说明负责
+          # 「这版为什么值得升」，自动列表负责「具体合了哪些 PR」，各管一段，不重复维护。
+          generate_release_notes: true
           # ⚠️ 下面的「下载」清单必须与 matrix 实际跑的平台一致 —— 列出不存在的文件名
           # 等于让用户照着下载然后 404。Linux 两条现在是注释状态，所以这里也没有 Linux；
           # 放回 matrix 时把那句「Linux 包暂未提供」换成 AppImage / .deb / .rpm 三件套说明。
@@ -779,6 +837,10 @@ jobs:
             🌐 **唯一官方网站 / Only Official Website**: [loongport.dev](https://loongport.dev)
 
             把一个中转站账号变成 codex 可用的多档位供应商
+
+            ### 本次更新
+
+            ${{ needs.tag-notes.outputs.notes }}
 
             ### 下载
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,3 +275,62 @@ dependabot 的，别照搬。PR 模板在 `.github/pull_request_template.md`。
 
 唯一属于 CLAUDE.md（维护视角）的是上面那条警告：**`cargo test` / `clippy` 全绿
 不代表能打包** —— Tauri 的 npm↔crate 版本校验只在打包时触发。
+
+## 五、打 tag 发版：必须写清这一版干了啥
+
+**每个 `v*` tag 都要说明这一版做了什么，唯一源是 annotated tag message 的正文**
+（首行标题之外的部分）。Release 页的「本次更新」直接取它，`release.yml` 的
+`tag-notes` job 负责读取与校验。
+
+**为什么要有这条**：`publish-release` 的 `body` 原先是整段写死的模板，只有版本号会变 ⇒
+[Releases 页](https://github.com/SailingLoong/LoongPort/releases)每一版长得一模一样，
+用户无从判断该不该升级。而 tag message 里其实早就写了内容（`v3.23.2` 那条写得很完整），
+只是没人读它 —— 这不是「缺少内容」，是**内容和展示之间断了一截**，已修根。
+
+### 怎么写
+
+```bash
+cat > /tmp/notes.md <<'EOF'
+LoongPort v3.24.0
+
+修好 Cloudflare 托管站点的登录，并让 live 配置不再抹掉用户手写内容。
+
+#### 新增
+- ...
+
+#### 修复
+- ...
+EOF
+
+git tag -a v3.24.0 --cleanup=whitespace -F /tmp/notes.md
+git push origin v3.24.0
+```
+
+三条硬约束（都实测过）：
+
+1. **`--cleanup=whitespace` 不能省** —— git 默认的 `strip` 模式把**以 `#` 开头的行当注释
+   删掉**，`### 新增` 这种 Markdown 标题会**静默消失**（`- 条目` 还在，标题没了）。
+   实测：默认模式下 `### 新增` / `### 修复` 两行全被吞，正文只剩两条裸列表项。
+2. **小标题从 `####` 起** —— Release body 自己那层用的是 `###`（「本次更新」「下载」），
+   正文里再用 `###` 会和它平级，层级读起来是乱的。
+3. **首行是标题、空一行、再写正文** —— 校验只看正文（`%(contents:body)`）。
+   历史上那些只有一行 `LoongPort v3.23.0` 的 tag 正文为空，会被直接拦下。
+
+### 写什么、不写什么
+
+- **写**「这版为什么值得升」：修了什么用户能感知的问题、新增什么能力，用人话，
+  面向下载的人而不是面向维护者。
+- **不写** PR 编号清单和 commit 流水 —— GitHub 会按两个 tag 之间的 PR 自动生成
+  「What's Changed」追加在后面（`generate_release_notes: true`，本仓 main 只接受 PR
+  进入，所以那份列表天然完整）。**人写的和自动生成的各管一段，别手抄一遍。**
+
+### 忘了写会怎样
+
+`tag-notes` job 在**编包之前**跑，几秒内就红，不会浪费 40 分钟构建（macOS 那格还是
+10× 计费）。它红了整条发布通道就停，补救是删 tag 重打：
+
+```bash
+git tag -d v3.24.0 && git push origin :refs/tags/v3.24.0
+git tag -a v3.24.0 --cleanup=whitespace -F /tmp/notes.md
+git push origin v3.24.0
+```


### PR DESCRIPTION
## Summary / 概述

**问题**：`publish-release` 的 `body` 是整段写死的模板，只有版本号会变 ⇒
[Releases 页](https://github.com/SailingLoong/LoongPort/releases)每一版内容完全一样，
用户无从判断该不该升级。

**根因不是「没写内容」**：tag message 里其实早就写了（`v3.23.2` 那条相当完整），
断的是「内容 → 展示」这一截。所以修的是那一截，不是再加一个地方让人重复写。

### 改了什么

- **新增 `tag-notes` job**：读 annotated tag 的正文（`%(contents:body)`），为空即失败。
  放在 `release` **之前** —— 忘写时几秒钟就红，而不是编完 40 分钟的包才发现
  （macOS 那格还是 10× 计费）。
- **`publish-release` 复用它的 output** 注入「本次更新」。闸校验的和页面显示的是同一份值，
  不留分叉口子（同 CLAUDE.md 三点六）。
- **开 `generate_release_notes: true`**：PR 列表交给 GitHub 自动生成追加在后面。
  本仓 main 只接受 PR 进入，那份列表天然完整 —— 人写的说明只负责「这版为什么值得升」，
  两段各管各的，不手抄。
- **CLAUDE.md 补 §五** 记下规则与命令。

### 一个实测到的坑（已写进 CLAUDE.md）

`git tag -a` 默认的 `--cleanup=strip` **把以 `#` 开头的行当注释删掉** ——
`### 新增` 这种 Markdown 标题会静默消失，只剩下面的裸列表项。所以打 tag 必须带
`--cleanup=whitespace`：

```bash
git tag -a v3.24.0 --cleanup=whitespace -F /tmp/notes.md
```

### 本地验证

- YAML 解析通过，`needs` 拓扑与 job outputs 结构如预期。
- 用仓内真实 tag 跑判据：`v3.23.2`（有正文）→ 通过并取到 4 条正文；
  `v3.23.0`（只有一行标题）→ 拦下。
- `--cleanup=whitespace` 与默认模式对照，确认 `###` 保留/被吞。

## Related Issue / 关联 Issue

无。

## Checklist / 检查清单

- [x] `pnpm typecheck` — 未触及 `src/`，CI 会跑
- [x] `pnpm format:check` — prettier glob 是 `{src,tests}/**/*.{js,jsx,ts,tsx,css,json,html}`，不含 `.yml` / `.md`
- [x] `cargo clippy` — 未改 Rust
- [x] i18n — 无用户可见文本改动（Release notes 面向下载者，不走 i18n）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
