### PR TITLE
fix(test): isolate frontend timeout failures

### DIFF
--- a/tests/components/SessionManagerPage.test.tsx
+++ b/tests/components/SessionManagerPage.test.tsx
@@ -16,6 +16,7 @@ import { setSessionFixtures } from "../msw/state";
 
 const toastSuccessMock = vi.fn();
 const toastErrorMock = vi.fn();
+const LIST_VIEW_MODE_STORAGE_KEY = "cc-switch.sessionManager.listViewMode";
 const GROUP_EXPANSION_STORAGE_KEY =
   "cc-switch.sessionManager.groupExpansionState";
 
@@ -154,7 +155,7 @@ describe("SessionManagerPage", () => {
     toastSuccessMock.mockReset();
     toastErrorMock.mockReset();
     Element.prototype.scrollIntoView = vi.fn();
-    window.localStorage.removeItem("cc-switch.sessionManager.listViewMode");
+    window.localStorage.removeItem(LIST_VIEW_MODE_STORAGE_KEY);
     window.localStorage.removeItem(GROUP_EXPANSION_STORAGE_KEY);
 
     const sessions: SessionMeta[] = [
@@ -637,6 +638,8 @@ describe("SessionManagerPage", () => {
   });
 
   it("batch deletes only sessions selected from a grouped directory", async () => {
+    // 视图切换由上面的分组用例覆盖；这里直接进入目标状态，避免重复支付 Radix Select 交互成本。
+    window.localStorage.setItem(LIST_VIEW_MODE_STORAGE_KEY, "grouped");
     renderPage();
 
     await waitFor(() =>
@@ -645,7 +648,7 @@ describe("SessionManagerPage", () => {
       ).toBeInTheDocument(),
     );
 
-    await enterGroupedBatchMode();
+    fireEvent.click(screen.getByRole("button", { name: /批量管理/i }));
     expandDirectoryGroup("codex", "codex");
     fireEvent.click(
       screen.getByRole("checkbox", {

--- a/tests/integration/App.test.tsx
+++ b/tests/integration/App.test.tsx
@@ -1,10 +1,15 @@
-import { Suspense, type ComponentType } from "react";
+import { Suspense } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { http, HttpResponse } from "msw";
+// 在收集阶段完成模块加载：若把 import 留在用例体内，超时后它仍可能续跑并越过 cleanup 再挂载 App。
+import App from "@/App";
 import { providersApi } from "@/lib/api/providers";
-import { LAST_APP_STORAGE_KEY } from "@/config/constants";
+import {
+  LAST_APP_STORAGE_KEY,
+  LAST_VIEW_STORAGE_KEY,
+} from "@/config/constants";
 import {
   resetProviderState,
   setCurrentProviderId,
@@ -151,12 +156,12 @@ vi.mock("@/components/mcp/McpPanel", () => ({
     ),
 }));
 
-const renderApp = (AppComponent: ComponentType) => {
+const renderApp = () => {
   const client = new QueryClient();
   return render(
     <QueryClientProvider client={client}>
       <Suspense fallback={<div data-testid="loading">loading</div>}>
-        <AppComponent />
+        <App />
       </Suspense>
     </QueryClientProvider>,
   );
@@ -171,9 +176,24 @@ describe("App integration with MSW", () => {
     // （`loongport`）。把「上次看的是 provider 列表」写进 localStorage —— 这既让这些用例
     // 拿到它们要测的那一屏，也顺带覆盖了「记住上次视图」这个行为本身。
     //
-    // key 必须与 App.tsx 的 VIEW_STORAGE_KEY 一致（那边加了 loongport- 前缀防止读到上游遗留值）。
-    localStorage.setItem("loongport-last-view", "providers");
+    localStorage.setItem(LAST_VIEW_STORAGE_KEY, "providers");
     localStorage.setItem(LAST_APP_STORAGE_KEY, "claude");
+  });
+
+  it.fails(
+    "cleans the rendered App when the test times out",
+    async () => {
+      renderApp();
+      // 这条必须真实撞穿自己的 10ms 超时，下一条才是在验证超时后的隔离性。
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    },
+    10,
+  );
+
+  it("mounts exactly one App after the timeout cleanup", () => {
+    renderApp();
+
+    expect(screen.getAllByText("switch-codex-image")).toHaveLength(1);
   });
 
   it("restores the image page and reconciles its MCP registration on startup", async () => {
@@ -186,8 +206,7 @@ describe("App integration with MSW", () => {
     );
     localStorage.setItem(LAST_APP_STORAGE_KEY, "codex-image");
 
-    const { default: App } = await import("@/App");
-    renderApp(App);
+    renderApp();
 
     await waitFor(() => {
       expect(screen.getByTestId("app-switcher")).toHaveTextContent(
@@ -206,16 +225,14 @@ describe("App integration with MSW", () => {
       }),
     );
 
-    const { default: App } = await import("@/App");
-    renderApp(App);
+    renderApp();
     fireEvent.click(await screen.findByText("switch-codex-image"));
 
     await waitFor(() => expect(syncCalls).toBe(1));
   });
 
   it("covers basic provider flows via real hooks", async () => {
-    const { default: App } = await import("@/App");
-    renderApp(App);
+    renderApp();
 
     await waitFor(() =>
       expect(screen.getByTestId("provider-list").textContent).toContain(
@@ -271,8 +288,7 @@ describe("App integration with MSW", () => {
   }, 10_000);
 
   it("shows toast when auto sync fails in background", async () => {
-    const { default: App } = await import("@/App");
-    renderApp(App);
+    renderApp();
 
     await waitFor(() =>
       expect(screen.getByTestId("provider-list").textContent).toContain(
@@ -331,8 +347,7 @@ describe("App integration with MSW", () => {
     setCurrentProviderId("openclaw", "deepseek");
     setLiveProviderIds("openclaw", ["deepseek-copy"]);
 
-    const { default: App } = await import("@/App");
-    renderApp(App);
+    renderApp();
 
     fireEvent.click(screen.getByText("switch-openclaw"));
 
@@ -377,8 +392,7 @@ describe("App integration with MSW", () => {
       .spyOn(providersApi, "getOpenClawLiveProviderIds")
       .mockRejectedValueOnce(new Error("broken config"));
 
-    const { default: App } = await import("@/App");
-    renderApp(App);
+    renderApp();
 
     fireEvent.click(screen.getByText("switch-openclaw"));
 


### PR DESCRIPTION
## What changed

- preload `@/App` during test collection instead of dynamically importing it inside each test
- add an expected-timeout regression sequence proving cleanup leaves exactly one App mounted for the following test
- start the grouped batch-delete test in its target persisted view instead of repeating the separately covered Radix Select interaction
- reuse the shared last-view storage key in the App integration setup

## Root cause

The App test counted the first Vite module transformation/import inside the test's 5-second timeout. If that import completed after Vitest had already timed the test out and run `afterEach(cleanup)`, the remaining test body could still call `renderApp`, leaving a late App mounted for the next test. That turned one timeout into misleading duplicate-element failures.

The SessionManagerPage case also repeated the relatively expensive Radix Select transition even though the grouped-view behavior is covered by adjacent tests; the target assertion is directory-scoped batch deletion, so the test now enters that persisted state directly.

## Measurements

Five isolated runs on the PR #98 main baseline (`8ee4df2a`), single worker:

- grouped directory batch delete: median **625 ms → 439 ms** (average 626 ms → 443 ms)
- image-page startup reconciliation test body: median **1028 ms → 69 ms** (average 1053 ms → 70 ms)

In the full parallel frontend suite, the grouped batch-delete case completed in 1805 ms and the suite passed.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `npx tsc --noEmit`
- `pnpm format:check`
- `npx vitest run` — 125 files, 793 tests passed
- repeated the expected-timeout isolation sequence five times; the timeout and the following single-mount assertion passed every run
