### PR TITLE
docs: document DeepSeek Harness integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,34 @@ ARM64 的 Windows 机器（如骁龙笔记本）用带 `-arm64` 的那两个。
 > 但要你回 [Releases](../../releases) 下载新的压缩包。这是选免安装版的代价，
 > 换来的是没有安装步骤、不会被安全软件拦。
 
+## DeepSeek Harness（dsh）
+
+LoongPort 还提供独立的 [`loongport` npm 集成](https://www.npmjs.com/package/loongport)，
+用于给 [DeepSeek Harness（dsh）](https://github.com/deepseek-ai/deepseek-harness)
+写入一个 OpenAI 兼容路由。它不属于下面的桌面端支持矩阵：传输、流式输出、工具调用与重试
+仍由 dsh 内置的 `llm-pi-ai` 负责。
+
+先预览计划，不改文件：
+
+```bash
+LOONGPORT_API_KEY='sk-…' npx loongport dsh setup \
+  --base-url https://relay.example.com/v1 \
+  --model model-id
+```
+
+确认后显式加 `--write`：
+
+```bash
+LOONGPORT_API_KEY='sk-…' npx loongport dsh setup \
+  --base-url https://relay.example.com/v1 \
+  --model model-id \
+  --write
+```
+
+API key 只从环境变量读取。命令只更新选定的 provider 路由与凭据名，保留其他 dsh 配置；
+完整的安装要求、安全边界和选项见 **[loongport.dev/zh/dsh](https://loongport.dev/zh/dsh)**，
+源码在 **[SailingLoong/loongport-dsh](https://github.com/SailingLoong/loongport-dsh)**。
+
 ## 支持范围
 
 | | 已支持 | 在做 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -210,6 +210,37 @@ can press "check for updates" yourself at any time.
 > from [Releases](../../releases). That is the trade-off for the portable build: no
 > install step, so nothing for security software to block.
 
+## DeepSeek Harness (dsh)
+
+LoongPort also ships an independent [`loongport` npm integration](https://www.npmjs.com/package/loongport)
+for adding one OpenAI-compatible route to
+[DeepSeek Harness (dsh)](https://github.com/deepseek-ai/deepseek-harness). It is separate
+from the desktop support matrix below: dsh's built-in `llm-pi-ai` still owns transport,
+streaming, tool calls and retries.
+
+Preview the redacted plan without changing files:
+
+```bash
+LOONGPORT_API_KEY='sk-…' npx loongport dsh setup \
+  --base-url https://relay.example.com/v1 \
+  --model model-id
+```
+
+Then apply it explicitly with `--write`:
+
+```bash
+LOONGPORT_API_KEY='sk-…' npx loongport dsh setup \
+  --base-url https://relay.example.com/v1 \
+  --model model-id \
+  --write
+```
+
+The API key is read only from the environment. The command updates only the selected
+provider route and credential name while preserving other dsh configuration. See
+**[loongport.dev/en/dsh](https://loongport.dev/en/dsh)** for prerequisites, security
+boundaries and every option; source lives at
+**[SailingLoong/loongport-dsh](https://github.com/SailingLoong/loongport-dsh)**.
+
 ## What it supports
 
 | | Shipped | In progress |


### PR DESCRIPTION
## Summary / 概述\n\n- Document the independent loongport npm integration for DeepSeek Harness (dsh) in the Chinese and English READMEs.\n- Include safe preview/apply commands, API-key handling, configuration preservation, and links to the localized guide and source repository.\n- Keep the npm integration explicitly separate from the desktop support matrix because the built-in llm-pi-ai provider owns transport.\n\n## Related Issue / 关联 Issue\n\nNone.\n\n## Screenshots / 截图\n\nDocumentation-only change; not applicable.\n\n## Checklist / 检查清单\n\n- [x] TypeScript typecheck passes\n- [x] Prettier check passes\n- [x] Rust tests, Clippy, and rustfmt checks pass\n- [x] Vitest passes: 127 files, 808 tests\n- [x] Chinese and English user-facing documentation updated