### PR TITLE
feat: gate relay directory auto-add by signed policy

### DIFF
--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -1169,11 +1169,14 @@ pub async fn relay_import_directory_site(
     app_handle: tauri::AppHandle,
     site: String,
 ) -> Result<ImportResult, RelayImportError> {
-    let source = if is_signed_directory_entry(&site) {
-        BrowserEntrySource::SignedDirectory
-    } else {
-        BrowserEntrySource::Manual
-    };
+    let config = crate::relay::remote_config::load_cached().ok_or_else(|| RelayImportError {
+        kind: Some(RelayImportErrorKind::UnsupportedSite),
+        message: "该站点需要手动添加".into(),
+    })?;
+    let source = directory_entry_source(&config, &site).ok_or_else(|| RelayImportError {
+        kind: Some(RelayImportErrorKind::UnsupportedSite),
+        message: "该站点需要手动添加".into(),
+    })?;
     import_site(&app_handle, &site, source).await
 }
 
@@ -1220,18 +1223,28 @@ enum BrowserEntrySource {
     SignedDirectory,
 }
 
-fn is_signed_directory_entry(input: &str) -> bool {
+fn directory_entry_source(
+    config: &crate::relay::remote_config::RemoteConfig,
+    input: &str,
+) -> Option<BrowserEntrySource> {
     let Ok(candidate) = browser_entry_url(input) else {
-        return false;
+        return None;
     };
-    crate::relay::remote_config::load_cached().is_some_and(|config| {
-        config.relay_directory.sites.values().any(|site| {
-            site.entry_url
-                .as_deref()
-                .and_then(|entry| browser_entry_url(entry).ok())
-                .is_some_and(|entry| entry == candidate)
+    config
+        .relay_directory
+        .sites
+        .iter()
+        .find_map(|(host, site)| {
+            if let Some(entry) = site.entry_url.as_deref() {
+                if url::Url::parse(entry).is_ok_and(|declared| declared.scheme() == "https") {
+                    return (browser_entry_url(entry).ok()? == candidate)
+                        .then_some(BrowserEntrySource::SignedDirectory);
+                }
+            }
+
+            (!host.is_empty() && browser_entry_url(host).ok()? == candidate)
+                .then_some(BrowserEntrySource::Manual)
         })
-    })
 }
 
 fn recoverable_native_discovery_error(
@@ -4874,6 +4887,63 @@ mod tests {
         assert_eq!(
             url.as_str(),
             "https://api.example.com/login?next=%2Fdashboard"
+        );
+    }
+
+    #[test]
+    fn directory_entry_source_accepts_only_policy_owned_entries() {
+        let config = crate::relay::remote_config::RemoteConfig {
+            relay_directory: crate::relay::remote_config::RelayDirectoryPolicy {
+                blocked_hosts: vec![],
+                sites: std::collections::BTreeMap::from([
+                    (
+                        "790053500.com".into(),
+                        crate::relay::remote_config::RelayDirectorySite {
+                            veridrop_host: Some("api.790053500.com".into()),
+                            entry_url: Some("https://790053500.com/keys".into()),
+                            display_name: Some("鑫旺".into()),
+                        },
+                    ),
+                    (
+                        "plain.example".into(),
+                        crate::relay::remote_config::RelayDirectorySite::default(),
+                    ),
+                    (
+                        "broken.example".into(),
+                        crate::relay::remote_config::RelayDirectorySite {
+                            veridrop_host: None,
+                            entry_url: Some("http://broken.example/keys".into()),
+                            display_name: None,
+                        },
+                    ),
+                ]),
+            },
+            ..crate::relay::remote_config::RemoteConfig::default()
+        };
+
+        assert_eq!(
+            directory_entry_source(&config, "https://790053500.com/keys"),
+            Some(BrowserEntrySource::SignedDirectory)
+        );
+        assert_eq!(
+            directory_entry_source(&config, "https://plain.example"),
+            Some(BrowserEntrySource::Manual)
+        );
+        assert_eq!(
+            directory_entry_source(&config, "https://unknown.example"),
+            None
+        );
+        assert_eq!(
+            directory_entry_source(&config, "https://790053500.com/other"),
+            None
+        );
+        assert_eq!(
+            directory_entry_source(&config, "https://broken.example"),
+            Some(BrowserEntrySource::Manual)
+        );
+        assert_eq!(
+            directory_entry_source(&config, "https://broken.example/keys"),
+            None
         );
     }
 

--- a/src-tauri/src/relay/leaderboard.rs
+++ b/src-tauri/src/relay/leaderboard.rs
@@ -65,6 +65,7 @@ pub struct RelayDirectoryItem {
     pub scenarios: Vec<String>,
     pub issues: Vec<String>,
     pub entry_url: String,
+    pub auto_add: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -606,6 +607,7 @@ pub fn apply_policy(
             if !seen_sites.insert(site_host.clone()) {
                 return None;
             }
+            let auto_add = override_site.is_some();
             let entry_url = override_site
                 .as_ref()
                 .and_then(|site| site.entry_url.clone())
@@ -629,6 +631,7 @@ pub fn apply_policy(
                 scenarios: item.scenarios,
                 issues: item.issues,
                 entry_url,
+                auto_add,
             })
         })
         .collect()
@@ -1190,6 +1193,28 @@ mod tests {
         assert_eq!(items[0].veridrop_host, "api.790053500.com");
         assert_eq!(items[0].display_name, "鑫旺");
         assert_eq!(items[0].entry_url, "https://790053500.com/keys");
+        assert!(items[0].auto_add);
+    }
+
+    #[test]
+    fn ordinary_leaderboard_sites_are_manual_only() {
+        let parsed = vec![ParsedLeaderboardItem {
+            veridrop_host: "ordinary.example".into(),
+            rank: Some(1),
+            score: 98,
+            samples: 12,
+            latest_date: "2026-08-14".into(),
+            detail_url: "https://veridrop.org/leaderboard/ordinary.example".into(),
+            protocol_scores: vec![],
+            claude_signature_rate: None,
+            scenarios: vec![],
+            issues: vec![],
+        }];
+
+        let items = apply_policy(parsed, &RemoteConfig::default());
+
+        assert_eq!(items.len(), 1);
+        assert!(!items[0].auto_add);
     }
 
     #[test]
@@ -1560,6 +1585,34 @@ mod tests {
         let filtered = apply_policy_to_cached(cached, &config_with_directory());
 
         assert!(filtered.items.is_empty());
+    }
+
+    #[test]
+    fn cached_items_use_the_current_auto_add_policy() {
+        let cached = CachedLeaderboard {
+            schema_version: CACHE_SCHEMA_VERSION,
+            kind: LeaderboardKind::Claude,
+            items: vec![ParsedLeaderboardItem {
+                veridrop_host: "api.790053500.com".into(),
+                rank: Some(72),
+                score: 96,
+                samples: 9,
+                latest_date: "2026-08-11".into(),
+                detail_url: "https://veridrop.org/leaderboard/api.790053500.com".into(),
+                protocol_scores: vec![],
+                claude_signature_rate: None,
+                scenarios: vec![],
+                issues: vec![],
+            }],
+            managed_hosts: vec![],
+            synced_at: 1,
+        };
+
+        let managed = apply_policy_to_cached(cached.clone(), &config_with_directory());
+        let unmanaged = apply_policy_to_cached(cached, &RemoteConfig::default());
+
+        assert!(managed.items[0].auto_add);
+        assert!(!unmanaged.items[0].auto_add);
     }
 
     #[test]

--- a/src/components/relay/directory/RelayDirectoryPage.tsx
+++ b/src/components/relay/directory/RelayDirectoryPage.tsx
@@ -25,6 +25,7 @@ import type {
 import { relayDirectoryKeys } from "@/lib/query/relayDirectory";
 import { extractErrorMessage } from "@/utils/errorUtils";
 
+import { openInBrowser } from "../openInBrowser";
 import {
   DIRECTORY_PAGE_SIZE,
   defaultDirectoryKind,
@@ -280,13 +281,17 @@ export function RelayDirectoryPage({
                 item={item}
                 busy={authenticatingHost === item.siteHost}
                 disabled={authenticatingHost !== null}
-                onAuthenticate={(selected) =>
+                onAuthenticate={(selected) => {
+                  if (!selected.autoAdd) {
+                    openInBrowser(selected.entryUrl);
+                    return;
+                  }
                   void authenticate(
                     selected.entryUrl,
                     selected.siteHost,
                     "directory",
-                  )
-                }
+                  );
+                }}
               />
             ))}
           </div>

--- a/src/components/relay/directory/RelayDirectoryRow.tsx
+++ b/src/components/relay/directory/RelayDirectoryRow.tsx
@@ -139,7 +139,11 @@ export function RelayDirectoryRow({
           {t("loongport.directory.actions.authenticate")}
         </Button>
         <span className="text-center text-[10px] text-muted-foreground">
-          {t("loongport.directory.actions.autoAddHint")}
+          {t(
+            item.autoAdd
+              ? "loongport.directory.actions.autoAddHint"
+              : "loongport.directory.actions.manualAddHint",
+          )}
         </span>
       </div>
     </article>

--- a/src/components/relay/directory/__tests__/RelayDirectoryPage.test.tsx
+++ b/src/components/relay/directory/__tests__/RelayDirectoryPage.test.tsx
@@ -129,6 +129,7 @@ function item(index: number): RelayDirectoryItem {
     issues: index === 1 ? ["token_usage"] : [],
     entryUrl:
       index === 1 ? "https://bestapi.store" : `https://site-${index}.example`,
+    autoAdd: index === 1,
   };
 }
 

--- a/src/components/relay/directory/__tests__/RelayDirectoryPage.test.tsx
+++ b/src/components/relay/directory/__tests__/RelayDirectoryPage.test.tsx
@@ -256,6 +256,30 @@ describe("RelayDirectoryPage", () => {
     );
   });
 
+  it("opens a manual-only row without importing it", async () => {
+    renderDirectory({ sourceAppId: "claude", onBack: () => {} });
+
+    const row = (await screen.findByText("站点 2")).closest("article");
+    expect(row).not.toBeNull();
+    const manualSite = within(row!);
+    expect(
+      manualSite.getByText("loongport.directory.actions.authenticate"),
+    ).toBeInTheDocument();
+    expect(
+      manualSite.getByText("loongport.directory.actions.manualAddHint"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      manualSite.getByRole("button", {
+        name: "loongport.directory.actions.authenticate",
+      }),
+    );
+
+    expect(openInBrowser).toHaveBeenCalledWith("https://site-2.example");
+    expect(importDirectorySite).not.toHaveBeenCalled();
+    expect(importSite).not.toHaveBeenCalled();
+  });
+
   it("labels a managed detail-page completion without inventing a rank", async () => {
     listDirectory.mockResolvedValue(
       leaderboard("gemini", {

--- a/src/components/relay/directory/__tests__/directoryState.test.ts
+++ b/src/components/relay/directory/__tests__/directoryState.test.ts
@@ -25,6 +25,7 @@ function item(index: number, overrides: Partial<RelayDirectoryItem> = {}) {
     scenarios: [],
     issues: [],
     entryUrl: `https://site-${index}.example`,
+    autoAdd: false,
     ...overrides,
   } satisfies RelayDirectoryItem;
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3095,6 +3095,7 @@
       "actions": {
         "authenticate": "Register or sign in",
         "autoAddHint": "Added automatically when complete",
+        "manualAddHint": "Add manually after signing in",
         "history": "Full history",
         "refresh": "Refresh live leaderboard",
         "retry": "Retry",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3095,6 +3095,7 @@
       "actions": {
         "authenticate": "登録またはログイン",
         "autoAddHint": "完了後に自動追加",
+        "manualAddHint": "ログイン後に手動で追加",
         "history": "全履歴",
         "refresh": "ライブランキングを更新",
         "retry": "再試行",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3096,6 +3096,7 @@
       "actions": {
         "authenticate": "註冊或登入",
         "autoAddHint": "完成後自動加入",
+        "manualAddHint": "需要手動加入",
         "history": "完整記錄",
         "refresh": "重新整理即時排行榜",
         "retry": "重試",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -3095,6 +3095,7 @@
       "actions": {
         "authenticate": "注册或登录",
         "autoAddHint": "完成后自动添加",
+        "manualAddHint": "需要手动添加",
         "history": "完整历史",
         "refresh": "刷新实时榜单",
         "retry": "重试",

--- a/src/lib/api/relay.ts
+++ b/src/lib/api/relay.ts
@@ -85,6 +85,7 @@ export interface RelayDirectoryItem {
   scenarios: string[];
   issues: string[];
   entryUrl: string;
+  autoAdd: boolean;
 }
 
 export interface RelayLeaderboard {


### PR DESCRIPTION
## What changed

- expose a backend-owned `autoAdd` capability on relay directory rows
- derive that capability only from the signed `relay_directory.sites` policy
- revalidate the current signed policy before any automatic directory import starts
- keep non-whitelisted VeriDrop rows visible, but open them externally for manual addition
- show “完成后自动添加” for eligible rows and “需要手动添加” for manual rows in all supported locales

## Why

The directory previously treated every displayed VeriDrop row as automatically importable. Some compatible leaderboard entries are useful for discovery but are not approved for the atomic LoongPort import flow. This change makes the signed remote configuration the single authority for automatic creation while preserving the broader directory.

## Safety and behavior

- no frontend whitelist copy
- no VeriDrop cache schema change; cached source facts are reprojected through the current policy
- unapproved entries are rejected before network requests or browser-window creation
- account persistence still occurs only after registration or login succeeds

## Validation

- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `npx tsc --noEmit`
- `pnpm format:check`
- `npx vitest run` (129 files, 805 tests)
- `pnpm tauri build --debug`