### PR TITLE
chore: release v3.25.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-switch",
-  "version": "3.24.0",
+  "version": "3.25.0",
   "description": "All-in-One Assistant for Claude Code, Codex & Gemini CLI",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "cc-switch"
-version = "3.24.0"
+version = "3.25.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # （裁决见 CLAUDE.md「三点五」）。面向用户的二进制名走 tauri.conf.json 的
 # `mainBinaryName`（已是 `LoongPort`）。
 name = "cc-switch"
-version = "3.24.0"
+version = "3.25.0"
 description = "同样的 Codex，成本省 95% 以上 —— 填一个域名、登录一次，其余自动配好"
 authors = ["SailingLoong", "Jason Young"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LoongPort",
   "mainBinaryName": "LoongPort",
-  "version": "3.24.0",
+  "version": "3.25.0",
   "identifier": "dev.loongport.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Synchronize the LoongPort application version to `3.25.0` across all authoritative manifests and the Rust lockfile.

This release includes the backend maintenance scheduler, background VeriDrop cache refresh, models.dev and relay pricing refreshes, and the signed relay-directory auto-add policy already merged into `main`.

## Validation

- version consistency test
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `npx tsc --noEmit`
- `pnpm format:check`
- `npx vitest run` (129 files, 805 tests)
- `pnpm tauri build --debug`