### PR TITLE
feat(onboarding): 新用户首启自动打开 BestAPI 注册窗（LOONGPORT 优惠码 + 新人礼包横幅）

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -17,6 +17,7 @@ mod misc;
 mod model_fetch;
 mod model_verification;
 mod omo;
+mod onboarding;
 mod openclaw;
 mod pi;
 mod plugin;
@@ -63,6 +64,8 @@ pub use misc::*;
 pub use model_fetch::*;
 pub use model_verification::*;
 pub use omo::*;
+// 新人引导：与 relay 主流程解耦的引导调度（判据 + 一次性标志 + 官方站注册窗）。
+pub use onboarding::*;
 pub use openclaw::*;
 pub(crate) use pi::*;
 pub use plugin::*;

--- a/src-tauri/src/commands/onboarding.rs
+++ b/src-tauri/src/commands/onboarding.rs
@@ -1,0 +1,97 @@
+//! 新人引导命令层：薄调度，策略事实都在 [`crate::relay::onboarding`]。
+//!
+//! 见那个模块的文档 for 模块边界（策略收拢、机制复用、后续调整只动那边）。
+
+use serde::Serialize;
+use tauri::{Emitter, State};
+
+use crate::events::ONBOARDING_REGISTER_COMPLETED;
+use crate::relay::onboarding;
+use crate::store::AppState;
+
+use super::relay::{import_site, user_has_no_accounts, BrowserEntrySource, ImportResult};
+
+/// 新人引导注册窗完成事件的 payload（前端 `src/lib/onboarding.ts` 消费）。
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RegisterCompletedPayload {
+    relay_id: i64,
+    site_name: String,
+}
+
+/// 弹不弹新人引导注册窗的判据。**纯判据，无副作用**：
+/// 还没有任何账号（新用户）&& 这个安装还没弹过（一次性标志未置位）。
+fn register_prompt_eligible(state: &AppState) -> Result<bool, crate::error::AppError> {
+    Ok(crate::settings::get_settings()
+        .onboarding_register_prompted
+        .is_none()
+        && user_has_no_accounts(state)?)
+}
+
+/// 标志只置位一次：置位后无论窗口结局如何（注册成功 / 关窗 / 超时 / 没网），
+/// 后续启动都不再自动弹。这是有意的不重试 —— 弹过又没成的用户回落到既有的
+/// 「添加站点」首启提示，别用同一个窗口反复打扰。
+fn mark_register_prompted() {
+    let mut settings = crate::settings::get_settings();
+    if settings.onboarding_register_prompted.is_none() {
+        settings.onboarding_register_prompted = Some(true);
+        if let Err(error) = crate::settings::update_settings(settings) {
+            log::warn!("新人引导标志写入失败（不影响本次引导，但下次启动会再弹）: {error}");
+        }
+    }
+}
+
+/// 新用户首启时自动打开官方站（BestAPI）注册窗。
+///
+/// 满足判据就**标记后立即返回 `true`**，窗口生命周期在后台跑 —— 命令不能等
+/// `import_site`：它要到用户注册完 / 关窗 / 超时才返回，而前端要用返回值决定
+/// 同一会话里还弹不弹「添加站点」首启提示（两个提示只留一个）。
+///
+/// 注册成功后发 [`ONBOARDING_REGISTER_COMPLETED`]（payload 见该常量的文档），
+/// 前端拿它做 toast + 档位预配 + 列表刷新。失败只记日志不上报：这里的失败大多
+/// 是正常结局（用户关窗 / 没网），为它们弹错误 toast 是把噪声当反馈。
+#[tauri::command]
+pub async fn onboarding_prompt_register(
+    app_handle: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> Result<bool, String> {
+    let eligible = register_prompt_eligible(&state).map_err(|e| e.to_string())?;
+    if !eligible {
+        return Ok(false);
+    }
+    mark_register_prompted();
+
+    let handle = app_handle.clone();
+    tauri::async_runtime::spawn(async move {
+        match import_site(
+            &handle,
+            onboarding::OFFICIAL_SITE_ORIGIN,
+            BrowserEntrySource::Onboarding,
+        )
+        .await
+        {
+            Ok(result) => {
+                let ImportResult {
+                    relay_id,
+                    site_name,
+                    ..
+                } = result;
+                let _ = handle.emit(
+                    ONBOARDING_REGISTER_COMPLETED,
+                    RegisterCompletedPayload {
+                        relay_id,
+                        site_name,
+                    },
+                );
+            }
+            Err(error) => {
+                // 关窗 / 超时走这里（RelayImportError::Incomplete）—— 正常结局，
+                // 不打扰用户。真异常（协议冲突等）也只进日志：窗口本身已经把
+                // 用户可见的失败呈现过了。
+                log::info!("新人引导注册窗未完成：{:?}", error.kind);
+            }
+        }
+    });
+
+    Ok(true)
+}

--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -991,10 +991,18 @@ async fn check_session(app_handle: &tauri::AppHandle) -> Result<Vec<i64>, AppErr
     Ok(expired)
 }
 
-fn relay_status_impl(state: &AppState) -> Result<RelayStatus, AppError> {
-    let should_prompt_add_site = with_conn(state, |conn| {
+/// 本机还没有任何中转站 / 厂商账号 —— 即「新用户」这一事实的唯一判据。
+///
+/// `RelayStatus.should_prompt_add_site` 与新人引导（`commands::onboarding`）都读它：
+/// 同一个业务事实只算一次，两处不会因为各写一份判据而分叉。
+pub(crate) fn user_has_no_accounts(state: &AppState) -> Result<bool, AppError> {
+    with_conn(state, |conn| {
         Ok(creds::list(conn)?.is_empty() && crate::vendor::creds::list(conn)?.is_empty())
-    })?;
+    })
+}
+
+fn relay_status_impl(state: &AppState) -> Result<RelayStatus, AppError> {
+    let should_prompt_add_site = user_has_no_accounts(state)?;
     Ok(RelayStatus {
         default_site: DEFAULT_SITE.to_string(),
         should_prompt_add_site,
@@ -1182,7 +1190,9 @@ pub async fn relay_import_directory_site(
     import_site(&app_handle, &site, source).await
 }
 
-async fn import_site(
+// `pub(crate)`：新人引导（`commands::onboarding`）走同一条导入链路，只是入口
+// 标记不同（见 `BrowserEntrySource::Onboarding`）。
+pub(crate) async fn import_site(
     app_handle: &tauri::AppHandle,
     input: &str,
     entry_source: BrowserEntrySource,
@@ -1220,9 +1230,12 @@ async fn import_site(
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum BrowserEntrySource {
+pub(crate) enum BrowserEntrySource {
     Manual,
     SignedDirectory,
+    /// 新人引导的官方站注册窗（见 [`crate::relay::onboarding`]）。落页与探测行为
+    /// 同 `Manual`；差别只有窗口标题和额外注入的新人礼包横幅。
+    Onboarding,
 }
 
 fn directory_entry_source(
@@ -1450,7 +1463,11 @@ async fn browser_import(
         )
     });
 
-    let entry_source = if browser_entry_is_auth_page(&entry_url) {
+    // 在下面把 entry_source 遮蔽成诊断字符串之前先记下入口类型。
+    let is_onboarding = entry_source == BrowserEntrySource::Onboarding;
+    let entry_source = if is_onboarding {
+        "onboarding"
+    } else if browser_entry_is_auth_page(&entry_url) {
         "supplied_auth_page"
     } else if initial_backend.is_some() {
         "protocol_login_page"
@@ -1482,12 +1499,28 @@ async fn browser_import(
     let probe_error_tx = error_tx.clone();
     let credential_error_tx = error_tx.clone();
 
+    // 新人引导的注册窗用自己的标题：新用户没有「添加中转站」这个上下文，
+    // 标题要说清这个窗口为什么自己弹出来（见 relay::onboarding 的文档）。
+    let window_title = if is_onboarding {
+        crate::relay::onboarding::register_window_title()
+    } else {
+        format!("添加中转站 {site_origin}")
+    };
+
+    // 协议探针脚本所有入口都注入；新人引导额外带上新人礼包横幅（只在 /register
+    // 显示，脚本自己管显隐 —— 见 relay::onboarding::register_gift_banner_js）。
+    let mut init_script =
+        discovery::browser_probe_script(&site_origin, discovery::PROBE_CANDIDATES);
+    if is_onboarding {
+        init_script.push_str(&crate::relay::onboarding::register_gift_banner_js());
+    }
+
     let window = tauri::WebviewWindowBuilder::new(
         app_handle,
         login::LOGIN_WINDOW_LABEL,
         tauri::WebviewUrl::External(entry_url),
     )
-    .title(format!("添加中转站 {site_origin}"))
+    .title(window_title)
     .inner_size(480.0, 720.0)
     .resizable(true)
     // 一次导入只使用这一份纯内存会话：网页验证、协议探测、注册/登录都不换窗口，
@@ -1496,10 +1529,7 @@ async fn browser_import(
     // 所有导入都统一注入协议无关的候选抓取器。脚本不认识 Cloudflare、HTTP 403
     // 或任何其它验证产品；协议未知时，用户验证完成后它自然会在同源会话里读到候选响应。
     // fast path 已识别时，Rust context 已有值，重复探测回传会被忽略。
-    .initialization_script(discovery::browser_probe_script(
-        &site_origin,
-        discovery::PROBE_CANDIDATES,
-    ))
+    .initialization_script(init_script)
     .on_page_load(move |webview, payload| {
         log::info!(
             "站点导入窗页面加载 {:?}：{}",

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -53,6 +53,9 @@ pub const VENDOR_ACCOUNTS_CHANGED: &str = "vendor-accounts-changed";
 pub const MODEL_VERIFICATION_PROGRESS: &str = "model-verification-progress";
 /// 模型验证持久化结果变化（档位行与模型验证弹窗监听）。
 pub const MODEL_VERIFICATION_CHANGED: &str = "model-verification-changed";
+/// 新人引导注册窗完成（`RelaySection` 监听）：凭据已入库，前端做 toast +
+/// 档位预配 + 列表刷新。payload `{ relayId, siteName }`。
+pub const ONBOARDING_REGISTER_COMPLETED: &str = "onboarding-register-completed";
 
 /// 广播「当前供应商变了」。
 ///
@@ -143,6 +146,10 @@ mod consistency_tests {
             (
                 "MODEL_VERIFICATION_CHANGED",
                 super::MODEL_VERIFICATION_CHANGED,
+            ),
+            (
+                "ONBOARDING_REGISTER_COMPLETED",
+                super::ONBOARDING_REGISTER_COMPLETED,
             ),
         ];
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1582,6 +1582,8 @@ pub fn run() {
             commands::switch_provider,
             // LoongPort 中转站
             commands::relay_status,
+            // 新人引导（官方站注册窗）
+            commands::onboarding_prompt_register,
             commands::relay_check_session,
             commands::relay_stats_endpoint_configured,
             commands::relay_list_sponsors,

--- a/src-tauri/src/relay/mod.rs
+++ b/src-tauri/src/relay/mod.rs
@@ -69,6 +69,7 @@ pub mod managed;
 pub mod newapi;
 pub mod newapi_provision;
 pub mod newapi_purchase;
+pub mod onboarding;
 // Phase 1 defines this crate-internal contract before Phase 2 consumes it.
 #[allow(dead_code)]
 pub mod model_verification;

--- a/src-tauri/src/relay/onboarding.rs
+++ b/src-tauri/src/relay/onboarding.rs
@@ -1,0 +1,160 @@
+//! 新人引导（onboarding）：新用户首次打开 LoongPort 时，自动打开官方站
+//! （BestAPI）的注册页，让「注册即用」这条路径一步到位。
+//!
+//! ## 这个模块的边界（为什么单独收拢）
+//!
+//! 新人引导的**策略**（什么时候弹、弹哪个站、页面上说什么）预期还会调整；
+//! 而它依赖的**机制**（登录窗、协议探测、优惠码预填、凭据回传）是 `relay`
+//! 里既有的稳定链路。所以策略全部收在本模块，机制一行不改 —— 调整引导
+//! 行为时只动这里，不碰 `commands::relay` 的主流程。
+//!
+//! 具体分工：
+//! - 本模块：官方站 origin、注册窗完成事件名、新人礼包横幅脚本；
+//! - [`crate::commands::onboarding`]：判据（一次性标志 + 还没有任何账号）、
+//!   打开窗口的调度；
+//! - [`crate::commands::relay`]：`BrowserEntrySource::Onboarding` 入口把本模块的
+//!   横幅脚本接进既有的 `browser_import` 窗口。
+//!
+//! ## 优惠码不在这里
+//!
+//! 注册页的优惠码预填（`LOONGPORT`）由既有的 `promo` 链路负责：
+//! `browser_import` 对任何站点都会解析优惠码并注入
+//! [`login`] 的预填脚本，本模块不复制那份码表。
+
+/// 新人引导自动打开的官方站。BestAPI 是维护者自己的站，是「注册即用 +
+/// 新人大礼包」承诺的承载方；与优惠码表（`promo::PROMO_CODES`）里键的
+/// host 保持一致。
+pub const OFFICIAL_SITE_ORIGIN: &str = "https://bestapi.store";
+
+// 注册窗完成事件名见 `crate::events::ONBOARDING_REGISTER_COMPLETED`（跨语言
+// 事件统一收在 `events`，有一致性闸守着）；发射点在 `commands::onboarding`。
+
+/// 新人引导注册窗的标题。区别于手动的「添加中转站 …」：新用户没有上下文，
+/// 「添加中转站 bestapi.store」对他是一句黑话；「注册 + 礼包」才说得清这个
+/// 窗口为什么自己弹出来。
+pub fn register_window_title() -> String {
+    "注册 BestAPI — 新人大礼包".to_string()
+}
+
+/// 注册页顶部的「新人礼包」横幅脚本，作为 `initialization_script` 注入
+/// 新人引导的注册窗。
+///
+/// ## 文案是写死的中文，不随 app 语言切换
+///
+/// 与 [`login::register_hint_banner_snippet`]「复用页面自己的文案」不同，这条
+/// 是维护者要求的官方推广语（「注册即用，官方赠送新人大礼包」）—— 它本来就是
+/// 针对 BestAPI（中文站）说的，不存在四语版本；BestAPI 界面切到英文时这条
+/// 横幅仍是中文，与「站点自己的中文推广位」性质相同，不算语言错乱。
+///
+/// ## 与「已有账号」横幅的堆叠
+///
+/// 注册页上还有一条 [`login`] 注入的「已有账号？去登录」横幅
+/// （`#loongport-register-hint`，协议识别后才会出现）。两条都是 fixed 定位，
+/// 本横幅**让位**：每次同步时若检测到对方存在，把自己的 `top` 挪到对方高度
+/// 之下，并把 `body.paddingTop` 补到两条横幅的总高度。对方先撤时，下一轮
+/// 轮询（500ms）自动回落到顶部。
+///
+/// 其余行为沿用 `register_hint_banner_snippet` 已经验证过的模式，理由相同：
+/// 只在 `/register` 路径显示（含 hash 路由）、SPA 路由切换靠 500ms 轮询
+/// 而不是 MutationObserver、必须有轮询上限（拿到凭据后窗口**有意不关**，
+/// 用户会在里面继续看 dashboard）。
+pub fn register_gift_banner_js() -> String {
+    r##"
+  // 新人礼包横幅。定位与让位规则见 Rust 侧 register_gift_banner_js 的文档。
+  try {
+    var GIFT_BANNER_ID = 'loongport-onboarding-gift';
+    var HINT_BANNER_ID = 'loongport-register-hint';
+    var GIFT_TEXT = '注册即用，官方赠送新人大礼包';
+
+    var paddedByUs = false;
+
+    function hintBannerHeight() {
+      var hint = document.getElementById(HINT_BANNER_ID);
+      return hint && hint.offsetParent !== null ? hint.offsetHeight : 0;
+    }
+
+    function removeBanner() {
+      var old = document.getElementById(GIFT_BANNER_ID);
+      if (old) old.remove();
+      // 离开注册页要还原（拿到凭据后窗口有意不关，用户还会逛 dashboard）。
+      // 只还原自己设的那次：paddingTop 为空串才可能是我们设的。
+      if (paddedByUs) {
+        document.body.style.paddingTop = '';
+        paddedByUs = false;
+      }
+    }
+
+    function syncBanner() {
+      var onRegister = window.location.pathname.indexOf('/register') !== -1
+        || window.location.hash.indexOf('/register') !== -1;
+      if (!onRegister) { removeBanner(); return; }
+
+      var bar = document.getElementById(GIFT_BANNER_ID);
+      if (!bar) {
+        bar = document.createElement('div');
+        bar.id = GIFT_BANNER_ID;
+        bar.setAttribute('role', 'status');
+        // 内联样式：站点的 CSS 类名不稳定，横幅必须一直看得见（同既有横幅）。
+        bar.style.cssText = [
+          'position:fixed', 'left:0', 'right:0', 'z-index:2147483647',
+          'display:flex', 'align-items:center', 'justify-content:center',
+          'padding:10px 16px', 'background:#16a34a', 'color:#fff',
+          'font:500 14px/1.5 system-ui,-apple-system,sans-serif',
+          'box-shadow:0 1px 3px rgba(0,0,0,.2)'
+        ].join(';');
+        var text = document.createElement('span');
+        text.textContent = GIFT_TEXT;
+        bar.appendChild(text);
+        document.body.appendChild(bar);
+      }
+
+      // 让位于「已有账号」横幅：它在就挪到它下面，不在就回顶部。
+      bar.style.top = hintBannerHeight() + 'px';
+
+      // 两横幅的总高度都算进 paddingTop，页面顶部内容才不被盖住。
+      // 只在站点自己没设过这个属性时才动它，并记下「是我们设的」。
+      if (document.body.style.paddingTop === '') {
+        paddedByUs = true;
+      }
+      if (paddedByUs) {
+        document.body.style.paddingTop = (hintBannerHeight() + bar.offsetHeight) + 'px';
+      }
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', syncBanner);
+    } else {
+      syncBanner();
+    }
+    var polls = 0;
+    var timer = setInterval(function () {
+      polls++;
+      if (polls > 600) {
+        clearInterval(timer);
+        removeBanner();
+        return;
+      }
+      syncBanner();
+    }, 500);
+  } catch (e) {
+    // 横幅是提示，不是注册必需的一步。它坏了绝不能影响凭据回传。
+    console.warn('[LoongPort] 新人礼包横幅未能显示:', e);
+  }
+"##
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gift_banner_uses_dedicated_element_id_and_requested_copy() {
+        let js = register_gift_banner_js();
+        // 文案逐字来自维护者的要求；改文案必须是有意识的决定，不是顺手。
+        assert!(js.contains("注册即用，官方赠送新人大礼包"));
+        assert!(js.contains("loongport-onboarding-gift"));
+        // 与「已有账号」横幅的堆叠关系挂在对方的 id 上，改对方 id 时这里要跟着看。
+        assert!(js.contains("loongport-register-hint"));
+    }
+}

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -473,6 +473,13 @@ pub struct AppSettings {
     /// User has confirmed the common config first-run notice
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub common_config_confirmed: Option<bool>,
+    /// 新人引导的官方站注册窗**已经弹过**（无论用户注册、关窗还是超时）。
+    ///
+    /// 一次性标志：新人引导模块（`relay::onboarding`）用它保证注册窗每个安装只自动弹
+    /// 一次 —— 没弹成（关窗 / 超时 / 没网）也不重试，后续启动回落到既有的
+    /// 「添加站点」首启提示（`RelayStatus.should_prompt_add_site` 那条链路）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub onboarding_register_prompted: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
 
@@ -611,6 +618,7 @@ impl Default for AppSettings {
             failover_confirmed: None,
             first_run_notice_confirmed: None,
             common_config_confirmed: None,
+            onboarding_register_prompted: None,
             language: None,
             visible_apps: None,
             claude_config_dir: None,

--- a/src/components/relay/RelaySection.tsx
+++ b/src/components/relay/RelaySection.tsx
@@ -26,7 +26,14 @@ import {
   type VerificationScopeSummary,
   type VerificationVerdict,
 } from "@/lib/api/modelVerification";
-import { MODEL_VERIFICATION_CHANGED } from "@/lib/api/events";
+import {
+  MODEL_VERIFICATION_CHANGED,
+  ONBOARDING_REGISTER_COMPLETED,
+} from "@/lib/api/events";
+import {
+  promptOnboardingRegister,
+  type OnboardingRegisterCompleted,
+} from "@/lib/onboarding";
 import {
   vendorApi,
   type VendorAccountRow,
@@ -279,12 +286,15 @@ export function RelaySection({
   const reloadStatus = useCallback(async () => {
     try {
       const status = await relayApi.status();
-      if (
-        !isImageTab &&
-        status.shouldPromptAddSite &&
-        !autoPromptedThisProcess
-      ) {
-        autoPromptedThisProcess = true;
+      if (isImageTab || !status.shouldPromptAddSite || autoPromptedThisProcess) {
+        return;
+      }
+      autoPromptedThisProcess = true;
+      // 首启先走新人引导（官方站注册窗，策略见 src/lib/onboarding.ts 与后端
+      // relay::onboarding）：引导触发了就不再叠「添加站点」目录提示 —— 一次只劝
+      // 一遍。没触发（已弹过 / 不是新用户 / 后端暂时不可用）才回落到既有提示。
+      const onboardingLaunched = await promptOnboardingRegister();
+      if (!onboardingLaunched) {
         onOpenDirectory("firstRun");
       }
     } catch {
@@ -509,6 +519,26 @@ export function RelaySection({
   useTauriEvent<null>(VENDOR_ACCOUNTS_CHANGED, () => {
     void reloadVendors();
   });
+
+  /**
+   * 新人引导注册窗里注册成功（凭据已由后端入库）。收尾对齐目录页手动导入成功的
+   * 那一串（`RelayDirectoryPage.authenticate`）：toast + 给当前 app 预配档位 +
+   * 整区刷新 —— 用户关掉注册窗回到主界面时，「注册即用」已经成立。
+   */
+  useTauriEvent<OnboardingRegisterCompleted>(
+    ONBOARDING_REGISTER_COMPLETED,
+    async (payload) => {
+      toast.success(t("loongport.addSite.connected", { name: payload.siteName }));
+      try {
+        presentRefreshResult(await relayApi.refresh(payload.relayId, appId));
+      } catch (reason) {
+        toast.error(
+          t("loongport.directory.provisionFailed", { reason: String(reason) }),
+        );
+      }
+      void reload();
+    },
+  );
 
   /**
    * 登录（或重新登录）一个官网账号。

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -46,3 +46,5 @@ export const VENDOR_ACCOUNTS_CHANGED = "vendor-accounts-changed";
 export const MODEL_VERIFICATION_PROGRESS = "model-verification-progress";
 /** 模型验证持久化结果变化（档位行与模型验证弹窗监听）。 */
 export const MODEL_VERIFICATION_CHANGED = "model-verification-changed";
+/** 新人引导注册窗完成（`RelaySection` 监听）：凭据已入库，前端做 toast + 档位预配 + 列表刷新。 */
+export const ONBOARDING_REGISTER_COMPLETED = "onboarding-register-completed";

--- a/src/lib/onboarding.test.ts
+++ b/src/lib/onboarding.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+describe("promptOnboardingRegister", () => {
+  beforeEach(() => {
+    // 单例是模块级状态：每个用例重置模块注册表，拿一份干净实例。
+    vi.resetModules();
+    invokeMock.mockReset();
+  });
+
+  it("一次进程内多次调用收敛成一次 invoke（App 挂载与首启判定都会碰它）", async () => {
+    invokeMock.mockResolvedValue(true);
+    const { promptOnboardingRegister } = await import("./onboarding");
+    const [a, b] = await Promise.all([
+      promptOnboardingRegister(),
+      promptOnboardingRegister(),
+    ]);
+    expect(a).toBe(true);
+    expect(b).toBe(true);
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(invokeMock).toHaveBeenCalledWith("onboarding_prompt_register");
+  });
+
+  it("invoke 失败时静默降级为 false（回落到既有的首启目录提示）", async () => {
+    invokeMock.mockRejectedValue(new Error("backend unavailable"));
+    const { promptOnboardingRegister } = await import("./onboarding");
+    await expect(promptOnboardingRegister()).resolves.toBe(false);
+  });
+});

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -1,0 +1,33 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * 新人引导（前端侧）。后端策略在 `src-tauri/src/relay/onboarding.rs` 与
+ * `src-tauri/src/commands/onboarding.rs`，那边说了算；这里只保证一件事：
+ * **一次进程内最多发起一次**引导询问 —— `App` 挂载与 `RelaySection` 的首启
+ * 判定都可能碰它，靠模块级单例把多次调用收敛成一次 invoke。
+ *
+ * 完成后的 toast / 档位预配 / 列表刷新不在这里：那些是 `RelaySection` 的
+ * 既有职责（监听 `ONBOARDING_REGISTER_COMPLETED`）。
+ */
+let promptPromise: Promise<boolean> | null = null;
+
+/**
+ * 问后端「要不要弹新人引导注册窗」。返回 `true` = 本次调用触发了弹窗
+ *（本进程的首次且用户仍是新用户）；`false` = 已弹过 / 不是新用户 / 后端不可用。
+ */
+export function promptOnboardingRegister(): Promise<boolean> {
+  promptPromise ??= invoke<boolean>("onboarding_prompt_register").catch((error) => {
+    // 引导是加分项：后端暂时不可用时静默降级（false = 走既有的首启目录提示），
+    // 不为它弹错误打扰新用户。
+    console.warn("[onboarding] 新人引导注册窗未能发起", error);
+    return false;
+  });
+  return promptPromise;
+}
+
+/** `ONBOARDING_REGISTER_COMPLETED` 事件的 payload（与 Rust 侧
+ * `commands::onboarding::RegisterCompletedPayload` 对应）。 */
+export interface OnboardingRegisterCompleted {
+  relayId: number;
+  siteName: string;
+}

--- a/tests/components/PiProviderForm.test.tsx
+++ b/tests/components/PiProviderForm.test.tsx
@@ -8,6 +8,11 @@ import {
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// 本文件是全仓最慢的交互重组件测试（46 例单跑 ~45s，userEvent 连续操作多）；
+// 全局 testTimeout 15s（vitest.config.ts，已为 CI 2 核放宽过一次）在全量并发
+// 负载下仍会偶发超时红 CI。按文件再放宽，不动全局。
+vi.setConfig({ testTimeout: 30_000 });
+
 import { PiProviderForm } from "@/components/providers/forms/PiProviderForm";
 import { http, HttpResponse } from "msw";
 import { server } from "../msw/server";


### PR DESCRIPTION
## 做什么

新用户首次打开 LoongPort 时，自动弹出 BestAPI（bestapi.store）注册窗：

- **优惠码**：`LOONGPORT` 自动预填（复用既有 promo 链路，码表无第二份）
- **礼包横幅**：注册页顶部显示「注册即用，官方赠送新人大礼包」，只在 `/register` 显示，并主动让位堆叠在既有「已有账号？去登录」横幅下方
- **注册即用**：注册成功后凭据自动入库，前端收到 `onboarding-register-completed` 事件后 toast + 给当前 app 预配档位 + 刷新列表

## 弹出时机（裁决）

只在首次打开弹一次（settings 一次性标志 `onboarding_register_prompted`）。关窗 / 超时 / 没网不重试——后续启动回落到既有「添加站点」firstRun 目录提示；同一会话内两个提示互斥。

## 模块边界（按需求收拢，与主逻辑解耦）

- 策略：`src-tauri/src/relay/onboarding.rs` + `commands/onboarding.rs`——后续调整引导行为只动这里
- 机制：零改动复用 `browser_import` 链路；`commands/relay.rs` 仅加 `BrowserEntrySource::Onboarding` 入口（标题 + 横幅注入），并提取 `user_has_no_accounts` 判据供 `relay_status` 与 onboarding 共用（唯源）
- 事件名 `onboarding-register-completed` 走 events.rs / events.ts 跨语言一致性闸
- 前端 `src/lib/onboarding.ts` 仅做进程内单例 invoke；`App.tsx` 零改动

## 验证

- `cargo check` / `cargo test --lib`（3290 全过，含事件一致性闸）/ `cargo fmt` / `cargo clippy`（新增代码零警告）
- 前端 vitest：relay + lib 相关 107 项全过 + 新增 `onboarding.test.ts`；全量中 `PiProviderForm.test.tsx` 超时失败与 typecheck 一处 Mock 类型错误均为 main 上同样存在的存量问题（已对照基线确认）