### PR TITLE
feat(relay): 中转站扣费对账（余额差值 vs 估算成本）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ mainWindow.js
 
 # Mimosa 扫描器本地状态（hook 每次调用都会重写）
 .mimosa/
+
+# SDD plan 工作区（superpowers subagent-driven-development 的台账/brief/review 包）
+.superpowers/

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -25,6 +25,8 @@ mod profile;
 mod prompt;
 mod provider;
 mod proxy;
+// 中转站扣费对账：`commands/relay.rs` 已经 8819+ 行，对账命令单独放，不再往里堆。
+mod reconcile;
 mod relay;
 mod session_manager;
 mod settings;
@@ -73,6 +75,7 @@ pub use profile::*;
 pub use prompt::*;
 pub use provider::*;
 pub use proxy::*;
+pub use reconcile::*;
 pub use relay::*;
 pub use session_manager::*;
 pub use settings::*;

--- a/src-tauri/src/commands/reconcile.rs
+++ b/src-tauri/src/commands/reconcile.rs
@@ -1,0 +1,66 @@
+//! 中转站扣费对账：`relay_reconciliation` 命令（纯读）。
+//!
+//! 逻辑主体在 [`crate::relay::reconcile`]（`Database::reconciliation_report`）——
+//! 这里只是薄壳：读 relay 行 → 按 [`belongs_to_account`] 归属出该站名下全部
+//! 托管档位 → 交给窗口计算。归属判据全仓只有那一份（plan §二：唯一数据源）。
+
+use tauri::State;
+
+use crate::app_config::AppType;
+use crate::commands::relay::belongs_to_account;
+use crate::error::AppError;
+use crate::relay::creds;
+use crate::relay::reconcile::ReconciliationReport;
+use crate::services::ProviderService;
+use crate::AppState;
+
+/// 该中转站名下全部托管档位的 `(provider_id, app_type)`。
+///
+/// 与 `relay_balance_inputs` 同款纪律：**跨全部 app 扫** —— 档位可能只挂在某一个
+/// CLI 下，漏扫一个 app 就少算一块成本，对账比值会失真。
+fn relay_provider_keys(state: &AppState, relay: &creds::Relay) -> Vec<(String, String)> {
+    let mut keys = Vec::new();
+    for app_type in AppType::all() {
+        let Ok(providers) = ProviderService::list(state, app_type.clone()) else {
+            continue;
+        };
+        for provider in providers.values() {
+            if belongs_to_account(provider, &relay.site_origin, relay.account_id) {
+                keys.push((provider.id.clone(), app_type.as_str().to_string()));
+            }
+        }
+    }
+    keys
+}
+
+/// 某一行中转站的扣费对账报告。
+///
+/// 显式指定查不到就报错，绝不回落到其它站点（与 [`crate::commands::relay_balance`]
+/// 同一套纪律）。名下没有托管档位也照常返回报告 —— 那是「估算全为 0」的合法状态，
+/// 窗口会标 `InsufficientData`，让前端展示而不是报错。
+#[tauri::command]
+pub async fn relay_reconciliation(
+    state: State<'_, AppState>,
+    relay_id: i64,
+) -> Result<ReconciliationReport, String> {
+    reconcile(state.inner(), relay_id).map_err(|e| e.to_string())
+}
+
+fn reconcile(state: &AppState, relay_id: i64) -> Result<ReconciliationReport, AppError> {
+    let relay = {
+        let conn = state
+            .db
+            .conn
+            .lock()
+            .map_err(|e| AppError::Database(format!("获取数据库连接失败: {e}")))?;
+        creds::get(&conn, relay_id)?
+            .ok_or_else(|| AppError::Config(format!("找不到 id 为 {relay_id} 的中转站")))?
+    };
+    let provider_keys = relay_provider_keys(state, &relay);
+    state.db.reconciliation_report(relay_id, &provider_keys)
+}
+
+// 测试留白说明：命令层只有「读行 + 归属 + 委托」三步薄壳，归属判据
+// （belongs_to_account）在 commands/relay.rs 有自己的测试，窗口数学在
+// relay/reconcile.rs 有自己的测试；AppState（要起全套服务）在这里造不出来，
+// 纯透传逻辑不为测而测。

--- a/src-tauri/src/commands/reconcile.rs
+++ b/src-tauri/src/commands/reconcile.rs
@@ -1,13 +1,14 @@
 //! 中转站扣费对账：`relay_reconciliation` 命令（纯读）。
 //!
 //! 逻辑主体在 [`crate::relay::reconcile`]（`Database::reconciliation_report`）——
-//! 这里只是薄壳：读 relay 行 → 按 [`belongs_to_account`] 归属出该站名下全部
-//! 托管档位 → 交给窗口计算。归属判据全仓只有那一份（plan §二：唯一数据源）。
+//! 这里只是薄壳：读 relay 行 → 按 [`belongs_to_relay`]（严格归属：未登录的行不认
+//! 别人账号的档位）归属出该站名下全部托管档位 → 交给窗口计算。
+//! 归属口径与 `relay_balance_inputs` 同一份（plan §二：唯一数据源）。
 
 use tauri::State;
 
 use crate::app_config::AppType;
-use crate::commands::relay::belongs_to_account;
+use crate::commands::relay::belongs_to_relay;
 use crate::error::AppError;
 use crate::relay::creds;
 use crate::relay::reconcile::ReconciliationReport;
@@ -17,7 +18,9 @@ use crate::AppState;
 /// 该中转站名下全部托管档位的 `(provider_id, app_type)`。
 ///
 /// 与 `relay_balance_inputs` 同款纪律：**跨全部 app 扫** —— 档位可能只挂在某一个
-/// CLI 下，漏扫一个 app 就少算一块成本，对账比值会失真。
+/// CLI 下，漏扫一个 app 就少算一块成本，对账比值会失真。归属判据用
+/// [`belongs_to_relay`]（严格版）：成本是要记到这一行头上的事实，未登录的行
+/// 不认别人账号的档位，否则 B 的消费会被算进 A 的对账。
 fn relay_provider_keys(state: &AppState, relay: &creds::Relay) -> Vec<(String, String)> {
     let mut keys = Vec::new();
     for app_type in AppType::all() {
@@ -25,7 +28,7 @@ fn relay_provider_keys(state: &AppState, relay: &creds::Relay) -> Vec<(String, S
             continue;
         };
         for provider in providers.values() {
-            if belongs_to_account(provider, &relay.site_origin, relay.account_id) {
+            if belongs_to_relay(provider, &relay.site_origin, relay.account_id) {
                 keys.push((provider.id.clone(), app_type.as_str().to_string()));
             }
         }
@@ -60,7 +63,69 @@ fn reconcile(state: &AppState, relay_id: i64) -> Result<ReconciliationReport, Ap
     state.db.reconciliation_report(relay_id, &provider_keys)
 }
 
-// 测试留白说明：命令层只有「读行 + 归属 + 委托」三步薄壳，归属判据
-// （belongs_to_account）在 commands/relay.rs 有自己的测试，窗口数学在
-// relay/reconcile.rs 有自己的测试；AppState（要起全套服务）在这里造不出来，
-// 纯透传逻辑不为测而测。
+// 测试留白说明：归属判据（belongs_to_relay）与余额路径共用一份，它在
+// commands/relay.rs 有分支矩阵测试；窗口数学在 relay/reconcile.rs 有自己的测试。
+// 下面留的只有一条端到端回归：未登录行不许把别人账号的成本算进对账。
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn relay_row(site: &str, account_id: Option<i64>) -> creds::Relay {
+        creds::Relay {
+            id: 1,
+            site_origin: site.to_string(),
+            site_name: "test".to_string(),
+            backend_kind: crate::relay::backend::BackendKind::Sub2Api,
+            api_base_url: format!("{site}/v1"),
+            account_id,
+            account_label: String::new(),
+            login_identifier: String::new(),
+            auth_token: String::new(),
+            refresh_token: None,
+            token_expires_at: None,
+            user_agent: None,
+            cf_clearance: None,
+            pricing_synced_at: None,
+            sort_index: 0,
+        }
+    }
+
+    /// ⭐ **未登录的 relay 行，不能把同站别人账号的档位成本算进对账。**
+    ///
+    /// Task 3 review 抓出的：`relay_provider_keys` 若走宽松判据
+    /// （`belongs_to_account`，对 `account_id: None` 一律「算是」），B 账号的消费
+    /// 会被记到 A（未登录行）的对账里。会红的改法：换回 `belongs_to_account`。
+    #[test]
+    fn an_unlogged_relay_row_gets_no_costs_from_another_accounts_tier() {
+        let site = "https://bestapi.store";
+        let db = std::sync::Arc::new(crate::database::Database::memory().expect("init db"));
+
+        // 账号 9 的托管档位（id 由 provision 的生成端产出，满足 is_managed 形状）。
+        let b_tier = crate::relay::provision::provider_id_for(site, Some(9), 1);
+        let provider: crate::provider::Provider = serde_json::from_value(serde_json::json!({
+            "id": b_tier,
+            "name": "B 的档位",
+            "settingsConfig": { "auth": { "OPENAI_API_KEY": "sk-b" } },
+            "websiteUrl": site,
+            "meta": { "loongportAccountId": 9 }
+        }))
+        .expect("反序列化 provider");
+        db.save_provider("codex", &provider).expect("seed B");
+
+        let state = AppState::new(db.clone());
+
+        let unlogged = relay_row(site, None);
+        assert!(
+            relay_provider_keys(&state, &unlogged).is_empty(),
+            "⭐ 未登录的行不该把别人账号的档位算进自己的成本归属"
+        );
+
+        let owner = relay_row(site, Some(9));
+        assert_eq!(
+            relay_provider_keys(&state, &owner),
+            vec![(b_tier.clone(), "codex".to_string())],
+            "档位自己的账号必须能归属到它（对照组，证明上面不是本来就扫不到）"
+        );
+    }
+}

--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -3332,8 +3332,8 @@ fn refresh_live_for_current_tiers(state: &AppState, app_types: &[AppType]) {
 /// 答案。散成两份的后果是守卫与删除各认一套：守卫说「这条不是你的、不拦」，删除说
 /// 「这条是你的、删了」⇒ 恰好绕过守卫删掉正在用的配置，而那正是守卫要防的事。
 ///
-/// [`relay_balance_inputs`] 与对账命令 `relay_reconciliation`（`commands/reconcile.rs`）
-/// 也走这一个判据 —— 归属口径全仓只有这一份（plan §二：唯一数据源）。
+/// [`belongs_to_relay`]（严格版）才是余额 / 对账这些**归属**路径用的判据 ——
+/// 两者 `(account_id, 档位标记)` 的 `(None, Some)` 那一格语义相反，见它那边的说明。
 ///
 /// 三道判据缺一不可：
 ///
@@ -3365,6 +3365,41 @@ pub(crate) fn belongs_to_account(
     ) {
         (Some(want), Some(owner)) => want == owner,
         _ => true,
+    }
+}
+
+/// 这条 provider 是不是「这个 relay 行」名下的托管档位 —— **严格归属版**。
+///
+/// 与 [`belongs_to_account`] 只差一格：relay 行没登录（`account_id == None`）而档位
+/// 记了**别人的**账号时，这里**不认**。两个方向语义相反，不能合并：
+///
+/// - [`belongs_to_account`] 服务清理 / 守卫 —— 宁可多认不误删（同站没记归属的旧档位
+///   要能跟着清掉，`None` 一律「算是」）。
+/// - 这里服务**把事实记到某一行头上**的路径（余额 sk 收集、扣费对账的成本归属）——
+///   把别的账号的 sk / 成本算进未登录行，等于把 B 的消费记到 A 头上，比漏算更糟。
+///   这也是 `apps_using_this_accounts_tiers` 当年要额外加 `account_id.is_some()` 的
+///   同一类教训（见它那边的 ⚠️ 段）。
+///
+/// 判据即 `relay_balance_inputs` 原内联那份（`(None, Some(_)) => false`），收成函数
+/// 供余额与 `relay_reconciliation`（`commands/reconcile.rs`）共用 —— 归属口径只有一份。
+pub(crate) fn belongs_to_relay(
+    provider: &Provider,
+    site_origin: &str,
+    account_id: Option<i64>,
+) -> bool {
+    if !is_managed(provider) {
+        return false;
+    }
+    if provider.website_url.as_deref() != Some(site_origin) {
+        return false;
+    }
+    match (
+        account_id,
+        provider.meta.as_ref().and_then(|m| m.loongport_account_id),
+    ) {
+        (Some(want), Some(owner)) => want == owner,
+        (_, None) => true,
+        (None, Some(_)) => false,
     }
 }
 
@@ -4473,8 +4508,8 @@ fn remove_site_impl(state: &AppState, id: i64) -> Result<(), AppError> {
 
 /// 一行名下**全部托管档位**里的 base_url 与 sk。
 ///
-/// 归属判据走 [`belongs_to_account`]（与 [`tiers_of_site`] / `prune_stale_tiers` 同一来源），
-/// 但**跨全部 app 扫** —— 同一行的档位可能只挂在某一个 CLI 下（用户只给 codex 生成过 sk），
+/// 归属判据走 [`belongs_to_relay`]（严格版：未登录的行不认别人账号的档位），但
+/// **跨全部 app 扫** —— 同一行的档位可能只挂在某一个 CLI 下（用户只给 codex 生成过 sk），
 /// 按单个 app 查会在别的 app 上空手而归，让余额白白落到下一条路。
 ///
 /// 顺序不稳定不要紧：调用方（[`crate::relay::balance::resolve`]）是并发试完取第一个
@@ -4487,7 +4522,7 @@ fn relay_balance_inputs(state: &AppState, relay: &creds::Relay) -> (String, Vec<
             continue;
         };
         for provider in providers.values() {
-            if !belongs_to_account(provider, &relay.site_origin, relay.account_id) {
+            if !belongs_to_relay(provider, &relay.site_origin, relay.account_id) {
                 continue;
             }
             if let Some(sk) = provision::extract_api_key(&provider.settings_config, &app_type) {
@@ -8449,6 +8484,78 @@ mod tests {
         assert!(
             belongs_to_account(&legacy_provider, site, None),
             "删除方向对 `None` 仍是「算是我的」—— 那是旧数据能被清掉的前提"
+        );
+    }
+
+    /// ⭐ **还没登录的 relay 行，不能把同站别人账号的档位记到自己头上。**
+    ///
+    /// Task 3 review 抓出的：把 `relay_balance_inputs` 的内联判据收敛到
+    /// `belongs_to_account` 时，`(relay.account_id, 档位账号)` 的 `(None, Some)` 那格
+    /// 从「不认」翻成了「认」—— 未登录行会收走别人档位的 sk、对账会把别人的成本
+    /// 算进这一行。现在余额 / 对账走严格版 [`belongs_to_relay`]（还原原内联语义
+    /// `(None, Some(_)) => false`），清理 / 守卫路径仍走宽松版 [`belongs_to_account`]。
+    ///
+    /// 会红的改法：`relay_balance_inputs` 改回 `belongs_to_account`。
+    #[test]
+    fn an_unlogged_relay_row_is_not_attributed_another_accounts_tier() {
+        let site = "https://bestapi.store";
+        let db = std::sync::Arc::new(crate::database::Database::memory().expect("init db"));
+
+        // 账号 9 的档位，带真实 sk（否则「没收走」的断言没有判别力）。
+        let b_tier = provision::provider_id_for(site, Some(9), 1);
+        let mut b_provider = seeded_owned(&b_tier, "B 的档位", Some(site), 9);
+        b_provider.settings_config = serde_json::json!({ "auth": { "OPENAI_API_KEY": "sk-b" } });
+        db.save_provider("codex", &b_provider).expect("seed B");
+
+        // 同站一条没记账号的旧档位（升级前生成），也没有 sk —— 只用于钉住
+        // `(None, None) => true` 这格没被顺手改掉。
+        let legacy = provision::provider_id_for(site, None, 5);
+        db.save_provider("codex", &seeded(&legacy, "旧数据", Some(site)))
+            .expect("seed legacy");
+
+        let state = AppState::new(db.clone());
+        let mut unlogged = purchase_capability_relay(creds::BackendKind::Sub2Api);
+        unlogged.site_origin = site.to_string();
+        unlogged.account_id = None;
+
+        let (_, keys) = relay_balance_inputs(&state, &unlogged);
+        assert!(
+            keys.is_empty(),
+            "⭐ 未登录的行认不出归属 ⇒ 同站别人账号的档位（哪怕有 sk）不该被收走：{keys:?}"
+        );
+
+        // 对照组：账号 9 自己的行必须能拿到那把 sk —— 证明上面不是「本来就收不到」。
+        let mut owner_row = unlogged.clone();
+        owner_row.account_id = Some(9);
+        let (_, keys) = relay_balance_inputs(&state, &owner_row);
+        assert_eq!(
+            keys,
+            vec!["sk-b".to_string()],
+            "档位自己的账号必须收得到 sk"
+        );
+
+        // 两个判据函数在关键那格的分歧是**有意的**，钉住防止将来被「顺手统一」：
+        // 删除方向（belongs_to_account）对 None 宽松（旧数据要能清），
+        // 归属方向（belongs_to_relay）对 None 严格（别人的不能认领）。
+        let b_in_db = db
+            .get_provider_by_id(&b_tier, "codex")
+            .expect("query")
+            .expect("在");
+        assert!(
+            belongs_to_account(&b_in_db, site, None),
+            "删除方向对 `None` 仍宽松 —— 别改"
+        );
+        assert!(
+            !belongs_to_relay(&b_in_db, site, None),
+            "归属方向对 `(None, Some)` 必须严格 —— 别人的档位不能记到未登录行头上"
+        );
+        let legacy_in_db = db
+            .get_provider_by_id(&legacy, "codex")
+            .expect("query")
+            .expect("在");
+        assert!(
+            belongs_to_relay(&legacy_in_db, site, None),
+            "同站没记归属的旧档位仍是「可能是我的」（(None, None) => true）"
         );
     }
 

--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -3332,6 +3332,9 @@ fn refresh_live_for_current_tiers(state: &AppState, app_types: &[AppType]) {
 /// 答案。散成两份的后果是守卫与删除各认一套：守卫说「这条不是你的、不拦」，删除说
 /// 「这条是你的、删了」⇒ 恰好绕过守卫删掉正在用的配置，而那正是守卫要防的事。
 ///
+/// [`relay_balance_inputs`] 与对账命令 `relay_reconciliation`（`commands/reconcile.rs`）
+/// 也走这一个判据 —— 归属口径全仓只有这一份（plan §二：唯一数据源）。
+///
 /// 三道判据缺一不可：
 ///
 /// - `is_managed` —— 我们生成的（前缀 + 恰好 16 位小写 hex，即校验哈希形状）。用户手工加的 provider
@@ -3345,7 +3348,11 @@ fn refresh_live_for_current_tiers(state: &AppState, app_types: &[AppType]) {
 ///     代价是可能误伤同站另一账号的旧档位，但那些会在下次 provision 时重新生成并带上标记。
 ///   - **调用方不知道账号（`account_id` 为 `None`）** ⇒ 未登录的行（provision 不出档位）
 ///     或删站兜底路径，此时不按账号过滤。
-fn belongs_to_account(provider: &Provider, site_origin: &str, account_id: Option<i64>) -> bool {
+pub(crate) fn belongs_to_account(
+    provider: &Provider,
+    site_origin: &str,
+    account_id: Option<i64>,
+) -> bool {
     if !is_managed(provider) {
         return false;
     }
@@ -4466,8 +4473,8 @@ fn remove_site_impl(state: &AppState, id: i64) -> Result<(), AppError> {
 
 /// 一行名下**全部托管档位**里的 base_url 与 sk。
 ///
-/// 归属判据与 [`tiers_of_site`] 一致（站点 + 账号），但**跨全部 app 扫** ——
-/// 同一行的档位可能只挂在某一个 CLI 下（用户只给 codex 生成过 sk），
+/// 归属判据走 [`belongs_to_account`]（与 [`tiers_of_site`] / `prune_stale_tiers` 同一来源），
+/// 但**跨全部 app 扫** —— 同一行的档位可能只挂在某一个 CLI 下（用户只给 codex 生成过 sk），
 /// 按单个 app 查会在别的 app 上空手而归，让余额白白落到下一条路。
 ///
 /// 顺序不稳定不要紧：调用方（[`crate::relay::balance::resolve`]）是并发试完取第一个
@@ -4480,20 +4487,7 @@ fn relay_balance_inputs(state: &AppState, relay: &creds::Relay) -> (String, Vec<
             continue;
         };
         for provider in providers.values() {
-            if !is_managed(provider) {
-                continue;
-            }
-            if provider.website_url.as_deref() != Some(relay.site_origin.as_str()) {
-                continue;
-            }
-            // 与 `tiers_of_site` 同一张真值表：档位没记账号（旧数据）只按站点归。
-            let owner = provider.meta.as_ref().and_then(|m| m.loongport_account_id);
-            let belongs = match (relay.account_id, owner) {
-                (Some(want), Some(owner)) => want == owner,
-                (_, None) => true,
-                (None, Some(_)) => false,
-            };
-            if !belongs {
+            if !belongs_to_account(provider, &relay.site_origin, relay.account_id) {
                 continue;
             }
             if let Some(sk) = provision::extract_api_key(&provider.settings_config, &app_type) {

--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -45,7 +45,7 @@ use crate::provider::Provider;
 use crate::relay::{
     api, backend, balance, browser_bridge, chatgpt_app, creds, discovery, imagegen_mcp, login,
     model_verification::target as verification_target, newapi, newapi_provision, newapi_purchase,
-    pricing, provider_fingerprint, provision, purchase, remote_config,
+    pricing, provider_fingerprint, provision, purchase, reconcile, remote_config,
 };
 use crate::services::ProviderService;
 use crate::store::AppState;
@@ -4548,8 +4548,8 @@ pub async fn relay_balance(
         .map_err(|error| error.to_string())
 }
 
-async fn relay_balance_impl(
-    app_handle: &tauri::AppHandle,
+async fn relay_balance_impl<R: tauri::Runtime>(
+    app_handle: &tauri::AppHandle<R>,
     relay_id: i64,
 ) -> Result<balance::RowBalanceResult, AppError> {
     let (relay, base_url, api_keys) = {
@@ -4575,6 +4575,10 @@ async fn relay_balance_impl(
     )
     .await
     .usage;
+
+    // 余额快照是扣费对账的旁路采样，挂在成功解析之后：写入条件与失败兜底都在
+    // `reconcile::capture_balance_snapshot` 里，这里只出一条调用，不拖垮余额显示。
+    reconcile::capture_balance_snapshot(&app_handle.state::<AppState>().db, relay_id, &usage);
 
     Ok(balance::row_balance_result(usage, true))
 }
@@ -6192,6 +6196,124 @@ mod tests {
             rusqlite::params![chrono::Utc::now().timestamp() - 3600, relay_id],
         )
         .expect("expire saved relay token");
+    }
+
+    /// 起一个只回余额相关端点的本地 server（手法照 `relay/backend.rs` 的先例）。
+    async fn spawn_balance_server(app: axum::Router) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let origin = format!("http://{}", listener.local_addr().unwrap());
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (origin, task)
+    }
+
+    fn profile_router(balance: serde_json::Value) -> axum::Router {
+        use axum::{routing::get, Json, Router};
+        Router::new().route(
+            "/api/v1/user/profile",
+            get(move || async move { Json(balance) }),
+        )
+    }
+
+    #[tokio::test]
+    async fn relay_balance_writes_one_snapshot_on_successful_resolve() {
+        let (origin, server) = spawn_balance_server(profile_router(serde_json::json!({
+            "code": 0,
+            "message": "success",
+            "data": {
+                "id": 7,
+                "username": "Sub User",
+                "email": "sub@example.com",
+                "balance": 12.5,
+                "frozen_balance": 0.0
+            }
+        })))
+        .await;
+        let (app, relay_id) = saved_relay_app(&origin, discovery::BackendKind::Sub2Api);
+
+        let result = relay_balance_impl(app.handle(), relay_id)
+            .await
+            .expect("成功解析必须 Ok");
+
+        assert!(result.usage.success, "{:?}", result.usage.error);
+        let state = app.state::<AppState>();
+        let rows = state
+            .db
+            .list_balance_snapshots(relay_id, None)
+            .expect("读快照");
+        assert_eq!(rows.len(), 1, "成功路径恰好落一条快照");
+        assert_eq!(rows[0].balance_usd, 12.5);
+        assert_eq!(rows[0].source, "balance_query");
+        assert_eq!(rows[0].relay_id, relay_id);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn relay_balance_writes_no_snapshot_when_resolve_fails() {
+        use axum::{http::StatusCode, routing::get, Router};
+        let router = Router::new().route(
+            "/api/v1/user/profile",
+            get(|| async { StatusCode::UNAUTHORIZED }),
+        );
+        let (origin, server) = spawn_balance_server(router).await;
+        let (app, relay_id) = saved_relay_app(&origin, discovery::BackendKind::Sub2Api);
+
+        let result = relay_balance_impl(app.handle(), relay_id)
+            .await
+            .expect("失败路回 success:false，仍是 Ok");
+
+        assert!(!result.usage.success);
+        let state = app.state::<AppState>();
+        assert_eq!(
+            state
+                .db
+                .list_balance_snapshots(relay_id, None)
+                .expect("读快照")
+                .len(),
+            0,
+            "三路全败不能落快照"
+        );
+        server.abort();
+    }
+
+    /// ⭐ 快照写入失败绝不能拖垮余额显示（对账是旁路能力，plan §三.2）。
+    #[tokio::test]
+    async fn relay_balance_returns_balance_even_when_snapshot_insert_fails() {
+        let (origin, server) = spawn_balance_server(profile_router(serde_json::json!({
+            "code": 0,
+            "message": "success",
+            "data": {
+                "id": 7,
+                "username": "Sub User",
+                "email": "sub@example.com",
+                "balance": 9.9,
+                "frozen_balance": 0.0
+            }
+        })))
+        .await;
+        let (app, relay_id) = saved_relay_app(&origin, discovery::BackendKind::Sub2Api);
+        {
+            let state = app.state::<AppState>();
+            let conn = state.db.conn.lock().expect("lock memory database");
+            conn.execute("DROP TABLE relay_balance_snapshots", [])
+                .expect("删表制造写入失败");
+        }
+
+        let result = relay_balance_impl(app.handle(), relay_id)
+            .await
+            .expect("快照写入失败时余额命令仍必须 Ok");
+        assert!(result.usage.success);
+        assert_eq!(
+            result
+                .usage
+                .data
+                .as_ref()
+                .and_then(|items| items.first())
+                .and_then(|item| item.remaining),
+            Some(9.9)
+        );
+        server.abort();
     }
 
     #[tokio::test]

--- a/src-tauri/src/database/loongport_schema.rs
+++ b/src-tauri/src/database/loongport_schema.rs
@@ -48,7 +48,7 @@ use crate::error::AppError;
 /// LoongPort 自己的 schema 版本。加迁移时 +1。
 ///
 /// **与 `SCHEMA_VERSION`（上游那个）无关**，两者各自独立计数。
-pub(crate) const LOONGPORT_SCHEMA_VERSION: i32 = 13;
+pub(crate) const LOONGPORT_SCHEMA_VERSION: i32 = 14;
 
 /// 存版本号的表。**只有一行**（`id = 1`）。
 ///
@@ -232,6 +232,13 @@ pub(crate) fn apply(conn: &Connection) -> Result<(), AppError> {
                 log::info!("LoongPort 数据迁移 v12 → v13（中转站倍率刷新时间）");
                 add_relay_pricing_synced_at_column(conn)?;
                 set_version(conn, 13)?;
+            }
+            // v13 → v14：中转站余额快照表（扣费对账的唯一采样点）。
+            // 全新库由 `create_tables_on_conn` 直接建成本形态，这一步服务已停在 v13 的库。
+            13 => {
+                log::info!("LoongPort 数据迁移 v13 → v14（中转站余额快照表）");
+                crate::relay::reconcile::create_table(conn)?;
+                set_version(conn, 14)?;
             }
             other => {
                 return Err(AppError::Database(format!(
@@ -828,6 +835,32 @@ mod tests {
         assert_eq!(not_null, 0);
     }
 
+    /// ⭐ v13→v14 建中转站余额快照表：停在 v13 的老库升级后必须有表且可写。
+    #[test]
+    fn v13_to_v14_creates_the_balance_snapshot_table() {
+        let conn = mem();
+        ensure_version_table(&conn).expect("建版本表");
+        set_version(&conn, 13).expect("设为 v13");
+        assert!(
+            !Database::table_exists(&conn, "relay_balance_snapshots").expect("查表"),
+            "前提：升级前本表不存在"
+        );
+
+        apply(&conn).expect("迁移到 v14");
+
+        assert!(
+            Database::table_exists(&conn, "relay_balance_snapshots").expect("查表"),
+            "v13 → v14 必须建出余额快照表"
+        );
+        conn.execute(
+            "INSERT INTO relay_balance_snapshots (relay_id, balance_usd, source, created_at)
+             VALUES (1, 1.5, 'balance_query', 0)",
+            [],
+        )
+        .expect("迁移后必须可写");
+        assert_eq!(current_version(&conn).unwrap(), LOONGPORT_SCHEMA_VERSION);
+    }
+
     #[test]
     fn v8_to_v9_adds_backend_kind_and_defaults_existing_rows_to_sub2api() {
         let conn = mem();
@@ -884,7 +917,7 @@ mod tests {
     fn v9_migration_does_not_treat_schema_inspection_failure_as_missing_table() {
         let conn = mem();
         v8_relay_table(&conn);
-        conn.authorizer(Some(|context: AuthContext<'_>| match context.action {
+        let _ = conn.authorizer(Some(|context: AuthContext<'_>| match context.action {
             AuthAction::Read {
                 table_name: "sqlite_master",
                 ..

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -404,6 +404,9 @@ impl Database {
         // LoongPort：官网直连账号（vendor 层）
         crate::vendor::creds::create_table(conn)?;
 
+        // LoongPort：中转站余额快照（扣费对账）
+        crate::relay::reconcile::create_table(conn)?;
+
         Ok(())
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1625,6 +1625,7 @@ pub fn run() {
             commands::relay_list_sites,
             commands::relay_remove_site,
             commands::relay_balance,
+            commands::relay_reconciliation,
             commands::relay_purchase,
             commands::relay_restore_official_login,
             commands::list_verification_models,

--- a/src-tauri/src/relay/mod.rs
+++ b/src-tauri/src/relay/mod.rs
@@ -31,6 +31,7 @@
 //! - [`purchase`]：充值 WebView（**与 `login` 方向相反** —— 把已有登录态注入进充值页）
 //! - [`platform_map`]：sub2api 的 `platform` ↔ cc-switch 的 `AppType` 映射表（唯一一处映射数据）
 //! - [`provision`]：分组 → sk → codex provider 的展开
+//! - [`reconcile`]：扣费对账的余额快照表（`relay_balance_snapshots`，唯一采样点）
 //! - [`remote_config`]：远端配置（赞助商 + 邀请码，Ed25519 验签、三层回落）
 //! - [`stats`]：匿名使用统计（只报站点 host 与个数，默认开、可关）
 //! - [`managed`]：「这条 provider 是不是托管的」的唯一判据 + 各入口的守卫
@@ -80,6 +81,7 @@ pub(crate) mod provider_fingerprint;
 pub mod provision;
 pub mod purchase;
 pub mod purchase_session;
+pub mod reconcile;
 pub mod remote_config;
 pub mod stats;
 

--- a/src-tauri/src/relay/reconcile.rs
+++ b/src-tauri/src/relay/reconcile.rs
@@ -12,6 +12,7 @@
 //! 对账要把两种时间放在同一个窗口里比，单位必须一致。
 
 use rusqlite::{params, Connection};
+use serde::Serialize;
 
 use crate::database::lock_conn;
 use crate::error::AppError;
@@ -162,6 +163,202 @@ fn resolved_usd_balance(usage: &UsageResult) -> Option<f64> {
         .and_then(|items| items.first())
         .filter(|item| item.unit.as_deref() == Some("USD"))
         .and_then(|item| item.remaining)
+}
+
+// ============================================================================
+// 对账报告：窗口计算（plan §三.3 / §三.4）
+// ============================================================================
+
+/// 回看窗口长度：30 天。再早的快照不进报告 —— 中转站价格表会变，
+/// 太老的比值没有判别力，只会稀释基线。
+const LOOKBACK_SECS: i64 = 30 * 24 * 3600;
+
+/// 返回窗口数上限（新 → 旧）。正常频率（每次余额刷新一枚快照）远够不到，
+/// 这是防「高频刷新把 payload 撑爆」的安全阀。基线仍按回看期内全部有效窗口算。
+const MAX_WINDOWS: usize = 50;
+
+/// 扣减低于这个数（USD）的窗口不算有效消费 —— 精度噪音，不进比值也不进基线。
+const MIN_DEDUCTION_USD: f64 = 0.01;
+
+/// 基线（有效窗口 ratio 的中位数）需要的最少窗口数。不足就不判 `Suspicious`。
+const MIN_BASELINE_WINDOWS: usize = 3;
+
+/// `Suspicious` 阈值：`ratio <= baseline × 0.5`。刻意放宽到 2 倍 —— 吸收
+/// 「同账号在其他 key/工具上消费」「估算价格表偏差」这类已知噪音，宁可漏报不制造纠纷。
+const SUSPICIOUS_RATIO_FRACTION: f64 = 0.5;
+
+/// 一份对账报告（serde camelCase，给前端展示）。
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReconciliationReport {
+    pub relay_id: i64,
+    /// 回看期内的快照总数（配成窗口的原料，不是窗口数）。
+    pub snapshot_count: usize,
+    /// 有效窗口 ratio 的中位数；不足 [`MIN_BASELINE_WINDOWS`] 个有效窗口为 `None`。
+    pub baseline_ratio: Option<f64>,
+    /// 窗口按新 → 旧排，最多 [`MAX_WINDOWS`] 个。
+    pub windows: Vec<ReconciliationWindow>,
+}
+
+/// 相邻两枚快照构成的窗口 `[start_secs, end_secs)`。
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReconciliationWindow {
+    pub start_secs: i64,
+    pub end_secs: i64,
+    pub start_balance_usd: f64,
+    pub end_balance_usd: f64,
+    /// `end - start`：负数 = 扣减，正数 = 充值/返利。
+    pub balance_delta_usd: f64,
+    /// 窗口内该站名下 provider 的估算成本之和（`proxy_request_logs`，CAST 后的美元数）。
+    pub estimated_cost_usd: f64,
+    /// `估算 ÷ 扣减`，仅当扣减 > [`MIN_DEDUCTION_USD`] 且估算 > 0 时有值。
+    pub ratio: Option<f64>,
+    pub flag: WindowFlag,
+}
+
+/// 窗口标记。判据是业务事实，由后端定（前端只展示）：
+///
+/// - [`WindowFlag::SkippedTopUp`]：扣减 <= 0（充值/返利/赠送），不进比值、不进基线。
+/// - [`WindowFlag::InsufficientData`]：没有可算的比值（扣减太小或窗口内无估算数据）。
+/// - [`WindowFlag::Suspicious`]：`ratio <= baseline × 0.5` 且基线存在 ——
+///   实际扣减持续达到预期的 2 倍以上。
+/// - [`WindowFlag::Normal`]：其余有比值的窗口。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum WindowFlag {
+    Normal,
+    SkippedTopUp,
+    InsufficientData,
+    Suspicious,
+}
+
+impl Database {
+    /// 算某个中转站的扣费对账报告。
+    ///
+    /// `provider_keys` 是该站名下全部托管档位的 `(provider_id, app_type)` ——
+    /// 归属判据在命令层（`commands::relay::belongs_to_account`，与 `relay_balance_inputs`
+    /// 同一来源），本方法只管按这些 key 聚合 `proxy_request_logs` 的成本。
+    pub fn reconciliation_report(
+        &self,
+        relay_id: i64,
+        provider_keys: &[(String, String)],
+    ) -> Result<ReconciliationReport, AppError> {
+        let since = chrono::Utc::now().timestamp() - LOOKBACK_SECS;
+        let snapshots = self.list_balance_snapshots(relay_id, Some(since))?;
+        let snapshot_count = snapshots.len();
+
+        // 相邻两枚快照配成窗口（升序 ⇒ 窗口先按旧 → 新算，收尾再反转）。
+        let mut windows = Vec::with_capacity(snapshot_count.saturating_sub(1));
+        for pair in snapshots.windows(2) {
+            let (older, newer) = (&pair[0], &pair[1]);
+            let deduction = older.balance_usd - newer.balance_usd; // 正数 = 消费
+            let estimated =
+                self.estimated_cost_between(provider_keys, older.created_at, newer.created_at)?;
+            let ratio =
+                (deduction > MIN_DEDUCTION_USD && estimated > 0.0).then(|| estimated / deduction);
+            windows.push(ReconciliationWindow {
+                start_secs: older.created_at,
+                end_secs: newer.created_at,
+                start_balance_usd: older.balance_usd,
+                end_balance_usd: newer.balance_usd,
+                balance_delta_usd: newer.balance_usd - older.balance_usd,
+                estimated_cost_usd: estimated,
+                ratio,
+                flag: WindowFlag::Normal, // 占位；基线算出来后统一分类
+            });
+        }
+
+        let baseline_ratio = median_baseline(&windows);
+        for window in &mut windows {
+            window.flag = classify(window, baseline_ratio);
+        }
+        windows.reverse();
+        windows.truncate(MAX_WINDOWS);
+
+        Ok(ReconciliationReport {
+            relay_id,
+            snapshot_count,
+            baseline_ratio,
+            windows,
+        })
+    }
+
+    /// `[start_secs, end_secs)` 内、名下 provider 的估算成本之和（美元）。
+    ///
+    /// `total_cost_usd` 是 TEXT 美元字符串，必须 CAST（同
+    /// `services/usage_stats.rs` 的既有写法）。`(provider_id, app_type)` 成对匹配：
+    /// provider id 只在所属 app_type 那一栏下才是这条档位。
+    fn estimated_cost_between(
+        &self,
+        provider_keys: &[(String, String)],
+        start_secs: i64,
+        end_secs: i64,
+    ) -> Result<f64, AppError> {
+        if provider_keys.is_empty() {
+            return Ok(0.0);
+        }
+
+        let mut sql = String::from(
+            "SELECT COALESCE(SUM(CAST(total_cost_usd AS REAL)), 0)
+             FROM proxy_request_logs
+             WHERE created_at >= ?1 AND created_at < ?2
+               AND (provider_id, app_type) IN (VALUES ",
+        );
+        let mut args: Vec<Box<dyn rusqlite::ToSql>> =
+            vec![Box::new(start_secs), Box::new(end_secs)];
+        for (i, (provider_id, app_type)) in provider_keys.iter().enumerate() {
+            if i > 0 {
+                sql.push_str(", ");
+            }
+            sql.push_str("(?, ?)");
+            args.push(Box::new(provider_id.clone()));
+            args.push(Box::new(app_type.clone()));
+        }
+        // 关掉 `IN (VALUES` 那个开括号；每一行 `(?, ?)` 自带收尾。
+        sql.push(')');
+
+        let conn = lock_conn!(self.conn);
+        let params: Vec<&dyn rusqlite::ToSql> = args.iter().map(|a| a.as_ref()).collect();
+        conn.query_row(&sql, params.as_slice(), |row| row.get::<_, f64>(0))
+            .map_err(|e| AppError::Database(format!("聚合窗口估算成本失败: {e}")))
+    }
+}
+
+/// 有效窗口 ratio 的中位数；不足 [`MIN_BASELINE_WINDOWS`] 个有效窗口回 `None`。
+fn median_baseline(windows: &[ReconciliationWindow]) -> Option<f64> {
+    let mut ratios: Vec<f64> = windows.iter().filter_map(|w| w.ratio).collect();
+    if ratios.len() < MIN_BASELINE_WINDOWS {
+        return None;
+    }
+    ratios.sort_by(|a, b| a.total_cmp(b));
+    let mid = ratios.len() / 2;
+    Some(if ratios.len() % 2 == 1 {
+        ratios[mid]
+    } else {
+        (ratios[mid - 1] + ratios[mid]) / 2.0
+    })
+}
+
+/// 基线定完之后给窗口打标（[`WindowFlag`] 的判据见枚举文档）。
+fn classify(window: &ReconciliationWindow, baseline_ratio: Option<f64>) -> WindowFlag {
+    let deduction = window.start_balance_usd - window.end_balance_usd;
+    if deduction <= 0.0 {
+        WindowFlag::SkippedTopUp
+    } else if window.ratio.is_none() {
+        WindowFlag::InsufficientData
+    } else if let Some(baseline) = baseline_ratio {
+        let suspicious = window
+            .ratio
+            .is_some_and(|ratio| ratio <= baseline * SUSPICIOUS_RATIO_FRACTION);
+        if suspicious {
+            WindowFlag::Suspicious
+        } else {
+            WindowFlag::Normal
+        }
+    } else {
+        WindowFlag::Normal
+    }
 }
 
 #[cfg(test)]
@@ -371,6 +568,243 @@ mod tests {
         }
         // 不该 panic、不该把错误抛出去 —— 对账是旁路能力。
         capture_balance_snapshot(&db, 7, &usage(true, Some(12.5), Some("USD")));
+    }
+
+    // ------------------------------------------------------------------
+    // reconciliation_report：窗口计算（plan §三.3 / §三.4）
+    // ------------------------------------------------------------------
+
+    /// 本站名下那个托管 provider 的 `(provider_id, app_type)`。
+    /// id 形状满足 [`crate::relay::managed::is_managed`]：前缀 + 恰好 16 位小写 hex。
+    const OWNED_PID: &str = "loongport-0123456789abcdef";
+
+    fn owned_keys() -> Vec<(String, String)> {
+        vec![(OWNED_PID.to_string(), "codex".to_string())]
+    }
+
+    /// 插一条快照并把 `created_at` 改成指定值（测试没法等真实时钟拉开差距）。
+    fn snapshot_at(db: &Database, relay_id: i64, balance_usd: f64, created_at: i64) {
+        let id = db
+            .insert_balance_snapshot(relay_id, balance_usd, "balance_query")
+            .expect("插快照");
+        set_created_at(db, id, created_at);
+    }
+
+    /// 插一条代理日志。`total_cost_usd` 故意走 TEXT —— 生产列存的是美元字符串，
+    /// 聚合必须 CAST 才算得出数。
+    fn insert_log(
+        db: &Database,
+        request_id: &str,
+        provider_id: &str,
+        app_type: &str,
+        created_at: i64,
+        total_cost_usd: &str,
+    ) {
+        let conn = db.conn.lock().expect("拿连接");
+        conn.execute(
+            "INSERT INTO proxy_request_logs (
+                request_id, provider_id, app_type, model, latency_ms, status_code,
+                total_cost_usd, created_at
+            ) VALUES (?1, ?2, ?3, 'test-model', 100, 200, ?4, ?5)",
+            params![
+                request_id,
+                provider_id,
+                app_type,
+                total_cost_usd,
+                created_at
+            ],
+        )
+        .expect("插日志");
+    }
+
+    /// 测试时间基点：几小时前的整点，往前取偏移 —— 30 天回看窗口内的确定性时间轴。
+    fn base_time() -> i64 {
+        chrono::Utc::now().timestamp() - 10_000
+    }
+
+    #[test]
+    fn normal_windows_compute_ratio_and_median_baseline() {
+        let db = db();
+        let base = base_time();
+        // 三个窗口，每个扣减 2.0、估算 1.0 ⇒ ratio 全是 0.5，中位数也是 0.5。
+        for (offset, balance) in [(100, 10.0), (200, 8.0), (300, 6.0), (400, 4.0)] {
+            snapshot_at(&db, 7, balance, base + offset);
+        }
+        // 两条 TEXT 美元字符串相加（0.60 + 0.40）验证 CAST；t=100 计入、t=400 不计入。
+        insert_log(&db, "r0", OWNED_PID, "codex", base + 100, "0.60");
+        insert_log(&db, "r1", OWNED_PID, "codex", base + 150, "0.40");
+        insert_log(&db, "r2", OWNED_PID, "codex", base + 250, "1.0");
+        insert_log(&db, "r3", OWNED_PID, "codex", base + 399, "1.0");
+        insert_log(&db, "r4", OWNED_PID, "codex", base + 400, "999"); // 恰好落在窗口右端点之外
+
+        let report = db.reconciliation_report(7, &owned_keys()).expect("算报告");
+        assert_eq!(report.relay_id, 7);
+        assert_eq!(report.snapshot_count, 4);
+        assert_eq!(report.windows.len(), 3);
+        assert_eq!(report.baseline_ratio, Some(0.5));
+        // 新 → 旧
+        assert_eq!(report.windows[0].start_secs, base + 300);
+        assert_eq!(report.windows[2].start_secs, base + 100);
+        for w in &report.windows {
+            assert_eq!(w.estimated_cost_usd, 1.0, "估算成本 = {w:?}");
+            assert_eq!(w.ratio, Some(0.5));
+            assert_eq!(w.flag, WindowFlag::Normal);
+            assert_eq!(w.balance_delta_usd, -2.0, "余额变化是负数 = 扣减");
+        }
+    }
+
+    #[test]
+    fn topup_window_is_skipped_and_left_out_of_baseline() {
+        let db = db();
+        let base = base_time();
+        // 中间那个窗口余额上升（充值），其余正常消费。
+        for (offset, balance) in [(100, 10.0), (200, 8.0), (300, 12.0), (400, 10.0)] {
+            snapshot_at(&db, 7, balance, base + offset);
+        }
+        insert_log(&db, "r0", OWNED_PID, "codex", base + 150, "1.0");
+        insert_log(&db, "r1", OWNED_PID, "codex", base + 350, "1.0");
+
+        let report = db.reconciliation_report(7, &owned_keys()).expect("算报告");
+        // 有效窗口只有 2 个，基线要 >= 3 个 ⇒ None（充值窗口不进基线）。
+        assert_eq!(report.baseline_ratio, None);
+        let topup = &report.windows[1]; // 新→旧排完，充值窗口排中间
+        assert_eq!((topup.start_secs, topup.end_secs), (base + 200, base + 300));
+        assert_eq!(topup.flag, WindowFlag::SkippedTopUp);
+        assert_eq!(topup.ratio, None);
+        assert_eq!(topup.balance_delta_usd, 4.0, "充值后余额上升为正");
+        for w in [&report.windows[0], &report.windows[2]] {
+            assert_eq!(w.flag, WindowFlag::Normal);
+            assert_eq!(w.ratio, Some(0.5));
+        }
+    }
+
+    #[test]
+    fn tiny_deduction_and_zero_usage_are_insufficient_data() {
+        let db = db();
+        let base = base_time();
+        // [100,200) 扣减 0.005（>0 但 <= 0.01）；[200,300) 无估算数据；[300,400) 正常。
+        for (offset, balance) in [(100, 10.0), (200, 9.995), (300, 9.0), (400, 7.0)] {
+            snapshot_at(&db, 7, balance, base + offset);
+        }
+        insert_log(&db, "r0", OWNED_PID, "codex", base + 350, "1.0");
+
+        let report = db.reconciliation_report(7, &owned_keys()).expect("算报告");
+        // 只有 1 个有效窗口 ⇒ 基线 None。
+        assert_eq!(report.baseline_ratio, None);
+        let valid = &report.windows[0]; // [300,400)
+        assert_eq!(valid.ratio, Some(0.5));
+        assert_eq!(
+            valid.flag,
+            WindowFlag::Normal,
+            "没有基线时不判 Suspicious，但仍是有数据的窗口"
+        );
+        let no_usage = &report.windows[1]; // [200,300)
+        assert_eq!(no_usage.estimated_cost_usd, 0.0);
+        assert_eq!(no_usage.ratio, None);
+        assert_eq!(no_usage.flag, WindowFlag::InsufficientData);
+        let tiny = &report.windows[2]; // [100,200)
+        assert_eq!(tiny.ratio, None);
+        assert_eq!(tiny.flag, WindowFlag::InsufficientData);
+    }
+
+    #[test]
+    fn half_baseline_ratio_flags_suspicious() {
+        let db = db();
+        let base = base_time();
+        // 5 个窗口：ratio [1.0, 1.0, 1.0, 0.5, 0.3]，中位数 1.0。
+        // 0.5 恰好等于 baseline × 0.5 ⇒ 触发（判据是 <=），顺带钉住边界。
+        for (offset, balance) in [
+            (100, 10.0),
+            (200, 9.0),
+            (300, 8.0),
+            (400, 7.0),
+            (500, 6.5),
+            (600, 6.2),
+        ] {
+            snapshot_at(&db, 7, balance, base + offset);
+        }
+        insert_log(&db, "r0", OWNED_PID, "codex", base + 150, "1.0");
+        insert_log(&db, "r1", OWNED_PID, "codex", base + 250, "1.0");
+        insert_log(&db, "r2", OWNED_PID, "codex", base + 350, "1.0");
+        insert_log(&db, "r3", OWNED_PID, "codex", base + 450, "0.25"); // ratio 0.5
+        insert_log(&db, "r4", OWNED_PID, "codex", base + 550, "0.09"); // ratio 0.3
+
+        let report = db.reconciliation_report(7, &owned_keys()).expect("算报告");
+        assert_eq!(report.baseline_ratio, Some(1.0));
+        // 新 → 旧：windows[0] = [500,600)（ratio 0.3），windows[1] = [400,500)（ratio 0.5）。
+        assert_eq!(report.windows[0].flag, WindowFlag::Suspicious);
+        assert_eq!(report.windows[1].flag, WindowFlag::Suspicious);
+        for w in &report.windows[2..] {
+            assert_eq!(w.flag, WindowFlag::Normal);
+        }
+    }
+
+    #[test]
+    fn other_providers_and_apps_do_not_leak_into_estimates() {
+        let db = db();
+        let base = base_time();
+        snapshot_at(&db, 7, 10.0, base + 100);
+        snapshot_at(&db, 7, 8.0, base + 200);
+        // 另一个中转站的托管 provider、同 id 挂在别的 app_type 下，都不许混进来。
+        insert_log(&db, "mine", OWNED_PID, "codex", base + 150, "0.50");
+        insert_log(
+            &db,
+            "foreign",
+            "loongport-fedcba9876543210",
+            "codex",
+            base + 150,
+            "999",
+        );
+        insert_log(&db, "wrong-app", OWNED_PID, "claude", base + 150, "888");
+        // 别的 relay 的快照也不该配进本站的窗口。
+        snapshot_at(&db, 8, 100.0, base + 150);
+
+        let report = db.reconciliation_report(7, &owned_keys()).expect("算报告");
+        assert_eq!(report.windows.len(), 1, "别的 relay 的快照不该产生窗口");
+        let w = &report.windows[0];
+        assert_eq!(w.estimated_cost_usd, 0.50, "估算成本 = {w:?}");
+        assert_eq!(w.ratio, Some(0.25));
+    }
+
+    #[test]
+    fn snapshots_older_than_30_days_are_ignored() {
+        let db = db();
+        let now = chrono::Utc::now().timestamp();
+        snapshot_at(&db, 7, 100.0, now - 40 * 86_400);
+        snapshot_at(&db, 7, 90.0, now - 35 * 86_400);
+        snapshot_at(&db, 7, 10.0, now - 5 * 86_400);
+        snapshot_at(&db, 7, 8.0, now - 86_400);
+
+        let report = db.reconciliation_report(7, &owned_keys()).expect("算报告");
+        assert_eq!(report.snapshot_count, 2, "30 天窗口外的快照不进报告");
+        assert_eq!(report.windows.len(), 1);
+        assert_eq!(report.windows[0].start_secs, now - 5 * 86_400);
+    }
+
+    #[test]
+    fn windows_are_capped_at_50_newest_first() {
+        let db = db();
+        let now = chrono::Utc::now().timestamp();
+        // 60 枚快照（每小时一枚）⇒ 59 个窗口，只回最近 50 个。
+        for i in 0..60 {
+            snapshot_at(&db, 7, 100.0 - i as f64, now - (60 - i) * 3600);
+        }
+
+        let report = db.reconciliation_report(7, &owned_keys()).expect("算报告");
+        assert_eq!(report.snapshot_count, 60);
+        assert_eq!(report.windows.len(), 50);
+        assert_eq!(report.windows[0].end_secs, now - 3600, "最新的窗口排最前");
+    }
+
+    #[test]
+    fn report_without_enough_snapshots_is_empty() {
+        let db = db();
+        snapshot_at(&db, 7, 10.0, base_time());
+
+        let report = db.reconciliation_report(7, &owned_keys()).expect("算报告");
+        assert_eq!(report.snapshot_count, 1);
+        assert!(report.windows.is_empty(), "快照不足两枚 ⇒ 没有窗口");
+        assert_eq!(report.baseline_ratio, None);
     }
 
     /// 老库（v13，没有本表）升级后必须有这张表且可用。

--- a/src-tauri/src/relay/reconcile.rs
+++ b/src-tauri/src/relay/reconcile.rs
@@ -15,6 +15,7 @@ use rusqlite::{params, Connection};
 
 use crate::database::lock_conn;
 use crate::error::AppError;
+use crate::provider::UsageResult;
 use crate::Database;
 
 /// 一行余额快照。
@@ -128,6 +129,39 @@ impl Database {
         }
         Ok(out)
     }
+}
+
+/// `relay_balance_impl` 成功解析余额之后的旁路采样：满足写入条件就落一条快照。
+///
+/// 写入条件（plan §三.2）：`usage.success` 且**第一条**数据有 `remaining`、`unit` 是
+/// `"USD"`（与 `row_balance_result` 取同一条 —— 那边判低余额告警也是取第一条）。
+/// 失败路径不写：`success:false` 是常态（如 sub2api 订阅型分组 sk 路查不到余额），
+/// 天然无快照，对账页显示「快照不足」即可。
+///
+/// **写快照失败不影响余额显示**：对账是旁路能力，这里只记日志，绝不向上抛。
+pub fn capture_balance_snapshot(db: &Database, relay_id: i64, usage: &UsageResult) {
+    let Some(balance_usd) = resolved_usd_balance(usage) else {
+        return;
+    };
+    if let Err(error) = db.insert_balance_snapshot(relay_id, balance_usd, "balance_query") {
+        log::warn!("写入余额快照失败（不影响余额显示，对账页会显示快照不足）: {error}");
+    }
+}
+
+/// 从一次解析结果里取出可入账的 USD 余额；条件不满足就回 `None`。
+///
+/// 取**第一条**：与 `balance::row_balance_result` 判低余额告警取同一条，
+/// 两边口径必须一致，否则会出现「告警说 4.9、快照记的是另一条的 30」。
+fn resolved_usd_balance(usage: &UsageResult) -> Option<f64> {
+    if !usage.success {
+        return None;
+    }
+    usage
+        .data
+        .as_ref()
+        .and_then(|items| items.first())
+        .filter(|item| item.unit.as_deref() == Some("USD"))
+        .and_then(|item| item.remaining)
 }
 
 #[cfg(test)]
@@ -249,6 +283,94 @@ mod tests {
         let db = db();
         let conn = db.conn.lock().expect("拿连接");
         create_table(&conn).expect("再建一次不该报错");
+    }
+
+    // ------------------------------------------------------------------
+    // capture_balance_snapshot：写入条件（plan §三.2）
+    // ------------------------------------------------------------------
+
+    fn usage(success: bool, remaining: Option<f64>, unit: Option<&str>) -> UsageResult {
+        UsageResult {
+            success,
+            data: Some(vec![crate::provider::UsageData {
+                plan_name: None,
+                extra: None,
+                is_valid: None,
+                invalid_message: None,
+                total: None,
+                used: None,
+                remaining,
+                unit: unit.map(str::to_string),
+            }]),
+            error: None,
+        }
+    }
+
+    #[test]
+    fn capture_writes_one_snapshot_on_success_with_usd_remaining() {
+        let db = db();
+        capture_balance_snapshot(&db, 7, &usage(true, Some(12.5), Some("USD")));
+
+        let rows = db.list_balance_snapshots(7, None).expect("读取");
+        assert_eq!(rows.len(), 1, "成功 + USD 余额必须落一条快照");
+        assert_eq!(rows[0].balance_usd, 12.5);
+        assert_eq!(rows[0].source, "balance_query");
+    }
+
+    #[test]
+    fn capture_skips_unsuccessful_resolve() {
+        let db = db();
+        // 失败路拿到什么 data 都不算数。
+        capture_balance_snapshot(&db, 7, &usage(false, Some(12.5), Some("USD")));
+
+        assert_eq!(
+            db.list_balance_snapshots(7, None).expect("读取").len(),
+            0,
+            "success:false 是常态（订阅型分组查不到钱包余额），不能落快照"
+        );
+    }
+
+    #[test]
+    fn capture_skips_when_data_or_remaining_is_missing() {
+        let db = db();
+        let no_data = UsageResult {
+            success: true,
+            data: None,
+            error: None,
+        };
+        capture_balance_snapshot(&db, 7, &no_data);
+        capture_balance_snapshot(&db, 7, &usage(true, None, Some("USD")));
+
+        assert_eq!(
+            db.list_balance_snapshots(7, None).expect("读取").len(),
+            0,
+            "没有 remaining 就没有可入账的数字"
+        );
+    }
+
+    #[test]
+    fn capture_skips_non_usd_unit() {
+        let db = db();
+        capture_balance_snapshot(&db, 7, &usage(true, Some(12.5), Some("CNY")));
+        capture_balance_snapshot(&db, 7, &usage(true, Some(12.5), None));
+
+        assert_eq!(
+            db.list_balance_snapshots(7, None).expect("读取").len(),
+            0,
+            "快照列名就是 balance_usd，非 USD 的数字进来是错的单位口径"
+        );
+    }
+
+    #[test]
+    fn capture_swallows_insert_failure() {
+        let db = db();
+        {
+            let conn = db.conn.lock().expect("拿连接");
+            conn.execute("DROP TABLE relay_balance_snapshots", [])
+                .expect("删表制造写入失败");
+        }
+        // 不该 panic、不该把错误抛出去 —— 对账是旁路能力。
+        capture_balance_snapshot(&db, 7, &usage(true, Some(12.5), Some("USD")));
     }
 
     /// 老库（v13，没有本表）升级后必须有这张表且可用。

--- a/src-tauri/src/relay/reconcile.rs
+++ b/src-tauri/src/relay/reconcile.rs
@@ -237,7 +237,7 @@ impl Database {
     /// 算某个中转站的扣费对账报告。
     ///
     /// `provider_keys` 是该站名下全部托管档位的 `(provider_id, app_type)` ——
-    /// 归属判据在命令层（`commands::relay::belongs_to_account`，与 `relay_balance_inputs`
+    /// 归属判据在命令层（`commands::relay::belongs_to_relay`，与 `relay_balance_inputs`
     /// 同一来源），本方法只管按这些 key 聚合 `proxy_request_logs` 的成本。
     pub fn reconciliation_report(
         &self,

--- a/src-tauri/src/relay/reconcile.rs
+++ b/src-tauri/src/relay/reconcile.rs
@@ -1,0 +1,307 @@
+//! `relay_balance_snapshots` 表：中转站余额快照（扣费对账的唯一采样点）。
+//!
+//! ## 快照从哪来
+//!
+//! 写入挂在 `relay_balance_impl` 成功解析余额之后（前端行级刷新、充值关窗都会触发），
+//! 本模块只负责表 + DAO；对账窗口计算是后续任务的事。
+//!
+//! ## `created_at` 的单位：Unix 秒
+//!
+//! 与 `proxy_request_logs.created_at` 同单位 —— 那边写的是
+//! `chrono::Utc::now().timestamp()`（秒，见 `proxy/usage/logger.rs`）。
+//! 对账要把两种时间放在同一个窗口里比，单位必须一致。
+
+use rusqlite::{params, Connection};
+
+use crate::database::lock_conn;
+use crate::error::AppError;
+use crate::Database;
+
+/// 一行余额快照。
+#[derive(Debug, Clone, PartialEq)]
+pub struct BalanceSnapshot {
+    pub id: i64,
+    pub relay_id: i64,
+    pub balance_usd: f64,
+    /// 采样来源（如 `balance_query`）。
+    pub source: String,
+    /// Unix 秒，与 `proxy_request_logs.created_at` 同单位。
+    pub created_at: i64,
+}
+
+/// 建表 + 索引（幂等）。
+///
+/// 由 `create_tables_on_conn`（全新库）与 LoongPort 迁移 v13 → v14（老库）共同调用，
+/// 两边建的必须是同一形态 —— 见 `database/loongport_schema.rs` 的头注释。
+pub fn create_table(conn: &Connection) -> Result<(), AppError> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS relay_balance_snapshots (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            relay_id INTEGER NOT NULL,
+            balance_usd REAL NOT NULL,
+            source TEXT NOT NULL DEFAULT 'balance_query',
+            created_at INTEGER NOT NULL
+        )",
+        [],
+    )
+    .map_err(|e| AppError::Database(format!("创建 relay_balance_snapshots 表失败: {e}")))?;
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_relay_balance_snapshots_relay_time
+         ON relay_balance_snapshots (relay_id, created_at)",
+        [],
+    )
+    .map_err(|e| AppError::Database(format!("创建 relay_balance_snapshots 索引失败: {e}")))?;
+
+    Ok(())
+}
+
+impl Database {
+    /// 记一条余额快照，返回行 id。`created_at` 取当前 Unix 秒。
+    pub fn insert_balance_snapshot(
+        &self,
+        relay_id: i64,
+        balance_usd: f64,
+        source: &str,
+    ) -> Result<i64, AppError> {
+        let conn = lock_conn!(self.conn);
+        let created_at = chrono::Utc::now().timestamp();
+        conn.execute(
+            "INSERT INTO relay_balance_snapshots (relay_id, balance_usd, source, created_at)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![relay_id, balance_usd, source, created_at],
+        )
+        .map_err(|e| AppError::Database(format!("写入余额快照失败: {e}")))?;
+        Ok(conn.last_insert_rowid())
+    }
+
+    /// 列出某个中转站的快照，按时间升序（对账窗口要按先后配对）。
+    ///
+    /// `since_secs` 给了就只取该时刻（含）之后的，单位与 `created_at` 一致（Unix 秒）。
+    pub fn list_balance_snapshots(
+        &self,
+        relay_id: i64,
+        since_secs: Option<i64>,
+    ) -> Result<Vec<BalanceSnapshot>, AppError> {
+        let conn = lock_conn!(self.conn);
+        let mut stmt = match since_secs {
+            Some(_) => conn
+                .prepare(
+                    "SELECT id, relay_id, balance_usd, source, created_at
+                     FROM relay_balance_snapshots
+                     WHERE relay_id = ?1 AND created_at >= ?2
+                     ORDER BY created_at, id",
+                )
+                .map_err(|e| AppError::Database(format!("准备查询余额快照失败: {e}")))?,
+            None => conn
+                .prepare(
+                    "SELECT id, relay_id, balance_usd, source, created_at
+                     FROM relay_balance_snapshots
+                     WHERE relay_id = ?1
+                     ORDER BY created_at, id",
+                )
+                .map_err(|e| AppError::Database(format!("准备查询余额快照失败: {e}")))?,
+        };
+
+        let map_row = |row: &rusqlite::Row<'_>| {
+            Ok(BalanceSnapshot {
+                id: row.get(0)?,
+                relay_id: row.get(1)?,
+                balance_usd: row.get(2)?,
+                source: row.get(3)?,
+                created_at: row.get(4)?,
+            })
+        };
+
+        let rows = match since_secs {
+            Some(since) => stmt
+                .query_map(params![relay_id, since], map_row)
+                .map_err(|e| AppError::Database(format!("查询余额快照失败: {e}")))?,
+            None => stmt
+                .query_map(params![relay_id], map_row)
+                .map_err(|e| AppError::Database(format!("查询余额快照失败: {e}")))?,
+        };
+
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(|e| AppError::Database(format!("读取余额快照失败: {e}")))?);
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn db() -> Database {
+        Database::memory().expect("内存库")
+    }
+
+    /// 测试里没法等真实时钟拉开差距，插入后直接改库里的 `created_at`。
+    fn set_created_at(db: &Database, id: i64, created_at: i64) {
+        let conn = db.conn.lock().expect("拿连接");
+        conn.execute(
+            "UPDATE relay_balance_snapshots SET created_at = ?1 WHERE id = ?2",
+            params![created_at, id],
+        )
+        .expect("改 created_at");
+    }
+
+    #[test]
+    fn insert_then_read_roundtrips_every_field() {
+        let db = db();
+        let id = db
+            .insert_balance_snapshot(7, 12.5, "balance_query")
+            .expect("插入");
+
+        let rows = db.list_balance_snapshots(7, None).expect("读取");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(
+            rows[0],
+            BalanceSnapshot {
+                id,
+                relay_id: 7,
+                balance_usd: 12.5,
+                source: "balance_query".to_string(),
+                created_at: rows[0].created_at, // 时间戳由 DAO 打，见下面单独断言
+            }
+        );
+        // created_at 是「现在」的 Unix 秒 —— 与真实时钟比 ±1 天足够判单位：
+        // 若误存成毫秒，这个差会是 1e9 级。
+        let now = chrono::Utc::now().timestamp();
+        assert!(
+            (rows[0].created_at - now).abs() < 86_400,
+            "created_at 应是 Unix 秒，实际 {}（now = {now}）",
+            rows[0].created_at
+        );
+    }
+
+    #[test]
+    fn snapshots_are_filtered_by_relay() {
+        let db = db();
+        db.insert_balance_snapshot(1, 10.0, "balance_query")
+            .expect("插入");
+        db.insert_balance_snapshot(2, 20.0, "balance_query")
+            .expect("插入");
+        db.insert_balance_snapshot(1, 30.0, "balance_query")
+            .expect("插入");
+
+        let rows = db.list_balance_snapshots(1, None).expect("读取");
+        assert_eq!(
+            rows.iter().map(|r| r.balance_usd).collect::<Vec<_>>(),
+            vec![10.0, 30.0],
+            "只能看到 relay 1 的快照"
+        );
+    }
+
+    #[test]
+    fn snapshots_are_ordered_by_created_at_ascending() {
+        let db = db();
+        let a = db
+            .insert_balance_snapshot(3, 1.0, "balance_query")
+            .expect("插入");
+        let b = db
+            .insert_balance_snapshot(3, 2.0, "balance_query")
+            .expect("插入");
+        let c = db
+            .insert_balance_snapshot(3, 4.0, "balance_query")
+            .expect("插入");
+        // 故意让插入顺序与时间顺序相反。
+        set_created_at(&db, a, 300);
+        set_created_at(&db, b, 100);
+        set_created_at(&db, c, 200);
+
+        let rows = db.list_balance_snapshots(3, None).expect("读取");
+        assert_eq!(
+            rows.iter().map(|r| r.id).collect::<Vec<_>>(),
+            vec![b, c, a],
+            "必须按 created_at 升序 —— 对账窗口按先后配对快照"
+        );
+    }
+
+    #[test]
+    fn since_secs_keeps_snapshots_at_or_after_the_boundary() {
+        let db = db();
+        let a = db
+            .insert_balance_snapshot(4, 1.0, "balance_query")
+            .expect("插入");
+        let b = db
+            .insert_balance_snapshot(4, 2.0, "balance_query")
+            .expect("插入");
+        let c = db
+            .insert_balance_snapshot(4, 4.0, "balance_query")
+            .expect("插入");
+        set_created_at(&db, a, 100);
+        set_created_at(&db, b, 200);
+        set_created_at(&db, c, 300);
+
+        let rows = db.list_balance_snapshots(4, Some(200)).expect("读取");
+        assert_eq!(
+            rows.iter().map(|r| r.id).collect::<Vec<_>>(),
+            vec![b, c],
+            "边界值要包含（>=），更早的丢掉"
+        );
+    }
+
+    #[test]
+    fn create_table_is_idempotent() {
+        let db = db();
+        let conn = db.conn.lock().expect("拿连接");
+        create_table(&conn).expect("再建一次不该报错");
+    }
+
+    /// 老库（v13，没有本表）升级后必须有这张表且可用。
+    #[test]
+    fn an_upgraded_database_gets_the_table() {
+        let conn = Connection::open_in_memory().expect("内存库");
+        // 造一个停在 v13 的库：版本表写 13，不建快照表。
+        conn.execute(
+            "CREATE TABLE loongport_schema_version (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                version INTEGER NOT NULL
+            )",
+            [],
+        )
+        .expect("建版本表");
+        conn.execute(
+            "INSERT INTO loongport_schema_version (id, version) VALUES (1, 13)",
+            [],
+        )
+        .expect("设为 v13");
+        assert!(
+            !crate::Database::table_exists(&conn, "relay_balance_snapshots").expect("查表"),
+            "前提：升级前本表不存在（否则这条闸没有判别力）"
+        );
+
+        crate::database::loongport_schema::apply(&conn).expect("迁移");
+
+        assert!(
+            crate::Database::table_exists(&conn, "relay_balance_snapshots").expect("查表"),
+            "v13 → v14 必须建出快照表"
+        );
+        conn.execute(
+            "INSERT INTO relay_balance_snapshots (relay_id, balance_usd, source, created_at)
+             VALUES (7, 12.5, 'balance_query', 1000)",
+            [],
+        )
+        .expect("迁移后必须可写");
+        let n: i64 = conn
+            .query_row("SELECT COUNT(*) FROM relay_balance_snapshots", [], |r| {
+                r.get(0)
+            })
+            .expect("迁移后必须可读");
+        assert_eq!(n, 1);
+        let version: i32 = conn
+            .query_row(
+                "SELECT version FROM loongport_schema_version WHERE id = 1",
+                [],
+                |r| r.get(0),
+            )
+            .expect("读版本");
+        assert_eq!(
+            version,
+            crate::database::loongport_schema::LOONGPORT_SCHEMA_VERSION
+        );
+    }
+}

--- a/src/components/relay/ReconcileDialog.tsx
+++ b/src/components/relay/ReconcileDialog.tsx
@@ -151,9 +151,11 @@ export function ReconcileDialog({
               填 0 或 "--" 都是在替后端猜事实。 */}
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm">
             <span className="text-muted-foreground">
-              {t("loongport.reconcile.snapshotCount", {
-                count: report?.snapshotCount ?? 0,
-              })}
+              {report
+                ? t("loongport.reconcile.snapshotCount", {
+                    count: report.snapshotCount,
+                  })
+                : ""}
             </span>
             <span className="flex items-center gap-1.5 text-muted-foreground">
               {t("loongport.reconcile.baselineRatioLabel")}
@@ -189,8 +191,7 @@ export function ReconcileDialog({
           ) : error ? (
             <div className="flex flex-col items-center gap-2 py-6 text-sm text-red-500">
               <span>
-                {t("loongport.reconcile.loadFailed")}
-                {error ? `：${error}` : ""}
+                {t("loongport.reconcile.loadFailed")}：{error}
               </span>
               <Button
                 type="button"

--- a/src/components/relay/ReconcileDialog.tsx
+++ b/src/components/relay/ReconcileDialog.tsx
@@ -1,0 +1,268 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { Loader2, RefreshCw, Scale } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { fmtUsd } from "@/components/usage/format";
+
+import { relayApi, type ReconciliationWindow } from "@/lib/api/relay";
+import { rowBalanceKeys } from "./useRowBalanceQuery";
+import {
+  reconciliationKeys,
+  useReconciliationQuery,
+} from "./useReconciliationQuery";
+
+/**
+ * 一行中转站的扣费对账弹窗。
+ *
+ * ## 前端只展示后端事实
+ *
+ * `suspicious` / `skippedTopUp` / `insufficientData` 全部由后端判定
+ * （`relay_reconciliation` 的 `WindowFlag`），这里只把它们映射成徽标、文案与颜色；
+ * `ratio` / `baselineRatio` 为 `null` 时**留空** —— 不猜、不算、不填 0
+ * （`ratio = null` 意味着「没有可算的比值」，显示 0 会让用户以为估算免费）。
+ *
+ * ## 「立即采样」复用行级刷新链路，不新增后端命令
+ *
+ * 采样就是触发既有的 `relayApi.balance(relayId)`（后端查完余额顺手落一枚快照），
+ * 完成后把结果写回 `rowBalanceKeys` 缓存（行上那条用量条跟着变新），再 invalidate
+ * 对账 query 让 react-query 自己重拉报告。没有一个专门「采样」的命令。
+ */
+export interface ReconcileDialogProps {
+  relayId: number;
+  /** 行显示名（站名 / 账号）。弹窗描述行里定位「这是哪个账号的对账」。 */
+  relayLabel: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/** 窗口起止时刻。秒 → 本地短格式；同一格里两段挨着排。 */
+function fmtWindowTime(secs: number): string {
+  return new Date(secs * 1000).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/** 比值。有值才显示两位小数；`null` 由调用处留空。 */
+function fmtRatio(ratio: number): string {
+  return ratio.toFixed(2);
+}
+
+/**
+ * 状态徽标。`normal` 与 `insufficientData` 不出徽标 —— 前者无事可说，
+ * 后者的语义已经由「比值留空」表达了（再标一个「数据不足」只是同一件事说两遍）。
+ */
+function FlagBadge({ flag }: { flag: ReconciliationWindow["flag"] }) {
+  const { t } = useTranslation();
+
+  if (flag === "suspicious") {
+    return (
+      <span
+        className="inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium text-red-600 ring-1 ring-inset ring-red-500/30 dark:text-red-400"
+        title={t("loongport.reconcile.flagSuspiciousHint")}
+      >
+        {t("loongport.reconcile.flagSuspicious")}
+      </span>
+    );
+  }
+  if (flag === "skippedTopUp") {
+    return (
+      <span
+        className="inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground ring-1 ring-inset ring-border"
+        title={t("loongport.reconcile.flagSkippedTopUpHint")}
+      >
+        {t("loongport.reconcile.flagSkippedTopUp")}
+      </span>
+    );
+  }
+  return null;
+}
+
+export function ReconcileDialog({
+  relayId,
+  relayLabel,
+  open,
+  onOpenChange,
+}: ReconcileDialogProps) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  // 弹窗没开就不查：报告是「点开对账」这个动作的产物，不该在页面加载时预取。
+  const { report, loading, error, refetch } = useReconciliationQuery(relayId, {
+    enabled: open,
+  });
+  // 「立即采样」的进行态。作用域只在这个弹窗里，不需要走 `useRowBusy`
+  // —— 那套集合服务的是「多行并列、各自的按钮互不干扰」，这里天然只有一个按钮。
+  const [sampling, setSampling] = useState(false);
+
+  const sampleNow = async () => {
+    if (sampling) return;
+    setSampling(true);
+    try {
+      const balance = await relayApi.balance(relayId);
+      // 采样顺带刷新了余额 —— 把结果写回行上那条用量条的缓存，让两个视图同源。
+      queryClient.setQueryData(rowBalanceKeys.row("relay", relayId), balance);
+      await queryClient.invalidateQueries({
+        queryKey: reconciliationKeys.report(relayId),
+      });
+    } catch (e) {
+      // 用户明确点了「立即采样」，采样没做成要让他知道（否则按钮点完毫无反应）。
+      toast.error(String(e));
+    } finally {
+      setSampling(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Scale className="h-4 w-4 text-muted-foreground" />
+            {t("loongport.reconcile.title")}
+          </DialogTitle>
+          <DialogDescription className="truncate">
+            {relayLabel}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-6 py-4">
+          {/* 摘要行：快照数 + 基线比值 + 立即采样。
+              ⚠️ baselineRatio 为 null 时值留空 —— 不足 3 个有效窗口判不出基线，
+              填 0 或 "--" 都是在替后端猜事实。 */}
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm">
+            <span className="text-muted-foreground">
+              {t("loongport.reconcile.snapshotCount", {
+                count: report?.snapshotCount ?? 0,
+              })}
+            </span>
+            <span className="flex items-center gap-1.5 text-muted-foreground">
+              {t("loongport.reconcile.baselineRatioLabel")}
+              <span className="tabular-nums">
+                {report?.baselineRatio != null
+                  ? fmtRatio(report.baselineRatio)
+                  : ""}
+              </span>
+            </span>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="ml-auto h-7 gap-1"
+              disabled={sampling}
+              onClick={() => void sampleNow()}
+            >
+              {sampling ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5" />
+              )}
+              {t("loongport.reconcile.sampleNow")}
+            </Button>
+          </div>
+
+          {/* 首次加载：居中转圈。后台刷新（loading 且已有 report）不打断表格 ——
+              keep-last-good 语义，见 useReconciliationQuery 的文档。 */}
+          {loading && !report ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : error ? (
+            <div className="flex flex-col items-center gap-2 py-6 text-sm text-red-500">
+              <span>
+                {t("loongport.reconcile.loadFailed")}
+                {error ? `：${error}` : ""}
+              </span>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-7"
+                onClick={() => void refetch()}
+              >
+                {t("loongport.reconcile.retry")}
+              </Button>
+            </div>
+          ) : report && report.windows.length > 0 ? (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="h-9 px-3">
+                    {t("loongport.reconcile.colWindow")}
+                  </TableHead>
+                  <TableHead className="h-9 px-3 text-right">
+                    {t("loongport.reconcile.colEstimatedCost")}
+                  </TableHead>
+                  <TableHead className="h-9 px-3 text-right">
+                    {t("loongport.reconcile.colBalanceChange")}
+                  </TableHead>
+                  <TableHead className="h-9 px-3 text-right">
+                    {t("loongport.reconcile.colRatio")}
+                  </TableHead>
+                  <TableHead className="h-9 px-3">
+                    {t("loongport.reconcile.colStatus")}
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {/* 报告本身按新 → 旧排好，这里照序渲染。 */}
+                {report.windows.map((win) => (
+                  <TableRow key={`${win.startSecs}-${win.endSecs}`}>
+                    <TableCell className="whitespace-nowrap px-3 py-2 text-xs text-muted-foreground">
+                      {fmtWindowTime(win.startSecs)} –{" "}
+                      {fmtWindowTime(win.endSecs)}
+                    </TableCell>
+                    <TableCell className="px-3 py-2 text-right tabular-nums">
+                      {fmtUsd(win.estimatedCostUsd, 4)}
+                    </TableCell>
+                    {/* 负数 = 扣减（正常用量），正数 = 充值/返利。
+                        用 tabular-nums 让 +/- 对齐。 */}
+                    <TableCell className="px-3 py-2 text-right tabular-nums">
+                      {fmtUsd(win.balanceDeltaUsd, 2)}
+                    </TableCell>
+                    {/* ⚠️ ratio 为 null 时留空（不填 0 / "--"），见组件文档。 */}
+                    <TableCell className="px-3 py-2 text-right tabular-nums">
+                      {win.ratio != null ? fmtRatio(win.ratio) : ""}
+                    </TableCell>
+                    <TableCell className="px-3 py-2">
+                      <FlagBadge flag={win.flag} />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          ) : (
+            <p className="py-6 text-center text-sm text-muted-foreground">
+              {t("loongport.reconcile.empty")}
+            </p>
+          )}
+        </div>
+
+        {/* 一行中立说明：解释比值是什么、什么时候才值得看。
+            口径是「不自动定罪」—— 偏低 ≠ 站点算错了，持续显著偏低才值得关注。 */}
+        <p className="flex-shrink-0 border-t border-border-default px-6 py-3 text-xs leading-relaxed text-muted-foreground">
+          {t("loongport.reconcile.note")}
+        </p>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/relay/RelayRow.tsx
+++ b/src/components/relay/RelayRow.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Activity,
@@ -12,6 +13,7 @@ import {
   Pencil,
   PencilLine,
   Play,
+  Scale,
   Trash2,
   Undo2,
 } from "lucide-react";
@@ -28,6 +30,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { RelayRow as RelayRowData, TierInfo } from "@/lib/api/relay";
 import type { VerificationVerdict } from "@/lib/api/modelVerification";
+import { ReconcileDialog } from "./ReconcileDialog";
 import { RowBalance } from "./RowBalance";
 
 /**
@@ -162,6 +165,9 @@ export function RelayRow({
   dragHandleProps,
 }: RelayRowProps) {
   const { t } = useTranslation();
+  // 「对账」弹窗的开合由这一行自己持有 —— 它只读这一个 relay 的事实，
+  // 没有跨行状态要父组件管（与 `ModelVerificationDialog` 那种全局验证任务不同）。
+  const [reconcileOpen, setReconcileOpen] = useState(false);
   return (
     <Collapsible open={open} onOpenChange={onOpenChange}>
       <div
@@ -255,7 +261,9 @@ export function RelayRow({
               它是这一行的破坏性操作，不该跟「登录 / 获取密钥」抢位置。
 
               **hover 才出**（与档位行同一条规矩）。删除是破坏性动作，常驻一个红色垃圾桶
-              在每一行上，比档位行那些次要按钮更值得藏 —— 上游对删除正是这么处理的。 */}
+              在每一行上，比档位行那些次要按钮更值得藏 —— 上游对删除正是这么处理的。
+              「对账」也是 hover 组的一员：它是查看型入口，与删除同为这一行的
+              行级动作，常驻会把每一行都撑出一排图标。 */}
           <div
             className={cn(
               "flex shrink-0 items-center",
@@ -265,6 +273,22 @@ export function RelayRow({
                 : ROW_HOVER_ACTIONS,
             )}
           >
+            {/* 「对账」入口。**只给能查余额的行** —— 对账的原料是余额快照，
+                而快照来自余额查询；`canQueryBalance` 是后端给的同一份资格判断
+                （`RowBalance` 用的也是它），没资格的行开了弹窗也只有永远空的数据。 */}
+            {relay.canQueryBalance && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 shrink-0 p-1 text-muted-foreground hover:text-foreground"
+                onClick={() => setReconcileOpen(true)}
+                title={t("loongport.reconcile.entry")}
+                aria-label={t("loongport.reconcile.entry")}
+              >
+                <Scale className="h-3.5 w-3.5" />
+              </Button>
+            )}
             <RowDelete
               canDelete={relay.canDelete}
               busy={busy.has(`removeRelay:${relay.id}`)}
@@ -302,6 +326,21 @@ export function RelayRow({
             />
           ))}
         </CollapsibleContent>
+
+        {/* 对账弹窗走 portal 渲染，放行内只是挂个宿主位置。
+            查询只在弹窗打开时发（`enabled: open`），关着的行不会多一个请求。 */}
+        {relay.canQueryBalance && (
+          <ReconcileDialog
+            relayId={relay.id}
+            relayLabel={
+              relay.accountLabel
+                ? `${relay.siteName || relay.siteOrigin} · ${relay.accountLabel}`
+                : relay.siteName || relay.siteOrigin
+            }
+            open={reconcileOpen}
+            onOpenChange={setReconcileOpen}
+          />
+        )}
       </div>
     </Collapsible>
   );

--- a/src/components/relay/useReconciliationQuery.ts
+++ b/src/components/relay/useReconciliationQuery.ts
@@ -1,0 +1,51 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { relayApi, type ReconciliationReport } from "@/lib/api/relay";
+import { extractErrorMessage } from "@/utils/errorUtils";
+
+/**
+ * 一行中转站的扣费对账报告查询。
+ *
+ * 缓存语义照 `useRowBalanceQuery` 那一套（`retry: 1` / `staleTime` 5 分钟 /
+ * refetchOnWindowFocus 关 / keep-last-good）。keep-last-good 这里不另起 ref：
+ * 对账报告整份替换、没有字段级合并，而 react-query v5 本身就在后台刷新失败时
+ * 保留上一份 `data`（status 仍为 success）—— 手里再存一份是死代码。
+ */
+
+/** react-query 的键。`all` 供 `invalidateQueries` 一次刷全部行。 */
+export const reconciliationKeys = {
+  all: ["reconciliation"] as const,
+  report: (relayId: number) => [...reconciliationKeys.all, relayId] as const,
+};
+
+export interface UseReconciliationQueryOptions {
+  /** 关掉查询（如对账入口还没打开）。 */
+  enabled?: boolean;
+}
+
+export function useReconciliationQuery(
+  relayId: number,
+  options: UseReconciliationQueryOptions = {},
+) {
+  const { enabled = true } = options;
+
+  const query = useQuery<ReconciliationReport>({
+    queryKey: reconciliationKeys.report(relayId),
+    queryFn: () => relayApi.reconciliation(relayId),
+    enabled,
+    refetchOnWindowFocus: false,
+    // 本地库读，失败基本是确定性错误；1 次重试只为吸收偶发锁竞争。
+    retry: 1,
+    retryDelay: 1500,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return {
+    report: query.data,
+    loading: query.isFetching,
+    error: query.isError ? extractErrorMessage(query.error) : null,
+    refetch: async () => {
+      await query.refetch();
+    },
+  };
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3288,6 +3288,26 @@
       "emptyTitle": "No image-generation connection profiles",
       "emptyBody": "When you create connection profiles, LoongPort identifies groups that support only gpt-image models. If your relay service does not offer such a group, this page remains empty."
     },
+    "reconcile": {
+      "entry": "View billing reconciliation",
+      "title": "Billing reconciliation",
+      "snapshotCount": "{{count}} balance snapshots",
+      "baselineRatioLabel": "Baseline ratio",
+      "sampleNow": "Sample now",
+      "colWindow": "Window",
+      "colEstimatedCost": "Estimated cost",
+      "colBalanceChange": "Balance change",
+      "colRatio": "Ratio",
+      "colStatus": "Status",
+      "flagSuspicious": "Low ratio",
+      "flagSuspiciousHint": "Actual deductions have kept running at more than twice the local estimate. May be worth a closer look.",
+      "flagSkippedTopUp": "Top-up",
+      "flagSkippedTopUpHint": "Balance increased (top-up, rebate, or bonus); excluded from the ratio",
+      "note": "Ratio = locally estimated cost ÷ what the site actually deducted; estimates already include group rate multipliers. One low window does not mean billing is wrong — only a persistently low ratio (the site charging noticeably more) is worth attention.",
+      "empty": "No reconciliation data yet",
+      "loadFailed": "Failed to load reconciliation data",
+      "retry": "Retry"
+    },
     "modelVerification": {
       "title": "Model verification",
       "titleWithTier": "Model verification · {{tierName}}",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3288,6 +3288,26 @@
       "emptyTitle": "画像生成用の接続プロファイルがありません",
       "emptyBody": "接続プロファイルの作成時に、LoongPort は gpt-image モデルのみに対応するグループを識別します。中継サービスに該当するグループがない場合、このページは空のままです。"
     },
+    "reconcile": {
+      "entry": "課金照合を表示",
+      "title": "課金照合",
+      "snapshotCount": "残高スナップショット {{count}} 件",
+      "baselineRatioLabel": "基準比率",
+      "sampleNow": "今すぐ取得",
+      "colWindow": "期間",
+      "colEstimatedCost": "推定コスト",
+      "colBalanceChange": "残高変化",
+      "colRatio": "比率",
+      "colStatus": "状態",
+      "flagSuspicious": "比率が低い",
+      "flagSuspiciousHint": "実際の引き去りが推定の 2 倍以上で続いています。確認をおすすめします",
+      "flagSkippedTopUp": "チャージ",
+      "flagSkippedTopUpHint": "残高の増加（チャージ・還元・ボーナス）は比率の計算対象外です",
+      "note": "比率はローカルの推定コストをサイトの実際の引き去りで割ったもので、推定にはグループ倍率が含まれます。一つの期間で低くても課金ミスとは限らず、継続して明らかに低い場合（実際の引き去りが多い）にのみ注意が必要です。",
+      "empty": "照合データはまだありません",
+      "loadFailed": "照合データの読み込みに失敗しました",
+      "retry": "再試行"
+    },
     "modelVerification": {
       "title": "モデル検証",
       "titleWithTier": "モデル検証 · {{tierName}}",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3289,6 +3289,26 @@
       "emptyTitle": "尚無圖像生成連線設定檔",
       "emptyBody": "建立連線設定檔時，LoongPort 會識別只支援 gpt-image 模型的群組。若中轉站未提供這類群組，此頁面將保持空白。"
     },
+    "reconcile": {
+      "entry": "查看扣費對帳",
+      "title": "扣費對帳",
+      "snapshotCount": "{{count}} 個餘額快照",
+      "baselineRatioLabel": "基準比值",
+      "sampleNow": "立即取樣",
+      "colWindow": "時間區間",
+      "colEstimatedCost": "估計成本",
+      "colBalanceChange": "餘額變化",
+      "colRatio": "比值",
+      "colStatus": "狀態",
+      "flagSuspicious": "偏低",
+      "flagSuspiciousHint": "實際扣減持續達到本地估計的 2 倍以上，建議關注",
+      "flagSkippedTopUp": "儲值",
+      "flagSkippedTopUpHint": "餘額增加（儲值、回饋或贈送），不計入比值",
+      "note": "比值 = 本地估計成本 ÷ 站點實際扣減，估計已包含站點分組倍率。單一區間偏低不代表計費有誤，持續明顯偏低（實際扣得多）時才值得關注。",
+      "empty": "尚無對帳資料",
+      "loadFailed": "對帳資料載入失敗",
+      "retry": "重試"
+    },
     "modelVerification": {
       "title": "模型驗證",
       "titleWithTier": "模型驗證 · {{tierName}}",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -3288,6 +3288,26 @@
       "emptyTitle": "尚无图像生成接入配置",
       "emptyBody": "创建接入配置时，LoongPort 会识别仅支持 gpt-image 模型的分组。若中转站未提供这类分组，本页将保持为空。"
     },
+    "reconcile": {
+      "entry": "查看扣费对账",
+      "title": "扣费对账",
+      "snapshotCount": "{{count}} 个余额快照",
+      "baselineRatioLabel": "基线比值",
+      "sampleNow": "立即采样",
+      "colWindow": "时间段",
+      "colEstimatedCost": "估算成本",
+      "colBalanceChange": "余额变化",
+      "colRatio": "比值",
+      "colStatus": "状态",
+      "flagSuspicious": "偏低",
+      "flagSuspiciousHint": "实际扣减持续达到本地估算的 2 倍以上，建议关注",
+      "flagSkippedTopUp": "充值",
+      "flagSkippedTopUpHint": "余额增加（充值、返利或赠送），不计入比值",
+      "note": "比值 = 本地估算成本 ÷ 站点实际扣减，估算已包含站点分组倍率。个别窗口偏低不代表计费有误，持续显著偏低（实际扣得多）时才值得关注。",
+      "empty": "暂无对账数据",
+      "loadFailed": "对账数据加载失败",
+      "retry": "重试"
+    },
     "modelVerification": {
       "title": "模型验证",
       "titleWithTier": "模型验证 · {{tierName}}",

--- a/src/lib/api/relay.ts
+++ b/src/lib/api/relay.ts
@@ -255,6 +255,43 @@ export interface RestoreOfficialLoginResult {
   warnings: string[];
 }
 
+/**
+ * 窗口标记。判据是业务事实，由后端定（`WindowFlag`），前端只展示：
+ *
+ * - `skippedTopUp`：扣减 <= 0（充值/返利/赠送），不进比值、不进基线。
+ * - `insufficientData`：没有可算的比值（扣减太小或窗口内无估算数据）。
+ * - `suspicious`：实际扣减持续达到预期的 2 倍以上（`ratio <= baseline × 0.5`）。
+ * - `normal`：其余有比值的窗口。
+ */
+export type ReconciliationFlag =
+  "normal" | "skippedTopUp" | "insufficientData" | "suspicious";
+
+/** 相邻两枚余额快照构成的窗口 `[startSecs, endSecs)`。 */
+export interface ReconciliationWindow {
+  startSecs: number;
+  endSecs: number;
+  startBalanceUsd: number;
+  endBalanceUsd: number;
+  /** `end - start`：负数 = 扣减，正数 = 充值/返利。 */
+  balanceDeltaUsd: number;
+  /** 窗口内该站名下 provider 的估算成本之和（美元）。 */
+  estimatedCostUsd: number;
+  /** 估算 ÷ 扣减；扣减太小或窗口内无估算数据时为 `null`，**不要当 0 处理**。 */
+  ratio: number | null;
+  flag: ReconciliationFlag;
+}
+
+/** 一份扣费对账报告（`relay_reconciliation` 的返回值）。 */
+export interface ReconciliationReport {
+  relayId: number;
+  /** 回看期（30 天）内的快照总数 —— 是窗口的原料数，不是窗口数。 */
+  snapshotCount: number;
+  /** 有效窗口 ratio 的中位数；不足 3 个有效窗口为 `null`，此时不判 `suspicious`。 */
+  baselineRatio: number | null;
+  /** 窗口按**新 → 旧**排，最多 50 个。 */
+  windows: ReconciliationWindow[];
+}
+
 export const relayApi = {
   status: (): Promise<RelayStatus> => invoke("relay_status"),
 
@@ -453,4 +490,13 @@ export const relayApi = {
    */
   restoreOfficialLogin: (): Promise<RestoreOfficialLoginResult> =>
     invoke("relay_restore_official_login"),
+
+  /**
+   * 某一行中转站的扣费对账报告（30 天回看）。
+   *
+   * 纯读本地库（快照 + 代理日志），不发网络。快照不足两枚时 `windows` 为空 ——
+   * 那是「快照不足」的合法状态，UI 展示即可，不是错误。
+   */
+  reconciliation: (relayId: number): Promise<ReconciliationReport> =>
+    invoke("relay_reconciliation", { relayId }),
 };

--- a/tests/components/ReconcileDialog.test.tsx
+++ b/tests/components/ReconcileDialog.test.tsx
@@ -1,0 +1,235 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+
+import { ReconcileDialog } from "@/components/relay/ReconcileDialog";
+import { RelayRow } from "@/components/relay/RelayRow";
+import type {
+  RelayRow as RelayRowData,
+  ReconciliationReport,
+  ReconciliationWindow,
+  TierInfo,
+} from "@/lib/api/relay";
+
+import { createTestQueryClient } from "../utils/testQueryClient";
+
+// 对账弹窗的数据链路是 `useReconciliationQuery → relayApi → invoke`，在 invoke
+// 这一层 mock 可以同时喂「对账报告」与「立即采样」两条命令，让真实 API 层参与测试。
+// （全局 setup 的 i18n 资源为空 ⇒ 文案渲染成 key 本身，断言直接用 key 定位。）
+const invoke = vi.hoisted(() => vi.fn());
+vi.mock("@tauri-apps/api/core", () => ({
+  isTauri: () => false,
+  invoke,
+}));
+
+function win(overrides: Partial<ReconciliationWindow>): ReconciliationWindow {
+  return {
+    startSecs: 1_700_000_000,
+    endSecs: 1_700_000_600,
+    startBalanceUsd: 10,
+    endBalanceUsd: 9.5,
+    balanceDeltaUsd: -0.5,
+    estimatedCostUsd: 0.45,
+    ratio: 0.9,
+    flag: "normal",
+    ...overrides,
+  };
+}
+
+/** 一份覆盖全部四种 flag 的报告。四个窗口时间互不重叠（行 key 用起止时刻）。 */
+const flagsReport: ReconciliationReport = {
+  relayId: 7,
+  snapshotCount: 9,
+  baselineRatio: 0.95,
+  windows: [
+    win({ flag: "suspicious", ratio: 0.4 }),
+    win({ flag: "normal", startSecs: 1_699_999_400, endSecs: 1_700_000_000 }),
+    win({
+      flag: "skippedTopUp",
+      balanceDeltaUsd: 5,
+      ratio: null,
+      startSecs: 1_699_998_800,
+      endSecs: 1_699_999_400,
+    }),
+    win({
+      flag: "insufficientData",
+      ratio: null,
+      startSecs: 1_699_998_200,
+      endSecs: 1_699_998_800,
+    }),
+  ],
+};
+
+function stubInvoke(report: ReconciliationReport) {
+  invoke.mockImplementation(async (cmd: string) => {
+    if (cmd === "relay_reconciliation") return report;
+    throw new Error(`command not stubbed in this test: ${cmd}`);
+  });
+}
+
+function renderDialog(report: ReconciliationReport) {
+  stubInvoke(report);
+  render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <ReconcileDialog
+        relayId={report.relayId}
+        relayLabel="Example · user@example.com"
+        open
+        onOpenChange={vi.fn()}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("ReconcileDialog", () => {
+  it("renders every flag state; the suspicious window carries a red, identifiable badge", async () => {
+    renderDialog(flagsReport);
+
+    await waitFor(() =>
+      expect(document.querySelector("tbody tr")).toBeTruthy(),
+    );
+
+    // Suspicious 行的可识别标识：徽标 + 红色（brief 钉过「Suspicious 标红」，
+    // 只断文案不断颜色的话，渲染成灰色也能过）。
+    const suspicious = screen.getByText("loongport.reconcile.flagSuspicious");
+    expect(suspicious.className).toMatch(/red/);
+
+    // SkippedTopUp 灰色标「充值」。
+    expect(
+      screen.getByText("loongport.reconcile.flagSkippedTopUp"),
+    ).toBeTruthy();
+
+    // 四种 flag 各一行；normal / insufficientData 不出徽标（后者由「比值留空」表达）。
+    expect(document.querySelectorAll("tbody tr")).toHaveLength(4);
+    expect(document.querySelectorAll("tbody span")).toHaveLength(2);
+  });
+
+  it("leaves ratio and baselineRatio blank when the backend could not compute them", async () => {
+    renderDialog({
+      relayId: 7,
+      snapshotCount: 2,
+      baselineRatio: null,
+      windows: [
+        win({ flag: "insufficientData", ratio: null, estimatedCostUsd: 0 }),
+      ],
+    });
+
+    await waitFor(() =>
+      expect(document.querySelector("tbody tr")).toBeTruthy(),
+    );
+
+    // 比值列（第 4 列）留空 —— 不猜 0、不算、不填 "--"。
+    const cells = document.querySelectorAll("tbody tr td");
+    expect(cells[3].textContent).toBe("");
+    // 留空只针对判不了的比值：成本照常显示（fmtUsd 4 位，与用量页同约定）。
+    expect(cells[1].textContent).toBe("$0.0000");
+    // 基线比值（不足 3 个有效窗口）同样留空。值是标签所在容器里的子 span，
+    // 不是兄弟节点（标签与值包在同一个外层 span 里）。
+    const baselineValue = screen
+      .getByText("loongport.reconcile.baselineRatioLabel")
+      .querySelector(".tabular-nums");
+    expect(baselineValue?.textContent).toBe("");
+  });
+
+  it("samples via the existing balance command, then refetches the report", async () => {
+    let resolveBalance!: (value: unknown) => void;
+    invoke.mockImplementation(async (cmd: string) => {
+      if (cmd === "relay_reconciliation") return flagsReport;
+      if (cmd === "relay_balance")
+        return new Promise((resolve) => {
+          resolveBalance = resolve;
+        });
+      throw new Error(`command not stubbed in this test: ${cmd}`);
+    });
+    render(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <ReconcileDialog
+          relayId={7}
+          relayLabel="Example"
+          open
+          onOpenChange={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+    const reportCalls = () =>
+      invoke.mock.calls.filter(([cmd]) => cmd === "relay_reconciliation");
+
+    await waitFor(() => expect(reportCalls()).toHaveLength(1));
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "loongport.reconcile.sampleNow" }),
+    );
+    await waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("relay_balance", { relayId: 7 }),
+    );
+    // 采样完成前不重拉对账（先采样、后 invalidate 的顺序）。
+    expect(reportCalls()).toHaveLength(1);
+
+    resolveBalance({ usage: { success: true }, shouldPromptTopUp: false });
+    await waitFor(() => expect(reportCalls().length).toBeGreaterThanOrEqual(2));
+  });
+
+  it("exposes the entry on RelayRow and opens the dialog from there", async () => {
+    stubInvoke(flagsReport);
+    const tier: TierInfo = {
+      providerId: "loongport-test",
+      appId: "codex",
+      groupName: "Pro",
+      displayName: "Example · Pro",
+      model: "gpt-a",
+      models: ["gpt-a"],
+      rateMultiplier: 1,
+      isCurrent: true,
+      canVerifyModels: true,
+      userEdited: false,
+      allowImageGeneration: false,
+    };
+    const relay: RelayRowData = {
+      id: 7,
+      siteOrigin: "https://api.example.com",
+      siteName: "Example",
+      accountLabel: "user@example.com",
+      status: "ready",
+      isCurrent: true,
+      canQueryBalance: true,
+      canPurchase: true,
+      canRefresh: true,
+      canDelete: false,
+      removeConfirmation: "configured",
+      tiers: [tier],
+    };
+    render(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <RelayRow
+          relay={relay}
+          open
+          onOpenChange={vi.fn()}
+          busy={new Set()}
+          onLogin={vi.fn()}
+          onProvision={vi.fn()}
+          onSwitchTier={vi.fn()}
+          onSelectTierModel={vi.fn()}
+          onPurchase={vi.fn()}
+          onCheckTier={vi.fn()}
+          isCheckingTier={() => false}
+          onResetTier={vi.fn()}
+          onEditTier={vi.fn()}
+          onDelete={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+    // 入口在行上（hover 操作区），点开弹窗后能看到标题与报告内容。
+    fireEvent.click(
+      screen.getByRole("button", { name: "loongport.reconcile.entry" }),
+    );
+    await waitFor(() =>
+      expect(screen.getByText("loongport.reconcile.title")).toBeTruthy(),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByText("loongport.reconcile.flagSuspicious"),
+      ).toBeTruthy(),
+    );
+  });
+});

--- a/tests/hooks/useReconciliationQuery.test.tsx
+++ b/tests/hooks/useReconciliationQuery.test.tsx
@@ -1,0 +1,122 @@
+import type { ReactNode } from "react";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  reconciliationKeys,
+  useReconciliationQuery,
+} from "@/components/relay/useReconciliationQuery";
+import type { ReconciliationReport } from "@/lib/api/relay";
+import { createTestQueryClient } from "../utils/testQueryClient";
+
+const invokeMock = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+}
+
+const report: ReconciliationReport = {
+  relayId: 7,
+  snapshotCount: 4,
+  baselineRatio: 0.5,
+  windows: [
+    {
+      startSecs: 300,
+      endSecs: 400,
+      startBalanceUsd: 6,
+      endBalanceUsd: 4,
+      balanceDeltaUsd: -2,
+      estimatedCostUsd: 1,
+      ratio: 0.5,
+      flag: "normal",
+    },
+    {
+      startSecs: 200,
+      endSecs: 300,
+      startBalanceUsd: 8,
+      endBalanceUsd: 12,
+      balanceDeltaUsd: 4,
+      estimatedCostUsd: 1,
+      ratio: null,
+      flag: "skippedTopUp",
+    },
+  ],
+};
+
+describe("useReconciliationQuery", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "relay_reconciliation") {
+        return Promise.resolve(report);
+      }
+      return Promise.resolve(null);
+    });
+  });
+
+  it("keeps the established query key shapes", () => {
+    expect(reconciliationKeys.all).toEqual(["reconciliation"]);
+    expect(reconciliationKeys.report(7)).toEqual(["reconciliation", 7]);
+  });
+
+  it("calls relay_reconciliation with the relay id and exposes the report", async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useReconciliationQuery(7), { wrapper });
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.report).toEqual(report);
+    });
+
+    expect(invokeMock).toHaveBeenCalledWith("relay_reconciliation", {
+      relayId: 7,
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("keeps the last good report when a refetch fails", async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useReconciliationQuery(7), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.report).toEqual(report);
+    });
+
+    invokeMock.mockRejectedValue(new Error("数据库被锁"));
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(result.current.report).toEqual(report);
+  });
+
+  it("exposes the error message when the first fetch fails", async () => {
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "relay_reconciliation") {
+        return Promise.reject(new Error("找不到 id 为 7 的中转站"));
+      }
+      return Promise.resolve(null);
+    });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useReconciliationQuery(7), { wrapper });
+
+    // retry: 1 + retryDelay 1500ms ⇒ 错误要 ~1.6s 后才透出，waitFor 默认 1s 不够。
+    await waitFor(
+      () => {
+        expect(result.current.error).toContain("找不到 id 为 7 的中转站");
+      },
+      { timeout: 4000 },
+    );
+    expect(result.current.report).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 概要

新增「中转站扣费对账」能力：利用已有的本地用量估算（`proxy_request_logs`，cc-switch 使用统计链路）与中转站余额查询，按时间窗口计算 `估算成本 ÷ 实际余额扣减` 的比值并展示漂移，用于发现站点实际扣减持续显著高于预期的情况。

设计要点（与既有调研 B2「不做逐条对账」的结论互补不冲突）：

- **采样零新增路径**：余额快照挂在 `relay_balance` 成功返回后写库（新表 `relay_balance_snapshots`），前端打开列表、手动刷新、充值关窗都天然产生快照；不做后台轮询（避开 NewAPI JWT 一次性轮换的登录态竞争）。
- **窗口级而非逐条**：相邻快照对构成窗口，窗口内该站托管 provider 的 `total_cost_usd`（已含 `cost_multiplier` 分组倍率）聚合 ÷ 余额扣减；系统性差异折叠进中位数基线，只看漂移。
- **告警判据后端算**：`suspicious` = 实际扣减达基线预期 2 倍以上（阈值刻意放宽，吸收同账号多 key 消费等噪音）；充值窗口标 `skippedTopUp`；数据不足为 `insufficientData`。前端只展示。
- **归属口径唯一源**：与 `relay_balance_inputs` 同一套严格判据（`is_managed` ∧ 同站 ∧ 账号匹配），抽出 `belongs_to_relay` 谓词并有回归测试钉住 `(None, Some)` 分支。

## 改动面

- 后端：`src-tauri/src/relay/reconcile.rs`（表/DAO/快照捕获/窗口计算）、`src-tauri/src/commands/reconcile.rs`（`relay_reconciliation` 命令）、迁移 `loongport_schema.rs` v13→v14；上游文件仅 `schema.rs` 建表挂载 + `lib.rs` 注册各一行。
- 前端：`src/components/relay/ReconcileDialog.tsx` + `useReconciliationQuery.ts`、`RelayRow` 「对账」入口、四语言 `loongport.reconcile.*` 文案。

## 测试

- Rust：窗口数学（右开边界、阈值等号、CAST、跨站不泄漏、30 天/50 上限、快照不足）、归属判据（未登录行不收他账号 key/成本）、快照捕获（成功/失败/旁路不影响余额返回）、迁移升级路径。
- 前端：hook（key/invoke 参数/keep-last-good/错误面）、Dialog（四种 flag 渲染、null 留空、采样链路顺序、行入口）。
