### PR TITLE
feat(proxy): 自动模式 M1 地基 —— 托管档位进故障转移链 + TTFT 聚合 + 熔断致命分级

### DIFF
--- a/src-tauri/src/commands/failover.rs
+++ b/src-tauri/src/commands/failover.rs
@@ -50,10 +50,10 @@ pub async fn get_available_providers_for_failover(
 ) -> Result<Vec<Provider>, String> {
     require_failover_app(&app_type)?;
     // 托管档位（中转站档位）也可以进队列 —— 见 `add_to_failover_queue` 的说明。
-    Ok(state
+    state
         .db
         .get_available_providers_for_failover(&app_type)
-        .map_err(|e| e.to_string())?)
+        .map_err(|e| e.to_string())
 }
 
 /// 添加供应商到故障转移队列

--- a/src-tauri/src/commands/failover.rs
+++ b/src-tauri/src/commands/failover.rs
@@ -49,17 +49,11 @@ pub async fn get_available_providers_for_failover(
     app_type: String,
 ) -> Result<Vec<Provider>, String> {
     require_failover_app(&app_type)?;
-    let available = state
+    // 托管档位（中转站档位）也可以进队列 —— 见 `add_to_failover_queue` 的说明。
+    Ok(state
         .db
         .get_available_providers_for_failover(&app_type)
-        .map_err(|e| e.to_string())?;
-
-    // 托管档位不该出现在选择器里 —— 见 `add_to_failover_queue` 的守卫说明。
-    // 这里滤掉是为了**不把拦得住的东西摆出来给人点**（点了会被守卫拒，但那是个坏体验）。
-    Ok(available
-        .into_iter()
-        .filter(|p| !crate::relay::is_managed(&p.id))
-        .collect())
+        .map_err(|e| e.to_string())?)
 }
 
 /// 添加供应商到故障转移队列
@@ -70,17 +64,15 @@ pub async fn add_to_failover_queue(
     provider_id: String,
 ) -> Result<(), String> {
     require_failover_app(&app_type)?;
-    // 托管档位不许进队列。**这是队列这条链的唯一准入口，所以守卫只需要加在这里** ——
-    // 下游三个消费点（开故障转移开关时切 P1、托盘 Auto、熔断自动切）切的都是队列里的
-    // provider_id，队列里没有托管项，那三条路就不可能指向托管项。
-    //
-    // 为什么必须拦：熔断自动切是**用户没点任何按钮**就发生的（FailoverSwitchManager
-    // 检测到上游报错后自己切），一旦切到托管档位，就跳过了「退出 ChatGPT → 切换 → 重开」
-    // 的编排 —— codex 的 live 配置被换成托管 sk 而 ChatGPT 还连着旧的，用户全程无感。
-    // （托盘菜单那条路现在点击托管项会走 `switch_tier_command` 编排，但这条队列路
-    // 完全不经过菜单，守卫只能加在这里。）
-    crate::relay::reject_if_managed(&provider_id).map_err(|e| e.to_string())?;
-
+    // 托管档位可以进队列。历史上这里拦过托管 id，理由是「熔断自动切会跳过
+    // 『退出 ChatGPT → 切换 → 重开』的编排」—— 但那条理由只成立于**非接管态**，
+    // 而这条链上的每个切换点都先验证了接管态：
+    // - `set_auto_failover_enabled` 开启故障转移前要求 `config.enabled`（接管）；
+    // - `FailoverSwitchManager::do_switch` 每次切换前重新读接管开关。
+    // 接管态下 CLI 流量走本地代理，`hot_switch_provider` 只换代理的服务目标、
+    // 不做退出重开编排 —— 切到托管档位对用户无感，没有「界面切了、codex 还连着旧的」
+    // 的问题。守卫防的场景在这条链上不可达，留着它只是挡住「把托管档位纳入
+    // 故障转移阶梯」这个真实需求（也是后续自动模式选路的地基）。
     state
         .db
         .add_to_failover_queue(&app_type, &provider_id)
@@ -161,20 +153,9 @@ pub async fn set_auto_failover_enabled(
                 return Err("故障转移队列为空，且未设置当前供应商，无法开启故障转移".to_string());
             };
 
-            // 这里是队列的**第二个准入口**，且它绕过了 `add_to_failover_queue` 命令
-            // （直接调 `state.db`），所以那道守卫在这里不生效，必须再拦一次。
-            //
-            // 真会走到：用户当前正用着某个托管档位、队列还空着，此时开故障转移开关 ⇒
-            // 「自动把当前 provider 作为 P1 加入」就把托管档位塞进了队列，
-            // 之后每次熔断都会自动切到它。
-            //
-            // 拦下而不是「跳过自动添加」：跳过的结果是队列仍为空、下面 `queue.first()`
-            // 拿不到 P1 而报一句语焉不详的「队列为空」，用户不知道为什么。
-            if crate::relay::is_managed(&current_id) {
-                return Err("当前用的是 LoongPort 托管的档位，它不能作为故障转移目标。\
-                            请先切到普通供应商，或手动往队列里加至少一个供应商，再开启故障转移。"
-                    .to_string());
-            }
+            // 托管档位作为 P1 也没问题：开启故障转移的前置条件就是接管态（上方
+            // `config.enabled` 检查），接管态下切到托管档位走热切换、无感。
+            // 见 `add_to_failover_queue` 的说明。
 
             state
                 .db

--- a/src-tauri/src/database/dao/usage_rollup.rs
+++ b/src-tauri/src/database/dao/usage_rollup.rs
@@ -127,7 +127,8 @@ impl Database {
                  request_count, success_count,
                  input_tokens, output_tokens,
                  cache_read_tokens, cache_creation_tokens,
-                 input_token_semantics, total_cost_usd, avg_latency_ms)
+                 input_token_semantics, total_cost_usd, avg_latency_ms,
+                 first_token_ms_sum, first_token_count)
             SELECT
                 d, a, p, m, rm, pm,
                 COALESCE(old.request_count, 0) + new_req,
@@ -142,7 +143,9 @@ impl Database {
                     THEN (COALESCE(old.avg_latency_ms, 0) * COALESCE(old.request_count, 0)
                           + new_lat * new_req)
                          / (COALESCE(old.request_count, 0) + new_req)
-                    ELSE 0 END
+                    ELSE 0 END,
+                COALESCE(old.first_token_ms_sum, 0) + new_ttft_sum,
+                COALESCE(old.first_token_count, 0) + new_ttft_count
             FROM (
                 SELECT
                     date(l.created_at, 'unixepoch', 'localtime') as d,
@@ -156,7 +159,9 @@ impl Database {
                     COALESCE(SUM(l.cache_read_tokens), 0) as new_cr,
                     COALESCE(SUM(l.cache_creation_tokens), 0) as new_cc,
                     COALESCE(SUM(CAST(l.total_cost_usd AS REAL)), 0) as new_cost,
-                    COALESCE(AVG(l.latency_ms), 0) as new_lat
+                    COALESCE(AVG(l.latency_ms), 0) as new_lat,
+                    COALESCE(SUM(l.first_token_ms), 0) as new_ttft_sum,
+                    SUM(CASE WHEN l.first_token_ms IS NOT NULL THEN 1 ELSE 0 END) as new_ttft_count
                 FROM proxy_request_logs l
                 WHERE l.created_at < ?1 AND {effective_filter}
                 GROUP BY d, a, p, m, rm, pm
@@ -513,6 +518,47 @@ mod tests {
             (total_cost - 5.0).abs() < 1e-6,
             "expected backfilled cost 5.0, got {total_cost}"
         );
+        Ok(())
+    }
+
+    /// TTFT（首字耗时）只在流式成功行上有值：明细被 prune 后必须能从归档行
+    /// 还原出「和 + 计数」，否则按供应商的首字耗时统计会随剪枝清零。
+    #[test]
+    fn test_rollup_preserves_ttft_sum_and_count() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let old_ts = chrono::Utc::now().timestamp() - 40 * 86400;
+
+        {
+            let conn = crate::database::lock_conn!(db.conn);
+            // 两行有 TTFT（100/200），一行 NULL（非流式），一行 NULL（错误行）
+            for (i, ttft) in [
+                ("ttft-a", Some(100i64)),
+                ("ttft-b", Some(200)),
+                ("ttft-c", None),
+                ("ttft-d", None),
+            ] {
+                conn.execute(
+                    "INSERT INTO proxy_request_logs (
+                        request_id, provider_id, app_type, model,
+                        input_tokens, output_tokens, total_cost_usd,
+                        latency_ms, first_token_ms, status_code, created_at
+                    ) VALUES (?1, 'p1', 'claude', 'claude-3', 100, 50, '0.01', 300, ?2, 200, ?3)",
+                    rusqlite::params![i, ttft, old_ts],
+                )?;
+            }
+        }
+
+        assert_eq!(db.rollup_and_prune(30)?, 4);
+
+        let conn = crate::database::lock_conn!(db.conn);
+        let (sum, count): (i64, i64) = conn.query_row(
+            "SELECT first_token_ms_sum, first_token_count FROM usage_daily_rollups
+             WHERE provider_id = 'p1'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(sum, 300, "只累计非 NULL 的 TTFT");
+        assert_eq!(count, 2, "NULL 行不计入 TTFT 计数");
         Ok(())
     }
 

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -277,6 +277,8 @@ impl Database {
         // request_model 保留路由接管的「客户端别名 → 真实模型」映射维度，
         // pricing_model 保留写入时的计价基准（request 计价模式下与 model 分叉），
         // 否则明细被 prune 后接管计费不可审计；历史行迁移时填 ''（未知）。
+        // first_token_ms_sum/count 存和与计数而不是均值：TTFT 只在流式成功行上有值
+        // （非流式/错误行为 NULL），存均值无法在明细+归档合并时正确加权。
         conn.execute(
             "CREATE TABLE IF NOT EXISTS usage_daily_rollups (
                 date TEXT NOT NULL,
@@ -294,11 +296,25 @@ impl Database {
                 input_token_semantics INTEGER NOT NULL DEFAULT 0,
                 total_cost_usd TEXT NOT NULL DEFAULT '0',
                 avg_latency_ms INTEGER NOT NULL DEFAULT 0,
+                first_token_ms_sum INTEGER NOT NULL DEFAULT 0,
+                first_token_count INTEGER NOT NULL DEFAULT 0,
                 PRIMARY KEY (date, app_type, provider_id, model, request_model, pricing_model)
             )",
             [],
         )
         .map_err(|e| AppError::Database(e.to_string()))?;
+        Self::add_column_if_missing(
+            conn,
+            "usage_daily_rollups",
+            "first_token_ms_sum",
+            "INTEGER NOT NULL DEFAULT 0",
+        )?;
+        Self::add_column_if_missing(
+            conn,
+            "usage_daily_rollups",
+            "first_token_count",
+            "INTEGER NOT NULL DEFAULT 0",
+        )?;
 
         // 18. Session Log Sync 表 (会话日志同步状态)
         conn.execute(
@@ -1336,6 +1352,8 @@ impl Database {
                  cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
                  total_cost_usd TEXT NOT NULL DEFAULT '0',
                  avg_latency_ms INTEGER NOT NULL DEFAULT 0,
+                 first_token_ms_sum INTEGER NOT NULL DEFAULT 0,
+                 first_token_count INTEGER NOT NULL DEFAULT 0,
                  PRIMARY KEY (date, app_type, provider_id, model, request_model, pricing_model)
              );
              INSERT INTO usage_daily_rollups

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -424,6 +424,15 @@ fn migration_v10_to_v11_rebuilds_rollups_with_request_model_dimension() {
     assert_eq!(rollup_pricing_model.r#type, "TEXT");
     assert_eq!(rollup_pricing_model.notnull, 1);
 
+    // 迁移重建的表形状必须与 create_tables_on_conn 的新建表一致：TTFT 和/计数列
+    // 也要在（否则同步暂存库跑迁移后，restore_tables 的 INSERT 会因缺列失败）。
+    let ttft_sum = get_column_info(&conn, "usage_daily_rollups", "first_token_ms_sum");
+    assert_eq!(ttft_sum.r#type, "INTEGER");
+    assert_eq!(ttft_sum.notnull, 1);
+    let ttft_count = get_column_info(&conn, "usage_daily_rollups", "first_token_count");
+    assert_eq!(ttft_count.r#type, "INTEGER");
+    assert_eq!(ttft_count.notnull, 1);
+
     // 明细表补上 pricing_model 列（可空，历史行 NULL）
     let pricing_model = get_column_info(&conn, "proxy_request_logs", "pricing_model");
     assert_eq!(pricing_model.r#type, "TEXT");

--- a/src-tauri/src/proxy/circuit_breaker.rs
+++ b/src-tauri/src/proxy/circuit_breaker.rs
@@ -72,6 +72,13 @@ impl Default for CircuitBreakerConfig {
     }
 }
 
+/// 致命失败（凭证/余额级，如上游 401/402/403）打开熔断后的冷却时长。
+///
+/// 这类错误短期不会自愈 —— 凭证不会被刷新、余额不会自己回来 —— 按普通
+/// `timeout_seconds`（默认 60s）每分钟探测一次只是拿用户的请求反复撞墙。
+/// 不做成配置项：致命分级本身就是策略，暴露成旋钮只会让人把它拧回 60s。
+const FATAL_OPEN_COOLDOWN_SECONDS: u64 = 1800;
+
 /// 熔断器实例
 pub struct CircuitBreaker {
     /// 当前状态
@@ -86,6 +93,8 @@ pub struct CircuitBreaker {
     failed_requests: Arc<AtomicU32>,
     /// 上次打开时间
     last_opened_at: Arc<RwLock<Option<Instant>>>,
+    /// 本次 Open 是否由致命失败触发（决定恢复冷却用长冷却还是配置超时）
+    fatal_open: Arc<std::sync::atomic::AtomicBool>,
     /// 配置（支持热更新）
     config: Arc<RwLock<CircuitBreakerConfig>>,
     /// 半开状态已放行的请求数（用于限流）
@@ -112,6 +121,7 @@ impl CircuitBreaker {
             total_requests: Arc::new(AtomicU32::new(0)),
             failed_requests: Arc::new(AtomicU32::new(0)),
             last_opened_at: Arc::new(RwLock::new(None)),
+            fatal_open: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             config: Arc::new(RwLock::new(config)),
             half_open_requests: Arc::new(AtomicU32::new(0)),
         }
@@ -120,6 +130,15 @@ impl CircuitBreaker {
     /// 更新熔断器配置（热更新，不重置状态）
     pub async fn update_config(&self, new_config: CircuitBreakerConfig) {
         *self.config.write().await = new_config;
+    }
+
+    /// 当前 Open 状态的恢复冷却（秒）：致命失败用长冷却，否则用配置超时
+    async fn open_cooldown_secs(&self, config: &CircuitBreakerConfig) -> u64 {
+        if self.fatal_open.load(Ordering::SeqCst) {
+            FATAL_OPEN_COOLDOWN_SECONDS
+        } else {
+            config.timeout_seconds
+        }
     }
 
     /// 判断当前 Provider 是否“可被纳入候选链路”
@@ -138,7 +157,7 @@ impl CircuitBreaker {
             CircuitState::Closed | CircuitState::HalfOpen => true,
             CircuitState::Open => {
                 if let Some(opened_at) = *self.last_opened_at.read().await {
-                    if opened_at.elapsed().as_secs() >= config.timeout_seconds {
+                    if opened_at.elapsed().as_secs() >= self.open_cooldown_secs(&config).await {
                         drop(config); // 释放读锁再转换状态
                         log::info!(
                             "[{}] 熔断器 Open → HalfOpen (超时恢复)",
@@ -166,7 +185,7 @@ impl CircuitBreaker {
                 let config = self.config.read().await;
                 // 检查是否应该尝试半开
                 if let Some(opened_at) = *self.last_opened_at.read().await {
-                    if opened_at.elapsed().as_secs() >= config.timeout_seconds {
+                    if opened_at.elapsed().as_secs() >= self.open_cooldown_secs(&config).await {
                         drop(config); // 释放读锁再转换状态
                         log::info!(
                             "[{}] 熔断器 Open → HalfOpen (超时恢复)",
@@ -252,7 +271,10 @@ impl CircuitBreaker {
                     log_cb::HALF_OPEN_PROBE_FAILED
                 );
                 drop(config);
-                self.transition_to_open().await;
+                // 沿用上一次打开时的致命标记：曾因欠费打开的档位探测再失败，
+                // 说明还是坏的，不该把冷却悄悄降回配置超时。
+                let fatal = self.fatal_open.load(Ordering::SeqCst);
+                self.transition_to_open(fatal).await;
             }
             CircuitState::Closed => {
                 // 检查连续失败次数
@@ -262,7 +284,8 @@ impl CircuitBreaker {
                         log_cb::TRIGGERED_FAILURES
                     );
                     drop(config); // 释放读锁再转换状态
-                    self.transition_to_open().await;
+                    let fatal = self.fatal_open.load(Ordering::SeqCst);
+                    self.transition_to_open(fatal).await;
                 } else {
                     // 检查错误率
                     let total = self.total_requests.load(Ordering::SeqCst);
@@ -278,13 +301,44 @@ impl CircuitBreaker {
                                 error_rate * 100.0
                             );
                             drop(config); // 释放读锁再转换状态
-                            self.transition_to_open().await;
+                            let fatal = self.fatal_open.load(Ordering::SeqCst);
+                            self.transition_to_open(fatal).await;
                         }
                     }
                 }
             }
             _ => {}
         }
+    }
+
+    /// 记录致命失败（凭证/余额级错误，如上游 401/402/403）
+    ///
+    /// 与 [`record_failure`](Self::record_failure) 的区别只有两点：
+    /// - **一次即开**：不等连续失败阈值 —— 第 2、3 次请求结果已可预知，没必要再撞；
+    /// - **长冷却**：恢复探测间隔用 [`FATAL_OPEN_COOLDOWN_SECONDS`] 而不是配置的
+    ///   `timeout_seconds`。
+    ///
+    /// 致命分级只在成功（`transition_to_closed`）时清除：半开探测失败会沿用上一次
+    /// 打开时的致命冷却 —— 一个曾因欠费打开的档位，探测又失败，说明它还是坏的。
+    pub async fn record_fatal_failure(&self, used_half_open_permit: bool) {
+        let config = self.config.read().await;
+
+        if used_half_open_permit {
+            self.release_half_open_permit();
+        }
+
+        self.consecutive_failures.fetch_add(1, Ordering::SeqCst);
+        self.total_requests.fetch_add(1, Ordering::SeqCst);
+        self.failed_requests.fetch_add(1, Ordering::SeqCst);
+        self.consecutive_successes.store(0, Ordering::SeqCst);
+
+        let cooldown = config.timeout_seconds.max(FATAL_OPEN_COOLDOWN_SECONDS);
+        drop(config);
+        log::warn!(
+            "[{}] 熔断器致命失败（凭证/余额级）→ Open，冷却 {cooldown}s",
+            log_cb::TRIGGERED_FATAL
+        );
+        self.transition_to_open(true).await;
     }
 
     /// 获取当前状态
@@ -356,9 +410,13 @@ impl CircuitBreaker {
     }
 
     /// 转换到打开状态
-    async fn transition_to_open(&self) {
+    ///
+    /// `fatal` 决定恢复冷却：普通失败沿用配置超时，致命失败用长冷却。
+    /// 普通失败路径传「沿用当前标记」—— 半开探测失败不该把致命冷却悄悄降回 60s。
+    async fn transition_to_open(&self, fatal: bool) {
         *self.state.write().await = CircuitState::Open;
         *self.last_opened_at.write().await = Some(Instant::now());
+        self.fatal_open.store(fatal, Ordering::SeqCst);
         self.consecutive_failures.store(0, Ordering::SeqCst);
         self.consecutive_successes.store(0, Ordering::SeqCst);
     }
@@ -379,6 +437,7 @@ impl CircuitBreaker {
     /// 转换到关闭状态
     async fn transition_to_closed(&self) {
         *self.state.write().await = CircuitState::Closed;
+        self.fatal_open.store(false, Ordering::SeqCst);
         self.consecutive_failures.store(0, Ordering::SeqCst);
         self.consecutive_successes.store(0, Ordering::SeqCst);
         // 重置计数器
@@ -459,7 +518,7 @@ mod tests {
         let breaker = CircuitBreaker::new(config);
 
         // 进入 Open，然后由于 timeout_seconds=0，allow_request 会立即切换到 HalfOpen 并占用探测名额
-        breaker.transition_to_open().await;
+        breaker.transition_to_open(false).await;
         let first = breaker.allow_request().await;
         assert!(first.allowed);
         assert!(first.used_half_open_permit);
@@ -491,5 +550,56 @@ mod tests {
         breaker.reset().await;
         assert_eq!(breaker.get_state().await, CircuitState::Closed);
         assert!(breaker.allow_request().await.allowed);
+    }
+
+    /// 致命失败一次即 Open，且冷却用长冷却而不是配置超时。
+    #[tokio::test]
+    async fn fatal_failure_opens_immediately_with_long_cooldown() {
+        let config = CircuitBreakerConfig {
+            failure_threshold: 4,
+            timeout_seconds: 60,
+            ..Default::default()
+        };
+        let breaker = CircuitBreaker::new(config);
+
+        // 普通失败 4 次才开；致命失败 1 次就开
+        breaker.record_fatal_failure(false).await;
+        assert_eq!(breaker.get_state().await, CircuitState::Open);
+        assert!(!breaker.is_available().await);
+
+        {
+            let config = breaker.config.read().await;
+            assert_eq!(
+                breaker.open_cooldown_secs(&config).await,
+                FATAL_OPEN_COOLDOWN_SECONDS
+            );
+        }
+    }
+
+    /// 成功（Closed 恢复）清除致命标记；之后普通失败打开用配置超时。
+    #[tokio::test]
+    async fn success_clears_fatal_cooldown() {
+        let config = CircuitBreakerConfig {
+            failure_threshold: 2,
+            success_threshold: 1,
+            timeout_seconds: 60,
+            ..Default::default()
+        };
+        let breaker = CircuitBreaker::new(config);
+
+        breaker.record_fatal_failure(false).await;
+        // 手动进入半开并让一次探测成功 → Closed
+        breaker.transition_to_half_open().await;
+        breaker.record_success(true).await;
+        assert_eq!(breaker.get_state().await, CircuitState::Closed);
+
+        // 再普通失败打开：冷却应回到配置超时（致命标记已被成功清除）
+        breaker.record_failure(false).await;
+        breaker.record_failure(false).await;
+        assert_eq!(breaker.get_state().await, CircuitState::Open);
+        {
+            let config = breaker.config.read().await;
+            assert_eq!(breaker.open_cooldown_secs(&config).await, 60);
+        }
     }
 }

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1001,22 +1001,37 @@ impl RequestForwarder {
 
                     match category {
                         ErrorCategory::Retryable => {
-                            // 可重试：真正的 provider 故障 → 记录失败并更新熔断器/DB 健康度
-                            self.router
-                                .record_result(
-                                    &provider.id,
-                                    app_type_str,
-                                    used_half_open_permit,
-                                    false,
-                                    Some(e.to_string()),
-                                )
-                                .await
-                                .warn_on_err(
-                                    DiagnosticEvent::new("proxy.health.record", "failed")
-                                        .field("phase", "retryable_failure")
-                                        .field("app", app_type_str)
-                                        .field("provider_id", provider.id.clone()),
-                                );
+                            // 可重试：真正的 provider 故障 → 记录失败并更新熔断器/DB 健康度。
+                            // 凭证/余额级错误（401/402/403）进一步分级为致命：换下一家
+                            // 照试，但这家熔断用长冷却 —— 短期内它不会自愈，按普通
+                            // 60s 冷却等于每分钟拿用户请求再撞一次。
+                            let fatal = is_fatal_upstream_error(&e);
+                            let record = if fatal {
+                                self.router
+                                    .record_fatal_result(
+                                        &provider.id,
+                                        app_type_str,
+                                        used_half_open_permit,
+                                        Some(e.to_string()),
+                                    )
+                                    .await
+                            } else {
+                                self.router
+                                    .record_result(
+                                        &provider.id,
+                                        app_type_str,
+                                        used_half_open_permit,
+                                        false,
+                                        Some(e.to_string()),
+                                    )
+                                    .await
+                            };
+                            record.warn_on_err(
+                                DiagnosticEvent::new("proxy.health.record", "failed")
+                                    .field("phase", "retryable_failure")
+                                    .field("app", app_type_str)
+                                    .field("provider_id", provider.id.clone()),
+                            );
 
                             {
                                 let mut status = self.status.write().await;
@@ -2716,6 +2731,22 @@ fn extract_error_message(error: &ProxyError) -> Option<String> {
         ProxyError::UpstreamError { body, .. } => body.clone(),
         _ => Some(error.to_string()),
     }
+}
+
+/// 凭证/计费级的上游错误：换供应商重试是对的，但这家供应商短期不会自愈
+/// （凭证不会被刷新、余额不会自己回来），熔断要用致命长冷却。
+///
+/// 只覆盖 401/402/403。429 里的「余额不足」变体需要解析响应体才能区分，
+/// 先按瞬态处理（欠费站点最终会以 402/403 显形）。只在 Retryable 分类内部
+/// 进一步分级 —— NonRetryable 的 4xx 根本不进健康度。
+fn is_fatal_upstream_error(error: &ProxyError) -> bool {
+    matches!(
+        error,
+        ProxyError::UpstreamError {
+            status: 401 | 402 | 403,
+            ..
+        }
+    )
 }
 
 /// 检测 Provider 是否为 Bedrock（通过 CLAUDE_CODE_USE_BEDROCK 环境变量判断）

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -2743,7 +2743,7 @@ fn is_fatal_upstream_error(error: &ProxyError) -> bool {
     matches!(
         error,
         ProxyError::UpstreamError {
-            status: 401 | 402 | 403,
+            status: 401..=403,
             ..
         }
     )

--- a/src-tauri/src/proxy/log_codes.rs
+++ b/src-tauri/src/proxy/log_codes.rs
@@ -18,6 +18,7 @@ pub mod cb {
     pub const TRIGGERED_FAILURES: &str = "CB-004";
     pub const TRIGGERED_ERROR_RATE: &str = "CB-005";
     pub const MANUAL_RESET: &str = "CB-006";
+    pub const TRIGGERED_FATAL: &str = "CB-007";
 }
 
 /// 服务器日志码

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -161,6 +161,44 @@ impl ProviderRouter {
         Ok(())
     }
 
+    /// 记录供应商请求结果（致命失败变体）
+    ///
+    /// 与 [`record_result`](Self::record_result) 的失败分支同步更新 DB 健康度，
+    /// 区别只在熔断器：致命失败一次即 Open 且用长冷却
+    /// （[`CircuitBreaker::record_fatal_failure`](crate::proxy::circuit_breaker::CircuitBreaker::record_fatal_failure)）。
+    /// 什么时候算「致命」由调用方分类（forwarder 按上游状态码 401/402/403）。
+    pub async fn record_fatal_result(
+        &self,
+        provider_id: &str,
+        app_type: &str,
+        used_half_open_permit: bool,
+        error_msg: Option<String>,
+    ) -> Result<(), AppError> {
+        // 1. 按应用独立获取熔断器配置
+        let failure_threshold = match self.db.get_proxy_config_for_app(app_type).await {
+            Ok(app_config) => app_config.circuit_failure_threshold,
+            Err(_) => 5, // 默认值
+        };
+
+        // 2. 更新熔断器状态（致命失败）
+        let circuit_key = format!("{app_type}:{provider_id}");
+        let breaker = self.get_or_create_circuit_breaker(&circuit_key).await;
+        breaker.record_fatal_failure(used_half_open_permit).await;
+
+        // 3. 更新数据库健康状态（与普通失败同一张表）
+        self.db
+            .update_provider_health_with_threshold(
+                provider_id,
+                app_type,
+                false,
+                error_msg.clone(),
+                failure_threshold,
+            )
+            .await?;
+
+        Ok(())
+    }
+
     /// 重置熔断器（手动恢复）
     pub async fn reset_circuit_breaker(&self, circuit_key: &str) {
         let breakers = self.circuit_breakers.read().await;
@@ -423,6 +461,45 @@ mod tests {
 
         assert_eq!(providers.len(), 1);
         assert_eq!(providers[0].id, "b");
+    }
+
+    /// 队列里的托管档位必须能被选路（自动模式选路的地基）。
+    ///
+    /// 历史上托管档位被挡在队列外（见 `relay/managed.rs` 的说明：守卫防的是
+    /// 非接管态下跳过 ChatGPT 编排，而这条链的切换点都先验证接管态，场景不可达，
+    /// 2026-08-15 修根移除）。这条测试钉住移除后的契约：托管 id 进队列后，
+    /// `select_providers` 照常返回它，后续熔断/热切换链路对它一视同仁。
+    #[tokio::test]
+    #[serial]
+    async fn select_providers_serves_managed_tiers_in_failover_queue() {
+        let _home = TempHome::new();
+        let db = Arc::new(Database::memory().unwrap());
+
+        let managed_id =
+            crate::relay::provision::provider_id_for("https://bestapi.store", Some(1), 42);
+        assert!(
+            crate::relay::is_managed(&managed_id),
+            "fixture 必须是托管形状的 id"
+        );
+
+        let provider = Provider::with_id(
+            managed_id.clone(),
+            "Managed Tier".to_string(),
+            json!({}),
+            None,
+        );
+        db.save_provider("claude", &provider).unwrap();
+        db.add_to_failover_queue("claude", &managed_id).unwrap();
+
+        let mut config = db.get_proxy_config_for_app("claude").await.unwrap();
+        config.auto_failover_enabled = true;
+        db.update_proxy_config_for_app(config).await.unwrap();
+
+        let router = ProviderRouter::new(db.clone());
+        let providers = router.select_providers("claude").await.unwrap();
+
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].id, managed_id);
     }
 
     #[tokio::test]

--- a/src-tauri/src/relay/managed.rs
+++ b/src-tauri/src/relay/managed.rs
@@ -12,11 +12,14 @@
 //!
 //! ## 为什么需要守卫（不只是前端过滤）
 //!
-//! 切换托管档位的正确入口是 `switch_tier_command` 那条编排（「退出 ChatGPT → 切换 →
-//! 重开」，命令层与托盘共用；`relay_switch_tier` 命令是它的一个壳）。任何绕过它直接切
-//! provider 的路径，结果都是**界面显示切了、codex 还连着旧分组**，而用户不会收到任何
-//! 提示。前端那道过滤（`isManagedProviderId`）挡不住托盘菜单与命令层，
+//! 托管记录由 provision 自动生成与维护（登录 / 获取密钥 / 切档位都在供应商页顶部的
+//! 中转站区），把它们当普通供应商编辑、复制、删除会破坏那套生命周期 —— 所以命令层的
+//! 增改删入口都拦托管 id。前端那道过滤（`isManagedProviderId`）挡不住托盘菜单与命令层，
 //! 所以守卫必须落在 Rust 侧。
+//!
+//! 注意守卫**不管切换路径**：故障转移队列允许托管档位（链上每个切换点都先验证接管态，
+//! 接管态热切换无感，见 `commands/failover.rs`）；托盘点击托管项走 `switch_tier_command`
+//! 编排。别把「禁止 CRUD」误扩成「禁止一切」。
 
 /// 托管 provider 的 id 前缀。
 ///
@@ -255,33 +258,12 @@ mod tests {
         reject_if_managed("custom-1").expect("普通 id 不该被拦");
     }
 
-    /// 故障转移队列的准入：托管档位不得进队列。
-    ///
-    /// 这条守的是一条**自动发生**的路径：队列里有托管项时，熔断会让
-    /// `FailoverSwitchManager` 在用户没点任何按钮的情况下切到它，跳过
-    /// 「退出 ChatGPT → 切换 → 重开」的编排（托盘菜单过滤在这条路上完全无效，
-    /// 因为切换不是从菜单点出来的）。
-    ///
-    /// 队列有**两个准入口**，都必须拦（commands/failover.rs）：
-    /// `add_to_failover_queue` 命令（用户手动加），以及 `set_auto_failover_enabled`
-    /// 里「队列为空时自动把当前 provider 作为 P1 加入」那段 —— 后者直接调
-    /// `state.db`，绕过前者的守卫，所以是独立的一道。
-    #[test]
-    fn managed_tiers_are_rejected_from_failover_queue() {
-        let real = provision::provider_id_for("https://bestapi.store", Some(1), 3);
-
-        // 准入口 1：手动加入 —— 走 reject_if_managed。
-        assert!(
-            reject_if_managed(&real).is_err(),
-            "托管档位必须被挡在故障转移队列之外"
-        );
-        // 准入口 2：自动作为 P1 加入 —— 走 is_managed 判断后给专门的文案。
-        assert!(is_managed(&real));
-
-        // 普通 provider 不受影响：故障转移对它们是正常功能，别顺手拦死。
-        for id in ["custom-1", "codex-official"] {
-            assert!(reject_if_managed(id).is_ok(), "id: {id}");
-            assert!(!is_managed(id), "id: {id}");
-        }
-    }
+    // 故障转移队列**不设**托管守卫（2026-08-15 修根移除）。
+    //
+    // 历史上这里拦过托管档位，理由是「熔断自动切会跳过 ChatGPT 退出重开编排」——
+    // 但故障转移链的每个切换点（`set_auto_failover_enabled`、`FailoverSwitchManager`）
+    // 都先验证接管态，而接管态下热切换对托管档位无感，守卫防的场景在这条链上
+    // 不可达。留在仓里的契约由 `provider_router` 的
+    // `select_providers_serves_managed_tiers_in_failover_queue` 钉住：队列里的
+    // 托管档位必须能被选路（这是自动模式选路的地基）。
 }

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -86,6 +86,9 @@ pub struct ProviderStats {
     pub total_cost: String,
     pub success_rate: f32,
     pub avg_latency_ms: u64,
+    /// 平均首字耗时（TTFT）。只统计有值的行（流式成功请求）；没有任何
+    /// TTFT 样本时为 0。自动模式「响应最快」策略的排序依据。
+    pub avg_first_token_ms: u64,
 }
 
 /// 模型统计
@@ -1340,7 +1343,10 @@ impl Database {
                 SUM(success_count) as success_count,
                 CASE WHEN SUM(request_count) > 0
                     THEN SUM(latency_sum) / SUM(request_count)
-                    ELSE 0 END as avg_latency
+                    ELSE 0 END as avg_latency,
+                CASE WHEN SUM(ttft_count) > 0
+                    THEN SUM(ttft_sum) / SUM(ttft_count)
+                    ELSE 0 END as avg_ttft
             FROM (
                 SELECT l.provider_id, l.app_type,
                     {detail_pname} as provider_name,
@@ -1348,7 +1354,9 @@ impl Database {
                     COALESCE(SUM({fresh_input_detail} + l.output_tokens), 0) as total_tokens,
                     COALESCE(SUM(CAST(l.total_cost_usd AS REAL)), 0) as total_cost,
                     COALESCE(SUM(CASE WHEN l.status_code >= 200 AND l.status_code < 300 THEN 1 ELSE 0 END), 0) as success_count,
-                    COALESCE(SUM(l.latency_ms), 0) as latency_sum
+                    COALESCE(SUM(l.latency_ms), 0) as latency_sum,
+                    COALESCE(SUM(l.first_token_ms), 0) as ttft_sum,
+                    COALESCE(SUM(CASE WHEN l.first_token_ms IS NOT NULL THEN 1 ELSE 0 END), 0) as ttft_count
                 FROM proxy_request_logs l
                 LEFT JOIN providers p ON l.provider_id = p.id AND l.app_type = p.app_type
                 {detail_where}
@@ -1360,7 +1368,9 @@ impl Database {
                     COALESCE(SUM({fresh_input_rollup} + r.output_tokens), 0),
                     COALESCE(SUM(CAST(r.total_cost_usd AS REAL)), 0),
                     COALESCE(SUM(r.success_count), 0),
-                    COALESCE(SUM(r.avg_latency_ms * r.request_count), 0)
+                    COALESCE(SUM(r.avg_latency_ms * r.request_count), 0),
+                    COALESCE(SUM(r.first_token_ms_sum), 0),
+                    COALESCE(SUM(r.first_token_count), 0)
                 FROM usage_daily_rollups r
                 LEFT JOIN providers p2 ON r.provider_id = p2.id AND r.app_type = p2.app_type
                 {rollup_where}
@@ -1391,6 +1401,7 @@ impl Database {
                 total_cost: format!("{:.6}", row.get::<_, f64>(5)?),
                 success_rate,
                 avg_latency_ms: row.get::<_, f64>(7)? as u64,
+                avg_first_token_ms: row.get::<_, f64>(8)? as u64,
             })
         };
 
@@ -3842,6 +3853,48 @@ mod tests {
         assert_eq!(stats[0].provider_id, "p1");
         assert_eq!(stats[0].request_count, 1);
         assert_eq!(stats[0].total_tokens, 275);
+
+        Ok(())
+    }
+
+    /// TTFT 聚合：只统计有 first_token_ms 的行，且明细与归档行能正确合并。
+    /// 这是自动模式「响应最快」策略的排序数据源。
+    #[test]
+    fn test_get_provider_stats_aggregates_ttft_over_detail_and_rollups() -> Result<(), AppError> {
+        let db = Database::memory()?;
+
+        {
+            let conn = lock_conn!(db.conn);
+            // 明细：两行有 TTFT（100/300），一行 NULL
+            for (id, ttft) in [("d1", Some(100i64)), ("d2", Some(300)), ("d3", None)] {
+                conn.execute(
+                    "INSERT INTO proxy_request_logs (
+                        request_id, provider_id, app_type, model,
+                        input_tokens, output_tokens, total_cost_usd,
+                        latency_ms, first_token_ms, status_code, created_at
+                    ) VALUES (?, 'p1', 'claude', 'claude-3', 100, 50, '0.01', 400, ?, 200, 2000)",
+                    params![id, ttft],
+                )?;
+            }
+            // 归档：sum=600, count=2（明细被 prune 后只剩这份）
+            conn.execute(
+                "INSERT INTO usage_daily_rollups (
+                    date, app_type, provider_id, model, request_count,
+                    input_tokens, output_tokens, total_cost_usd, avg_latency_ms,
+                    first_token_ms_sum, first_token_count
+                ) VALUES ('2026-01-01', 'claude', 'p1', 'claude-3', 2,
+                          200, 100, '0.02', 400, 600, 2)",
+                [],
+            )?;
+        }
+
+        let stats = db.get_provider_stats(None, None, Some("claude"), None, None)?;
+        assert_eq!(stats.len(), 1);
+        // (100 + 300 + 600) / (2 + 2) = 250
+        assert_eq!(
+            stats[0].avg_first_token_ms, 250,
+            "TTFT 均值必须跨明细+归档按样本数加权，NULL 行不参与"
+        );
 
         Ok(())
     }

--- a/src/components/usage/ProviderStatsTable.tsx
+++ b/src/components/usage/ProviderStatsTable.tsx
@@ -60,13 +60,16 @@ export function ProviderStatsTable({
             <TableHead className="text-right">
               {t("usage.avgLatency", "平均延迟")}
             </TableHead>
+            <TableHead className="text-right">
+              {t("usage.avgFirstToken", "平均首字耗时")}
+            </TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {stats?.length === 0 ? (
             <TableRow>
               <TableCell
-                colSpan={6}
+                colSpan={7}
                 className="text-center text-muted-foreground"
               >
                 {t("usage.noData", "暂无数据")}
@@ -92,6 +95,10 @@ export function ProviderStatsTable({
                 </TableCell>
                 <TableCell className="text-right">
                   {stat.avgLatencyMs}ms
+                </TableCell>
+                <TableCell className="text-right">
+                  {/* 无 TTFT 样本（0）时显示占位：0ms 是「没有数据」不是「真的 0ms」 */}
+                  {stat.avgFirstTokenMs > 0 ? `${stat.avgFirstTokenMs}ms` : "—"}
                 </TableCell>
               </TableRow>
             ))

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1637,6 +1637,7 @@
     "tokens": "Tokens",
     "avgCost": "Average Cost",
     "avgLatency": "Average Latency",
+    "avgFirstToken": "Avg First Token",
     "successRate": "Success Rate",
     "requestId": "Request ID",
     "never": "Never",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1637,6 +1637,7 @@
     "tokens": "トークン",
     "avgCost": "平均コスト",
     "avgLatency": "平均レイテンシ",
+    "avgFirstToken": "平均初トークン時間",
     "successRate": "成功率",
     "requestId": "リクエスト ID",
     "never": "なし",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1638,6 +1638,7 @@
     "tokens": "Tokens",
     "avgCost": "平均成本",
     "avgLatency": "平均延遲",
+    "avgFirstToken": "平均首字耗時",
     "successRate": "成功率",
     "requestId": "請求 ID",
     "never": "從不",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1637,6 +1637,7 @@
     "tokens": "Tokens",
     "avgCost": "平均成本",
     "avgLatency": "平均延迟",
+    "avgFirstToken": "平均首字耗时",
     "successRate": "成功率",
     "requestId": "请求 ID",
     "never": "从不",

--- a/src/types/usage.ts
+++ b/src/types/usage.ts
@@ -149,6 +149,8 @@ export interface ProviderStats {
   totalCost: string;
   successRate: number;
   avgLatencyMs: number;
+  /** 平均首字耗时；只统计流式成功请求，无样本时为 0 */
+  avgFirstTokenMs: number;
 }
 
 export interface ModelStats {


### PR DESCRIPTION
## 自动模式第一期地基（M1 / 共三期）

自动模式目标：用户只选 app + 模型，系统按策略（价格最低默认 / 响应最快=TTFT 最短）自动挑最合适的托管档位。本期只打地基，不改选路行为。

### 1. 故障转移链放开托管档位（修根）

历史上 `reject_if_managed` 把托管档位挡在故障转移队列外，理由是「熔断自动切会跳过 ChatGPT 退出重开编排」。但该链上的每个切换点（`set_auto_failover_enabled`、`FailoverSwitchManager::do_switch`）都先验证接管态，而接管态下 `hot_switch_provider` 只换代理服务目标、对用户无感 —— **守卫防的场景在这条链上不可达**，留着它只是挡住「把托管档位纳入故障转移阶梯」这个真实需求（也是 M2 策略选路的地基）。

- 移除 `add_to_failover_queue` / `set_auto_failover_enabled` 两处准入拦截与选择器过滤
- 契约由 `select_providers_serves_managed_tiers_in_failover_queue` 钉住
- `reject_if_managed` 回归本职：只守托管记录的普通 CRUD（编辑/复制/删除）

### 2. TTFT 按供应商聚合（M2「响应最快」策略的数据源）

- `usage_daily_rollups` 增加 `first_token_ms_sum` / `first_token_count`（存和+计数而非均值：TTFT 只在流式成功行有值，存均值无法跨明细+归档正确加权）
- `get_provider_stats` 输出 `avg_first_token_ms`，明细与归档按样本数加权合并
- 用量面板供应商表新增「平均首字耗时」列（无样本显示 —），四语文案
- 同步 v10→v11 迁移的重建 DDL（新建表与迁移输出形状必须一致，否则同步暂存库跑迁移后 `restore_tables` 因缺列失败 —— 测试已钉）

### 3. 熔断致命/瞬态二分（借 sub2api 判据设计，非代码）

- 上游 401/402/403（凭证/余额级）→ `record_fatal_failure`：一次即 Open + 30 分钟长冷却，成功才清除致命标记
- 429/5xx/超时维持配置的 60s 冷却；NonRetryable 客户端 4xx 依旧不进健康度
- 已知债务：429 的「余额不足」变体需解析响应体才能区分，先按瞬态处理

## 验证

- `cargo test`：3301 通过（含新增 6 条：守卫契约 / TTFT 归档 / TTFT 加权聚合 / 迁移形状 / 致命开闸 / 成功清致命）
- `cargo clippy -D warnings`、`cargo fmt`、`tsc --noEmit`、`vitest run`（1104 通过）全绿

## 后续

- M2：策略排序器（Cheapest 默认 / Fastest）注入 `select_providers`，开启时一次性授权
- M3：托盘收敛为 app→模型映射