### PR TITLE
feat(proxy): 自动模式 M2-a —— 策略排序器注入选路（价格最低/响应最快 + 会话亲和）

### DIFF
--- a/src-tauri/src/commands/auto_mode.rs
+++ b/src-tauri/src/commands/auto_mode.rs
@@ -1,0 +1,142 @@
+//! 自动模式命令（LoongPort）。
+//!
+//! 自动模式：用户只选 app（和模型，M3），系统按全局策略（价格最低默认 /
+//! 响应最快）从托管档位里自动挑最合适的，当前档位带会话亲和。
+//! 选路注入在 `proxy::provider_router::select_providers`，这里只负责开关、
+//! 策略与「开启即切到策略第一名」的编排。
+
+use crate::events::PROVIDER_SWITCHED;
+use crate::proxy::auto_strategy::{self, AutoStrategy};
+use crate::store::AppState;
+use std::str::FromStr;
+use tauri::Emitter;
+
+/// 自动模式状态快照（前端一次拉全）。
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AutoModeStatus {
+    pub enabled: bool,
+    /// "cheapest" | "fastest"
+    pub strategy: String,
+}
+
+fn require_auto_mode_app(app_type: &str) -> Result<(), String> {
+    let app = crate::app_config::AppType::from_str(app_type)
+        .map_err(|error| format!("无效的应用类型: {error}"))?;
+    if !app.supports_local_proxy() {
+        return Err(format!("{} 不支持自动模式", app.as_str()));
+    }
+    Ok(())
+}
+
+/// 读取某应用的自动模式状态
+#[tauri::command]
+pub async fn get_auto_mode_status(
+    state: tauri::State<'_, AppState>,
+    app_type: String,
+) -> Result<AutoModeStatus, String> {
+    require_auto_mode_app(&app_type)?;
+    Ok(AutoModeStatus {
+        enabled: auto_strategy::is_auto_mode_enabled(&state.db, &app_type),
+        strategy: auto_strategy::get_strategy(&state.db).as_str().to_string(),
+    })
+}
+
+/// 设置某应用的自动模式开关。
+///
+/// 开启要求该应用已处于代理接管态（与故障转移同一条前置：自动切换只发生在
+/// 接管态，CLI 流量走本地代理，热切换无感）。开启成功后立即切到策略第一名，
+/// 让「开了自动模式」的语义当场兑现；关闭只落开关，不动当前供应商。
+#[tauri::command]
+pub async fn set_auto_mode_enabled(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+    app_type: String,
+    enabled: bool,
+) -> Result<(), String> {
+    require_auto_mode_app(&app_type)?;
+    log::info!("[AutoMode] Setting enabled: app_type='{app_type}', enabled={enabled}");
+
+    if enabled {
+        let config = state
+            .db
+            .get_proxy_config_for_app(&app_type)
+            .await
+            .map_err(|e| e.to_string())?;
+        if !config.enabled {
+            return Err("需要先启用该应用的代理接管，再开启自动模式".to_string());
+        }
+
+        // 候选必须非空才允许开 —— 空开会在 select_providers 里静默回退常规选路，
+        // 用户以为开了自动模式实际没生效。
+        // 排序与选路共用同一份实现（auto_strategy::rank_managed_tier_candidates，
+        // 含会话亲和置顶）：活跃会话里第一名就是当前档位，切换为 no-op，不丢缓存。
+        let Some(ranked) = auto_strategy::rank_managed_tier_candidates(&state.db, &app_type)
+            .map_err(|e| e.to_string())?
+        else {
+            return Err(
+                "没有可用的托管档位，无法开启自动模式。请先在中转站区登录并获取档位。".to_string(),
+            );
+        };
+
+        if let Some(best) = ranked.first() {
+            let best_id = best.id.clone();
+            let current_id = auto_strategy::effective_current_provider_id(&state.db, &app_type);
+            if current_id.as_deref() != Some(best_id.as_str()) {
+                state
+                    .proxy_service
+                    .switch_proxy_target(&app_type, &best_id)
+                    .await
+                    .map_err(|e| e.to_string())?;
+
+                let _ = app.emit(
+                    PROVIDER_SWITCHED,
+                    serde_json::json!({
+                        "appType": app_type,
+                        "providerId": best_id,
+                        "source": "autoModeEnabled"
+                    }),
+                );
+            }
+        }
+    }
+
+    auto_strategy::set_enabled(&state.db, &app_type, enabled).map_err(|e| e.to_string())?;
+
+    // 刷新托盘菜单，确保状态同步
+    if let Ok(new_menu) = crate::tray::create_tray_menu(&app, &state) {
+        if let Some(tray) = app.tray_by_id(crate::tray::TRAY_ID) {
+            let _ = tray.set_menu(Some(new_menu));
+        }
+    }
+
+    Ok(())
+}
+
+/// 设置全局策略（cheapest / fastest）。
+///
+/// 只落设置不主动切换：新策略从下一批请求的排序生效（会话亲和仍然优先，
+/// 活跃会话不会被策略切换打断 —— 那正是亲和规则存在的理由）。
+#[tauri::command]
+pub async fn set_auto_mode_strategy(
+    state: tauri::State<'_, AppState>,
+    strategy: String,
+) -> Result<(), String> {
+    let parsed = match strategy.as_str() {
+        "cheapest" => AutoStrategy::Cheapest,
+        "fastest" => AutoStrategy::Fastest,
+        other => return Err(format!("未知的自动模式策略: {other}")),
+    };
+    auto_strategy::set_strategy(&state.db, parsed).map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::require_auto_mode_app;
+
+    #[test]
+    fn auto_mode_rejects_apps_without_a_proxy_data_plane() {
+        assert!(require_auto_mode_app("claude").is_ok());
+        assert!(require_auto_mode_app("pi").is_err());
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,6 +1,8 @@
 #![allow(non_snake_case)]
 
 mod auth;
+// 自动模式（系统按策略挑托管档位）：选路在 proxy 层，这里是开关/策略命令层。
+mod auto_mode;
 mod balance;
 mod codex_oauth;
 mod coding_plan;
@@ -50,6 +52,7 @@ mod webdav_sync;
 mod workspace;
 
 pub use auth::*;
+pub use auto_mode::*;
 pub use balance::*;
 pub use codex_oauth::*;
 pub use coding_plan::*;

--- a/src-tauri/src/database/dao/providers.rs
+++ b/src-tauri/src/database/dao/providers.rs
@@ -403,6 +403,34 @@ impl Database {
         Ok(())
     }
 
+    /// 批量读一个应用下全部档位的存库倍率（自动模式「价格最低」策略用）。
+    ///
+    /// 只返回有值的行：key 不在 map 里 = 倍率未知（排序时当最贵处理，
+    /// 见 `proxy::auto_strategy`），免得调用方到处拆 `Option`。
+    pub fn get_tier_rate_multipliers(
+        &self,
+        app_type: &str,
+    ) -> Result<HashMap<String, f64>, AppError> {
+        let conn = lock_conn!(self.conn);
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, tier_rate_multiplier FROM providers
+                 WHERE app_type = ?1 AND tier_rate_multiplier IS NOT NULL",
+            )
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        let rows = stmt
+            .query_map(params![app_type], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?))
+            })
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        let mut result = HashMap::new();
+        for row in rows {
+            let (id, multiplier) = row.map_err(|e| AppError::Database(e.to_string()))?;
+            result.insert(id, multiplier);
+        }
+        Ok(result)
+    }
+
     pub fn update_provider_settings_config(
         &self,
         app_type: &str,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1857,6 +1857,10 @@ pub fn run() {
             commands::remove_from_failover_queue,
             commands::get_auto_failover_enabled,
             commands::set_auto_failover_enabled,
+            // Auto mode (LoongPort): 系统按策略自动挑托管档位
+            commands::get_auto_mode_status,
+            commands::set_auto_mode_enabled,
+            commands::set_auto_mode_strategy,
             // Usage statistics
             commands::get_usage_summary,
             commands::get_usage_summary_by_app,

--- a/src-tauri/src/proxy/auto_strategy.rs
+++ b/src-tauri/src/proxy/auto_strategy.rs
@@ -1,0 +1,369 @@
+//! 自动模式策略排序（LoongPort）。
+//!
+//! 产品语义：用户只选 app（和模型，M3），系统从可用托管档位里按策略挑最合适的：
+//! - **Cheapest（默认）**：按 `providers.tier_rate_multiplier` 升序；
+//! - **Fastest**：按最近窗口的平均首字耗时（TTFT）升序。
+//!
+//! ## 会话亲和（硬需求）
+//!
+//! 同一会话中途切换供应商会丢失提示词缓存，未命中缓存的请求按全价计费 ——
+//! 所以**当前在用档位只要近期还有流量，就保持置顶**，策略重排只影响它身后的
+//! 候选顺序（当前档位故障熔断后自然落到重排结果上）。闲置超过亲和窗口，
+//! 重排才真正接管（下一批请求由策略第一名服务，成功后热切换）。
+//!
+//! ## 为什么是独立模块
+//!
+//! `provider_router` / `circuit_breaker` 来自上游，选路骨架保持最小改动；
+//! 自动模式的排序判据、窗口、亲和规则全是 LoongPort 语义，收在这里。
+
+use crate::database::Database;
+use crate::provider::Provider;
+use std::cmp::Ordering;
+use std::str::FromStr;
+
+/// settings 表里「某应用自动模式是否开启」的 key 前缀（`auto_mode_enabled_<app>`）。
+pub const SETTING_ENABLED_PREFIX: &str = "auto_mode_enabled_";
+/// settings 表里全局策略的 key（`cheapest` / `fastest`）。
+pub const SETTING_STRATEGY: &str = "auto_mode_strategy";
+
+/// 会话亲和窗口：当前档位最近一次请求距今小于该值即视为「会话进行中」。
+/// 30 分钟 ≈ 一次长编码会话的自然间隔，期间不因策略重排切走。
+/// 公开给 `provider_router`（非托管当前供应商的置顶判断用同一窗口，别两处各写一份）。
+pub const AFFINITY_WINDOW_SECS: i64 = 30 * 60;
+
+/// TTFT 统计窗口：只看最近 7 天的首字耗时（更早的对「现在谁快」没有代表性，
+/// 且窗口必须 ≤ 明细保留天数，prune 掉的数据不参与）。
+const TTFT_WINDOW_SECS: i64 = 7 * 86400;
+
+/// 自动模式策略。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoStrategy {
+    /// 价格最低：按档位倍率升序（默认）。
+    Cheapest,
+    /// 响应最快：按平均首字耗时升序。
+    Fastest,
+}
+
+impl AutoStrategy {
+    /// 从 settings 值解析；不认识的值落回默认（cheapest），别让脏数据炸掉选路。
+    pub fn from_setting_value(value: &str) -> Self {
+        match value {
+            "fastest" => Self::Fastest,
+            _ => Self::Cheapest,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Cheapest => "cheapest",
+            Self::Fastest => "fastest",
+        }
+    }
+}
+
+/// 某应用的自动模式是否开启（settings 表，缺省 false）。
+pub fn is_auto_mode_enabled(db: &Database, app_type: &str) -> bool {
+    db.get_setting(&format!("{SETTING_ENABLED_PREFIX}{app_type}"))
+        .ok()
+        .flatten()
+        .is_some_and(|value| value == "true")
+}
+
+/// 读全局策略（缺省 cheapest）。
+pub fn get_strategy(db: &Database) -> AutoStrategy {
+    db.get_setting(SETTING_STRATEGY)
+        .ok()
+        .flatten()
+        .map(|value| AutoStrategy::from_setting_value(&value))
+        .unwrap_or(AutoStrategy::Cheapest)
+}
+
+/// 写入某应用的自动模式开关。
+pub fn set_enabled(
+    db: &Database,
+    app_type: &str,
+    enabled: bool,
+) -> Result<(), crate::error::AppError> {
+    db.set_setting(
+        &format!("{SETTING_ENABLED_PREFIX}{app_type}"),
+        if enabled { "true" } else { "false" },
+    )
+}
+
+/// 写入全局策略。
+pub fn set_strategy(db: &Database, strategy: AutoStrategy) -> Result<(), crate::error::AppError> {
+    db.set_setting(SETTING_STRATEGY, strategy.as_str())
+}
+
+/// 当前供应商 id：本地 settings 优先（校验存在性），fallback 到数据库 is_current。
+/// `provider_router` 的常规选路与自动模式候选共用这一份解析。
+pub fn effective_current_provider_id(db: &Database, app_type: &str) -> Option<String> {
+    crate::app_config::AppType::from_str(app_type)
+        .ok()
+        .and_then(|app_enum| {
+            crate::settings::get_effective_current_provider(db, &app_enum)
+                .ok()
+                .flatten()
+        })
+        .or_else(|| db.get_current_provider(app_type).ok().flatten())
+}
+
+/// 自动模式候选（选路与「开启即切最优」命令共用，唯源）：
+/// 该应用全部托管档位，按策略排序；当前在用档位（含非托管）会话活跃时置顶。
+/// 没有任何托管档位时返回 `None`（调用方回退常规选路 / 拒绝开启）。
+///
+/// 当前在用的是**非托管**供应商（用户自选的官网直连等）且会话活跃时，同样置顶 ——
+/// 亲和规则的判据是「切换丢缓存」，与在用的是不是托管档位无关；用户的手动选择
+/// 在他闲置或该供应商熔断之前不被系统挤走。
+pub fn rank_managed_tier_candidates(
+    db: &Database,
+    app_type: &str,
+) -> Result<Option<Vec<Provider>>, crate::error::AppError> {
+    let tiers: Vec<Provider> = db
+        .get_all_providers(app_type)?
+        .values()
+        .filter(|p| crate::relay::is_managed(&p.id))
+        .cloned()
+        .collect();
+
+    if tiers.is_empty() {
+        return Ok(None);
+    }
+
+    let current_id = effective_current_provider_id(db, app_type);
+    let now = chrono::Utc::now().timestamp();
+    let mut ranked = rank_tiers(
+        db,
+        app_type,
+        &tiers,
+        current_id.as_deref(),
+        get_strategy(db),
+        now,
+    );
+
+    if let Some(current_id) = current_id.as_deref() {
+        let already_first = ranked.first().is_some_and(|p| p.id == current_id);
+        if !already_first {
+            let session_active = db
+                .get_provider_last_activity(app_type)?
+                .get(current_id)
+                .is_some_and(|last| now - *last < AFFINITY_WINDOW_SECS);
+            if session_active {
+                if let Some(current) = db.get_provider_by_id(current_id, app_type)? {
+                    ranked.insert(0, current);
+                }
+            }
+        }
+    }
+
+    Ok(Some(ranked))
+}
+
+/// 对托管档位按策略排序；当前在用档位在亲和窗口内保持置顶。
+///
+/// `now` 由调用方注入（unix 秒），测试里可以拨时钟。
+/// 排序键带上档位 id 做最终 tie-breaker，保证结果确定（同名倍率/同无样本时
+/// 不会因 HashMap 遍历序而抖动）。
+pub fn rank_tiers(
+    db: &Database,
+    app_type: &str,
+    tiers: &[Provider],
+    current_id: Option<&str>,
+    strategy: AutoStrategy,
+    now: i64,
+) -> Vec<Provider> {
+    let multipliers = db.get_tier_rate_multipliers(app_type).unwrap_or_default();
+    let ttft = db
+        .get_provider_avg_first_token_ms(app_type, now - TTFT_WINDOW_SECS)
+        .unwrap_or_default();
+    let last_activity = db.get_provider_last_activity(app_type).unwrap_or_default();
+
+    let cost_of =
+        |p: &Provider| -> f64 { multipliers.get(&p.id).copied().unwrap_or(f64::INFINITY) };
+    let ttft_of = |p: &Provider| -> u64 { ttft.get(&p.id).copied().unwrap_or(u64::MAX) };
+
+    let mut ranked = tiers.to_vec();
+    ranked.sort_by(|a, b| {
+        let primary = match strategy {
+            AutoStrategy::Cheapest => cost_of(a)
+                .partial_cmp(&cost_of(b))
+                .unwrap_or(Ordering::Equal),
+            AutoStrategy::Fastest => ttft_of(a).cmp(&ttft_of(b)),
+        };
+        // 次级键互为 fallback： cheapest 时更快者先（同价选快的），
+        // fastest 时更便宜者先（同速选便宜的），冷启动（无 TTFT 样本）也能有序。
+        let secondary = match strategy {
+            AutoStrategy::Cheapest => ttft_of(a).cmp(&ttft_of(b)),
+            AutoStrategy::Fastest => cost_of(a)
+                .partial_cmp(&cost_of(b))
+                .unwrap_or(Ordering::Equal),
+        };
+        primary.then(secondary).then_with(|| a.id.cmp(&b.id))
+    });
+
+    // 会话亲和：当前档位近期活跃 → 置顶（见模块文档）。不活跃/无记录则不动。
+    if let Some(current_id) = current_id {
+        let session_active = last_activity
+            .get(current_id)
+            .is_some_and(|last| now - *last < AFFINITY_WINDOW_SECS);
+        if session_active {
+            if let Some(pos) = ranked.iter().position(|p| p.id == current_id) {
+                let current = ranked.remove(pos);
+                ranked.insert(0, current);
+            }
+        }
+    }
+
+    ranked
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::Database;
+    use crate::relay::provision;
+    use serde_json::json;
+
+    /// 生成一个真实形状的托管档位 id（钉住 is_managed 判据，别手写假的）。
+    fn managed_id(site: &str, group: i64, salt: i64) -> String {
+        let id = provision::provider_id_for(site, Some(group), salt);
+        assert!(crate::relay::is_managed(&id));
+        id
+    }
+
+    fn tier(id: &str, name: &str) -> Provider {
+        Provider::with_id(id.to_string(), name.to_string(), json!({}), None)
+    }
+
+    fn seed_activity(db: &Database, app_type: &str, provider_id: &str, at: i64, ttft_ms: i64) {
+        let conn = db.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO proxy_request_logs (
+                request_id, provider_id, app_type, model,
+                input_tokens, output_tokens, total_cost_usd,
+                latency_ms, first_token_ms, status_code, created_at
+            ) VALUES (?1, ?2, ?3, 'm', 1, 1, '0', 10, ?4, 200, ?5)",
+            rusqlite::params![
+                format!("act-{provider_id}-{at}-{ttft_ms}"),
+                provider_id,
+                app_type,
+                ttft_ms,
+                at
+            ],
+        )
+        .unwrap();
+    }
+
+    fn now() -> i64 {
+        chrono::Utc::now().timestamp()
+    }
+
+    #[test]
+    fn cheapest_orders_by_multiplier_with_unknown_last() {
+        let db = Database::memory().unwrap();
+        let cheap = managed_id("https://a.example", 1, 1);
+        let mid = managed_id("https://b.example", 1, 2);
+        let unknown = managed_id("https://c.example", 1, 3);
+        let tiers = vec![tier(&unknown, "U"), tier(&cheap, "C"), tier(&mid, "M")];
+
+        // 倍率是 providers 表的列：行不存在时 UPDATE 静默落空，必须先存行
+        for p in &tiers {
+            db.save_provider("claude", p).unwrap();
+        }
+        db.set_tier_rate_multiplier("claude", &cheap, Some(0.5))
+            .unwrap();
+        db.set_tier_rate_multiplier("claude", &mid, Some(1.2))
+            .unwrap();
+
+        let ranked = rank_tiers(&db, "claude", &tiers, None, AutoStrategy::Cheapest, now());
+        let ids: Vec<&str> = ranked.iter().map(|p| p.id.as_str()).collect();
+        // 倍率未知（None）当最贵处理，排最后 —— 别让「不知道价格」变成「最便宜」
+        assert_eq!(ids, vec![cheap.as_str(), mid.as_str(), unknown.as_str()]);
+    }
+
+    #[test]
+    fn fastest_orders_by_ttft_with_sampleless_last() {
+        let db = Database::memory().unwrap();
+        let fast = managed_id("https://a.example", 1, 1);
+        let slow = managed_id("https://b.example", 1, 2);
+        let cold = managed_id("https://c.example", 1, 3);
+        let tiers = vec![tier(&cold, "Cold"), tier(&slow, "S"), tier(&fast, "F")];
+
+        let t = now();
+        seed_activity(&db, "claude", &fast, t - 60, 120);
+        seed_activity(&db, "claude", &slow, t - 60, 900);
+
+        let ranked = rank_tiers(&db, "claude", &tiers, None, AutoStrategy::Fastest, t);
+        let ids: Vec<&str> = ranked.iter().map(|p| p.id.as_str()).collect();
+        // 有样本的按耗时升序；无 TTFT 样本（cold）排最后 —— 冷启动不抢跑
+        assert_eq!(ids, vec![fast.as_str(), slow.as_str(), cold.as_str()]);
+    }
+
+    #[test]
+    fn affinity_hoists_recently_active_current_tier() {
+        let db = Database::memory().unwrap();
+        let expensive_current = managed_id("https://a.example", 1, 1);
+        let cheap = managed_id("https://b.example", 1, 2);
+        let tiers = vec![tier(&expensive_current, "Cur"), tier(&cheap, "C")];
+
+        for p in &tiers {
+            db.save_provider("claude", p).unwrap();
+        }
+        db.set_tier_rate_multiplier("claude", &expensive_current, Some(2.0))
+            .unwrap();
+        db.set_tier_rate_multiplier("claude", &cheap, Some(0.5))
+            .unwrap();
+
+        let t = now();
+        // 当前档位 10 分钟前还有流量 → 会话进行中，保持置顶
+        seed_activity(&db, "claude", &expensive_current, t - 600, 500);
+
+        let ranked = rank_tiers(
+            &db,
+            "claude",
+            &tiers,
+            Some(&expensive_current),
+            AutoStrategy::Cheapest,
+            t,
+        );
+        assert_eq!(ranked[0].id, expensive_current);
+
+        // 闲置超过亲和窗口 → 重排接管，最便宜的回到第一
+        let ranked_idle = rank_tiers(
+            &db,
+            "claude",
+            &tiers,
+            Some(&expensive_current),
+            AutoStrategy::Cheapest,
+            t + AFFINITY_WINDOW_SECS + 1,
+        );
+        assert_eq!(ranked_idle[0].id, cheap);
+    }
+
+    #[test]
+    fn strategy_setting_roundtrip_and_default() {
+        let db = Database::memory().unwrap();
+        assert_eq!(get_strategy(&db), AutoStrategy::Cheapest);
+
+        set_strategy(&db, AutoStrategy::Fastest).unwrap();
+        assert_eq!(get_strategy(&db), AutoStrategy::Fastest);
+
+        // 脏数据不炸选路：落回默认
+        db.set_setting(SETTING_STRATEGY, "nonsense").unwrap();
+        assert_eq!(get_strategy(&db), AutoStrategy::Cheapest);
+    }
+
+    #[test]
+    fn enabled_flag_roundtrip() {
+        let db = Database::memory().unwrap();
+        assert!(!is_auto_mode_enabled(&db, "claude"));
+
+        set_enabled(&db, "claude", true).unwrap();
+        assert!(is_auto_mode_enabled(&db, "claude"));
+        // 按 app 隔离
+        assert!(!is_auto_mode_enabled(&db, "codex"));
+
+        set_enabled(&db, "claude", false).unwrap();
+        assert!(!is_auto_mode_enabled(&db, "claude"));
+    }
+}

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! 提供本地HTTP代理服务，支持多Provider故障转移和请求透传
 
+pub mod auto_strategy;
 pub mod body_filter;
 pub mod cache_injector;
 pub mod circuit_breaker;

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -2,13 +2,11 @@
 //!
 //! 负责选择和管理代理目标供应商，实现智能故障转移
 
-use crate::app_config::AppType;
 use crate::database::Database;
 use crate::error::AppError;
 use crate::provider::Provider;
 use crate::proxy::circuit_breaker::{AllowResult, CircuitBreaker, CircuitBreakerConfig};
 use std::collections::HashMap;
-use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -31,66 +29,84 @@ impl ProviderRouter {
 
     /// 选择可用的供应商（支持故障转移）
     ///
-    /// 返回按优先级排序的可用供应商列表：
-    /// - 故障转移关闭时：仅返回当前供应商
+    /// 返回按优先级排序的可用供应商列表，优先级从高到低：
+    /// - 自动模式开启时：托管档位按策略排序（Cheapest/Fastest，会话亲和置顶当前档位）
     /// - 故障转移开启时：仅使用故障转移队列，按队列顺序依次尝试（P1 → P2 → ...）
+    /// - 两者都关闭时：仅返回当前供应商
     pub async fn select_providers(&self, app_type: &str) -> Result<Vec<Provider>, AppError> {
         let mut result = Vec::new();
         let mut total_providers = 0usize;
         let mut circuit_open_count = 0usize;
 
-        // 检查该应用的自动故障转移开关是否开启（从 proxy_config 表读取）
-        let auto_failover_enabled = match self.db.get_proxy_config_for_app(app_type).await {
-            Ok(config) => config.auto_failover_enabled,
-            Err(e) => {
-                log::error!("[{app_type}] 读取 proxy_config 失败: {e}，默认禁用故障转移");
-                false
-            }
-        };
-
-        if auto_failover_enabled {
-            // 故障转移开启：仅按队列顺序依次尝试（P1 → P2 → ...）
-            let all_providers = self.db.get_all_providers(app_type)?;
-
-            // 使用 DAO 返回的排序结果，确保和前端展示一致
-            let ordered_ids: Vec<String> = self
-                .db
-                .get_failover_queue(app_type)?
-                .into_iter()
-                .map(|item| item.provider_id)
-                .collect();
-
-            total_providers = ordered_ids.len();
-
-            for provider_id in ordered_ids {
-                let Some(provider) = all_providers.get(&provider_id).cloned() else {
-                    continue;
-                };
-
-                let circuit_key = format!("{app_type}:{}", provider.id);
-                let breaker = self.get_or_create_circuit_breaker(&circuit_key).await;
-
-                if breaker.is_available().await {
-                    result.push(provider);
-                } else {
-                    circuit_open_count += 1;
+        // 自动模式（LoongPort）：托管档位按策略排序，优先于故障转移队列 ——
+        // 同时开着两个时以自动模式为准（用户把选择权交给了系统，队列不再有意义）。
+        // 没有托管档位时回落到下面的常规选路，别让请求直接失败。
+        let auto_mode_candidates =
+            if crate::proxy::auto_strategy::is_auto_mode_enabled(&self.db, app_type) {
+                match self.collect_auto_mode_candidates(app_type).await? {
+                    Some(candidates) => {
+                        total_providers = candidates.len();
+                        Some(candidates)
+                    }
+                    None => {
+                        log::warn!("[{app_type}] 自动模式开启但没有托管档位，回退到常规选路");
+                        None
+                    }
                 }
-            }
-        } else {
-            // 故障转移关闭：仅使用当前供应商，跳过熔断器检查
-            let current_id = AppType::from_str(app_type)
-                .ok()
-                .and_then(|app_enum| {
-                    crate::settings::get_effective_current_provider(&self.db, &app_enum)
-                        .ok()
-                        .flatten()
-                })
-                .or_else(|| self.db.get_current_provider(app_type).ok().flatten());
+            } else {
+                None
+            };
 
-            if let Some(current_id) = current_id {
-                if let Some(current) = self.db.get_provider_by_id(&current_id, app_type)? {
-                    total_providers = 1;
-                    result.push(current);
+        if let Some(candidates) = auto_mode_candidates {
+            self.filter_by_circuit_breaker(
+                app_type,
+                candidates,
+                &mut result,
+                &mut circuit_open_count,
+            )
+            .await;
+        } else {
+            // 检查该应用的自动故障转移开关是否开启（从 proxy_config 表读取）
+            let auto_failover_enabled = match self.db.get_proxy_config_for_app(app_type).await {
+                Ok(config) => config.auto_failover_enabled,
+                Err(e) => {
+                    log::error!("[{app_type}] 读取 proxy_config 失败: {e}，默认禁用故障转移");
+                    false
+                }
+            };
+
+            if auto_failover_enabled {
+                // 故障转移开启：仅按队列顺序依次尝试（P1 → P2 → ...）
+                let all_providers = self.db.get_all_providers(app_type)?;
+
+                // 使用 DAO 返回的排序结果，确保和前端展示一致
+                let ordered_ids: Vec<String> = self
+                    .db
+                    .get_failover_queue(app_type)?
+                    .into_iter()
+                    .map(|item| item.provider_id)
+                    .collect();
+
+                let ordered = ordered_ids
+                    .into_iter()
+                    .filter_map(|id| all_providers.get(&id).cloned())
+                    .collect::<Vec<_>>();
+                total_providers = ordered.len();
+
+                self.filter_by_circuit_breaker(
+                    app_type,
+                    ordered,
+                    &mut result,
+                    &mut circuit_open_count,
+                )
+                .await;
+            } else {
+                // 故障转移关闭：仅使用当前供应商，跳过熔断器检查
+                if let Some(current_id) = self.resolve_current_provider_id(app_type) {
+                    if let Some(current) = self.db.get_provider_by_id(&current_id, app_type)? {
+                        total_providers = 1;
+                        result.push(current);
+                    }
                 }
             }
         }
@@ -106,6 +122,40 @@ impl ProviderRouter {
         }
 
         Ok(result)
+    }
+
+    /// 自动模式候选：委托给 `auto_strategy::rank_managed_tier_candidates`
+    /// （选路与「开启即切最优」命令共用同一份实现，唯源）。
+    async fn collect_auto_mode_candidates(
+        &self,
+        app_type: &str,
+    ) -> Result<Option<Vec<Provider>>, AppError> {
+        crate::proxy::auto_strategy::rank_managed_tier_candidates(&self.db, app_type)
+    }
+
+    /// 当前供应商 id：本地 settings 优先（校验存在性），fallback 到数据库 is_current。
+    fn resolve_current_provider_id(&self, app_type: &str) -> Option<String> {
+        crate::proxy::auto_strategy::effective_current_provider_id(&self.db, app_type)
+    }
+
+    /// 按熔断器可用性过滤候选，累计放行结果与熔断计数。
+    async fn filter_by_circuit_breaker(
+        &self,
+        app_type: &str,
+        candidates: Vec<Provider>,
+        result: &mut Vec<Provider>,
+        circuit_open_count: &mut usize,
+    ) {
+        for provider in candidates {
+            let circuit_key = format!("{app_type}:{}", provider.id);
+            let breaker = self.get_or_create_circuit_breaker(&circuit_key).await;
+
+            if breaker.is_available().await {
+                result.push(provider);
+            } else {
+                *circuit_open_count += 1;
+            }
+        }
     }
 
     /// 请求执行前获取熔断器“放行许可”
@@ -500,6 +550,87 @@ mod tests {
 
         assert_eq!(providers.len(), 1);
         assert_eq!(providers[0].id, managed_id);
+    }
+
+    /// 自动模式开启时：候选 = 该应用全部托管档位，按策略排序（默认 cheapest），
+    /// 与故障转移队列无关（队列里有别的 provider 也不掺进来）。
+    #[tokio::test]
+    #[serial]
+    async fn select_providers_auto_mode_ranks_managed_tiers_by_strategy() {
+        let _home = TempHome::new();
+        let db = Arc::new(Database::memory().unwrap());
+
+        let cheap = crate::relay::provision::provider_id_for("https://a.example", Some(1), 1);
+        let expensive = crate::relay::provision::provider_id_for("https://b.example", Some(1), 2);
+        db.save_provider(
+            "claude",
+            &Provider::with_id(expensive.clone(), "Expensive".to_string(), json!({}), None),
+        )
+        .unwrap();
+        db.save_provider(
+            "claude",
+            &Provider::with_id(cheap.clone(), "Cheap".to_string(), json!({}), None),
+        )
+        .unwrap();
+        db.set_tier_rate_multiplier("claude", &cheap, Some(0.5))
+            .unwrap();
+        db.set_tier_rate_multiplier("claude", &expensive, Some(2.0))
+            .unwrap();
+
+        // 队列里塞一个非托管 provider —— 自动模式下必须被无视
+        db.save_provider(
+            "claude",
+            &Provider::with_id(
+                "vendor-1".to_string(),
+                "Vendor".to_string(),
+                json!({}),
+                None,
+            ),
+        )
+        .unwrap();
+        db.add_to_failover_queue("claude", "vendor-1").unwrap();
+
+        crate::proxy::auto_strategy::set_enabled(&db, "claude", true).unwrap();
+
+        let router = ProviderRouter::new(db.clone());
+        let providers = router.select_providers("claude").await.unwrap();
+
+        assert_eq!(providers.len(), 2, "只有托管档位进候选");
+        assert_eq!(providers[0].id, cheap, "cheapest 策略下倍率低者第一");
+        assert_eq!(providers[1].id, expensive);
+    }
+
+    /// 自动模式开启但没有托管档位：回退常规选路（故障转移队列），
+    /// 不能因为开了自动模式就让请求无供应商可用。
+    #[tokio::test]
+    #[serial]
+    async fn select_providers_auto_mode_without_tiers_falls_back_to_failover() {
+        let _home = TempHome::new();
+        let db = Arc::new(Database::memory().unwrap());
+
+        db.save_provider(
+            "claude",
+            &Provider::with_id(
+                "vendor-1".to_string(),
+                "Vendor".to_string(),
+                json!({}),
+                None,
+            ),
+        )
+        .unwrap();
+        db.add_to_failover_queue("claude", "vendor-1").unwrap();
+
+        let mut config = db.get_proxy_config_for_app("claude").await.unwrap();
+        config.auto_failover_enabled = true;
+        db.update_proxy_config_for_app(config).await.unwrap();
+
+        crate::proxy::auto_strategy::set_enabled(&db, "claude", true).unwrap();
+
+        let router = ProviderRouter::new(db.clone());
+        let providers = router.select_providers("claude").await.unwrap();
+
+        assert_eq!(providers.len(), 1);
+        assert_eq!(providers[0].id, "vendor-1");
     }
 
     #[tokio::test]

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -1263,6 +1263,59 @@ impl Database {
         Ok(stats)
     }
 
+    /// 自动模式「响应最快」策略：各供应商在窗口内的平均首字耗时。
+    ///
+    /// 只统计有 first_token_ms 的行（流式成功请求）；窗口应 ≤ 明细保留天数，
+    /// 走 proxy_request_logs 即可（被 prune 掉的旧数据对「现在谁快」也没有代表性）。
+    /// key 不在返回值里 = 窗口内没有 TTFT 样本（排序时排最后，见 `proxy::auto_strategy`）。
+    pub fn get_provider_avg_first_token_ms(
+        &self,
+        app_type: &str,
+        since: i64,
+    ) -> Result<HashMap<String, u64>, AppError> {
+        let conn = lock_conn!(self.conn);
+        let mut stmt = conn.prepare(
+            "SELECT provider_id,
+                    SUM(first_token_ms) / SUM(CASE WHEN first_token_ms IS NOT NULL THEN 1 ELSE 0 END)
+             FROM proxy_request_logs
+             WHERE app_type = ?1 AND created_at >= ?2 AND first_token_ms IS NOT NULL
+             GROUP BY provider_id",
+        )?;
+        let rows = stmt.query_map(params![app_type, since], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })?;
+        let mut result = HashMap::new();
+        for row in rows {
+            let (provider_id, avg) = row?;
+            result.insert(provider_id, avg.max(0) as u64);
+        }
+        Ok(result)
+    }
+
+    /// 自动模式会话亲和：各供应商在该应用下的最近一次请求时间（unix 秒）。
+    ///
+    /// 用于判断「当前在用档位是否还在会话中」—— 切换会丢提示词缓存，
+    /// 近期有流量的档位保持置顶，闲置后才允许策略重排接管。
+    pub fn get_provider_last_activity(
+        &self,
+        app_type: &str,
+    ) -> Result<HashMap<String, i64>, AppError> {
+        let conn = lock_conn!(self.conn);
+        let mut stmt = conn.prepare(
+            "SELECT provider_id, MAX(created_at) FROM proxy_request_logs
+             WHERE app_type = ?1 GROUP BY provider_id",
+        )?;
+        let rows = stmt.query_map(params![app_type], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })?;
+        let mut result = HashMap::new();
+        for row in rows {
+            let (provider_id, last) = row?;
+            result.insert(provider_id, last);
+        }
+        Ok(result)
+    }
+
     /// 获取 Provider 统计
     pub fn get_provider_stats(
         &self,


### PR DESCRIPTION
## 自动模式第二期（M2-a / 后端 + 命令层）

用户只选 app（模型选择是 M3），系统从托管档位里按全局策略自动挑最合适的。本期把策略排序器注入选路；UI（开关/策略切换/一次性授权）在 M2-b。

### 策略排序（`proxy/auto_strategy.rs`，新文件）

- **Cheapest（默认）**：按 `tier_rate_multiplier` 升序；倍率未知当最贵排最后 —— 别让「不知道价格」变成「最便宜」
- **Fastest**：按 7 天窗口平均 TTFT 升序（M1 落地的 `first_token_ms` 聚合）；无样本垫底，冷启动不抢跑
- 次级键互为 fallback（同价选快、同速选便宜），档位 id 兜底，排序确定

### 会话亲和（硬需求）

同一会话中途切换供应商会丢提示词缓存、未命中缓存按全价计费。**当前在用供应商 30 分钟内有流量即置顶**，策略重排只影响它身后的候选；闲置后重排才接管。亲和对非托管的当前供应商同样生效 —— 判据是「切换丢缓存」，与在用的是不是托管档位无关，用户的手动选择不被挤走。

### 选路注入（`select_providers`）

- 自动模式优先于故障转移队列（选择权交给系统后队列不再有意义）
- 无托管档位回退常规选路，不让请求无供应商可用
- 熔断过滤复用（含 M1 的致命长冷却：401/402/403 一次即开 + 30 分钟）
- 排序实现唯源：选路与「开启即切最优」命令共用 `rank_managed_tier_candidates`

### 命令层（`commands/auto_mode.rs`）

- `get_auto_mode_status(appType)` → { enabled, strategy }
- `set_auto_mode_enabled`：要求接管态 + 存在托管档位；开启即切策略第一名（活跃会话里第一名就是当前档位，no-op 不丢缓存）
- `set_auto_mode_strategy`：全局策略（cheapest/fastest），落设置不主动切换 —— 新策略从下一批请求生效，活跃会话仍被亲和保护

## 验证

`cargo test` 3340 通过（新增 8 条），`clippy -D warnings`、`cargo fmt` 绿。

## 后续

M2-b：前端 UI（自动模式开关 + 策略选择 + 开启确认）；M3：托盘收敛为 app→模型映射。