### PR TITLE
feat(ui): 顶栏 GitHub 点星入口 + 首次注册成功后的一次性支持 toast

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -428,6 +428,17 @@ pub struct AppSettings {
     /// 与 `stats_notice_confirmed` / `proxy_confirmed` / `usage_confirmed` 同一个惯例。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cc_switch_import_prompted: Option<bool>,
+    /// 顶栏 GitHub 入口上的小红点被点过没有。
+    ///
+    /// `None` = 还没点过 ⇒ 前端显示红点。纯 UI 提示的一次性标志，
+    /// 与 `cc_switch_import_prompted` 同一个惯例。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub github_star_badge_clicked: Option<bool>,
+    /// 「去 GitHub 点个星」的 toast 出过没有。
+    ///
+    /// `None` = 还没出过 ⇒ 前端在首次注册成功后出一次。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub github_star_toast_shown: Option<bool>,
     /// Whether to show the failover toggle independently on the main page
     #[serde(default)]
     pub enable_failover_toggle: bool,
@@ -609,6 +620,8 @@ impl Default for AppSettings {
             stats_notice_confirmed: None,
             stats_install_id: None,
             cc_switch_import_prompted: None,
+            github_star_badge_clicked: None,
+            github_star_toast_shown: None,
             enable_failover_toggle: false,
             show_profile_switcher: true,
             // 见字段上的说明：这条保的是 ChatGPT 桌面版的登录凭据，LoongPort 必须默认开。

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,6 +77,8 @@ import { EditProviderDialog } from "@/components/providers/EditProviderDialog";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { SettingsPage } from "@/components/settings/SettingsPage";
 import { UpdateBadge } from "@/components/UpdateBadge";
+import { GitHubStarButton } from "@/components/GitHubStarButton";
+import { StarPromoToast } from "@/components/StarPromoToast";
 import { EnvWarningBanner } from "@/components/env/EnvWarningBanner";
 import { ProxyToggle } from "@/components/proxy/ProxyToggle";
 import { ClaudeDesktopRouteToggle } from "@/components/proxy/ClaudeDesktopRouteToggle";
@@ -1330,6 +1332,8 @@ function App() {
                     setCurrentView("settings");
                   }}
                 />
+                {/* GitHub 入口 + 首次小红点：自带全部状态（含点掉红点的持久化）。 */}
+                <GitHubStarButton />
                 {isCurrentAppTakeoverActive && (
                   <Button
                     variant="ghost"
@@ -1810,6 +1814,10 @@ function App() {
           `statsNoticeConfirmed`，没表态就一个字节都不发）。
           它自带「读设置 → 判要不要弹」的全部状态，这里只挂一行。 */}
       <StatsNoticeDialog />
+
+      {/* 首次注册成功后的一次性「点个星」toast：自带全部状态（含出过就不再出的
+          持久化），这里只挂一行 —— 与上面那个同一个模式。 */}
+      <StarPromoToast />
 
       {/* 切 codex 供应商前的「要不要退 ChatGPT」确认框。它由 `useCodexSwitchGuard`
           持有全部状态（弹不弹、切哪个），这里只挂一行 —— 与上面那个同一个模式。 */}

--- a/src/components/GitHubStarButton.tsx
+++ b/src/components/GitHubStarButton.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/components/ui/button";
+import { GithubIcon } from "@/components/icons/GithubIcon";
+import { GITHUB_REPO } from "@/config/constants";
+import { settingsApi } from "@/lib/api";
+import type { Settings } from "@/types";
+
+/**
+ * 顶栏的 GitHub 入口：常驻按钮 + 首次小红点。
+ *
+ * 红点在用户点过一次这个按钮后永久消失（`githubStarBadgeClicked` settings 标志，
+ * 与 `ccSwitchImportPrompted` 等一次性标志同一个惯例）。点掉 ≠ 点了星 ——
+ * GitHub 的 starred API 需要登录态授权，桌面客户端不该为验证一个 UI 提示去要它，
+ * 所以判据就是「点过」，不验证结果。
+ *
+ * 另一条「首次注册成功后的一次性 toast」在 `StarPromoToast`，与本按钮互不依赖
+ * （toast 的 action 跳同一个仓库，但用户从那边过去不会点这里的按钮 —— 两个标志各管各的）。
+ */
+export function GitHubStarButton() {
+  const { t } = useTranslation();
+  const [settings, setSettings] = useState<Settings | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    settingsApi
+      .get()
+      .then((s) => {
+        if (!cancelled) setSettings(s);
+      })
+      .catch(() => {
+        // 读不到设置就当已点过处理（不显示红点）：宁可少一个提示，不在顶栏挂一个
+        // 永远点不掉的假红点。
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // 注意是「加载完且未点过」才显示 —— 反过来（默认显示）会让已点过的用户每次
+  // 启动都看到红点闪一下再消失。
+  const showDot = settings !== null && settings.githubStarBadgeClicked !== true;
+
+  const handleClick = async () => {
+    // 乐观更新：打开浏览器的那一刻红点就该消失；持久化失败最坏结果是下次启动
+    // 红点再现，无害。
+    if (settings) setSettings({ ...settings, githubStarBadgeClicked: true });
+    await settingsApi.openExternal(GITHUB_REPO);
+    if (!settings) return;
+    try {
+      // `webdavSync` 是只读的聚合字段，save 时要摘掉（与仓里其它调用点一致）。
+      const { webdavSync: _webdavSync, ...rest } = settings;
+      await settingsApi.save({
+        ...rest,
+        githubStarBadgeClicked: true,
+      });
+    } catch {
+      // 见上：持久化失败可接受。
+    }
+  };
+
+  const title = t("loongport.star.buttonTitle");
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      title={title}
+      aria-label={title}
+      onClick={() => void handleClick()}
+      className="relative hover:bg-black/5 dark:hover:bg-white/5"
+    >
+      <GithubIcon className="h-4 w-4" />
+      {showDot && (
+        <span
+          className="absolute top-1 right-1 h-2 w-2 rounded-full bg-red-500"
+          aria-hidden="true"
+        />
+      )}
+    </Button>
+  );
+}

--- a/src/components/StarPromoToast.tsx
+++ b/src/components/StarPromoToast.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+
+import { GITHUB_REPO } from "@/config/constants";
+import { settingsApi } from "@/lib/api";
+import { ONBOARDING_REGISTER_COMPLETED } from "@/lib/api/events";
+import { useTauriEvent } from "@/hooks/useTauriEvent";
+import type { Settings } from "@/types";
+
+/** 注册成功 toast（`RelaySection` 发）与本条之间的间隔：别两条叠在一起。 */
+const SHOW_DELAY_MS = 5000;
+/** toast 停留时长：比默认略长，给用户看清和反应的时间。 */
+const TOAST_DURATION_MS = 10000;
+
+/**
+ * 「觉得有用就点个 ⭐」的一次性轻推：新用户第一次注册中转站成功（拿到核心价值）
+ * 之后，用 sonner toast —— 不是模态弹窗 —— 提一次 GitHub 点星，之后永不再现
+ *（`githubStarToastShown` settings 标志，与 `ccSwitchImportPrompted` 等同一个惯例）。
+ *
+ * 有意选 toast 而不是弹窗：模态求 star 是公认的打扰型做法，且本仓有意删过上游的
+ * 首启欢迎弹窗（见 `App.tsx` 挂载处的注释），不该再往回走。常驻入口在顶栏的
+ * `GitHubStarButton`，两者各管各的标志。
+ *
+ * 只挂在 `ONBOARDING_REGISTER_COMPLETED` 上：走「添加站点」手动路径的用户不推，
+ * 他们仍有顶栏入口 —— 一条提示链路够了，不为覆盖全体用户再加第二个触发点。
+ */
+export function StarPromoToast() {
+  const { t } = useTranslation();
+  const settingsRef = useRef<Settings | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    settingsApi
+      .get()
+      .then((s) => {
+        if (!cancelled) settingsRef.current = s;
+      })
+      .catch(() => {
+        // 读不到就不推：这是加分项，不为其报错。
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useTauriEvent<unknown>(ONBOARDING_REGISTER_COMPLETED, () => {
+    const settings = settingsRef.current;
+    // null = 设置还没加载完（注册窗至少要几秒，实际到不了这里）或加载失败 —— 都不推。
+    if (!settings || settings.githubStarToastShown === true) return;
+
+    // 先落标志再展示：存失败的话下次还会推，可接受；反过来（先展示后落）遇到崩溃
+    // 会推第二次。同时更新本地 ref，同一次进程里重复事件也不会推两条。
+    settingsRef.current = { ...settings, githubStarToastShown: true };
+    const { webdavSync: _webdavSync, ...rest } = settings;
+    settingsApi.save({ ...rest, githubStarToastShown: true }).catch(() => {});
+
+    window.setTimeout(() => {
+      toast(t("loongport.star.toastTitle"), {
+        description: t("loongport.star.toastBody"),
+        duration: TOAST_DURATION_MS,
+        action: {
+          label: t("loongport.star.toastAction"),
+          onClick: () => void settingsApi.openExternal(GITHUB_REPO),
+        },
+      });
+    }, SHOW_DELAY_MS);
+  });
+
+  return null;
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3387,6 +3387,12 @@
         "cancelled": "Verification stopped.",
         "invalidResponse": "The provider's response could not be verified. Try again later or review it manually."
       }
+    },
+    "star": {
+      "buttonTitle": "GitHub repository (star it if you like it)",
+      "toastTitle": "Enjoying LoongPort?",
+      "toastBody": "LoongPort is free and open source. A ⭐ on GitHub helps a lot.",
+      "toastAction": "Star on GitHub"
     }
   },
   "firstRunNotice": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3387,6 +3387,12 @@
         "cancelled": "検証を停止しました。",
         "invalidResponse": "プロバイダーの応答を検証できませんでした。しばらくしてから再試行するか、手動で確認してください。"
       }
+    },
+    "star": {
+      "buttonTitle": "GitHub リポジトリ（よければ ⭐ を）",
+      "toastTitle": "LoongPort はいかがですか？",
+      "toastBody": "LoongPort は無料のオープンソースです。GitHub で ⭐ を付けて応援してください。",
+      "toastAction": "スターを付ける"
     }
   },
   "firstRunNotice": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3388,6 +3388,12 @@
         "cancelled": "驗證已停止。",
         "invalidResponse": "服務商傳回的回應無法驗證。請稍後再試或人工複核。"
       }
+    },
+    "star": {
+      "buttonTitle": "GitHub 儲存庫（點個 ⭐ 支持一下）",
+      "toastTitle": "用得還順手嗎？",
+      "toastBody": "LoongPort 免費開源，去 GitHub 點個 ⭐ 支持一下吧。",
+      "toastAction": "去點星"
     }
   },
   "firstRunNotice": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -3387,6 +3387,12 @@
         "cancelled": "验证已停止。",
         "invalidResponse": "服务商返回的响应无法验证。请稍后重试或人工复核。"
       }
+    },
+    "star": {
+      "buttonTitle": "GitHub 仓库（点个 ⭐ 支持一下）",
+      "toastTitle": "用得还顺手吗？",
+      "toastBody": "LoongPort 免费开源，去 GitHub 点个 ⭐ 支持一下吧。",
+      "toastAction": "去点星"
     }
   },
   "firstRunNotice": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -403,6 +403,10 @@ export interface Settings {
   statsNoticeConfirmed?: boolean;
   /** 首启「是否一键导入 cc-switch」问过没。`undefined` = 还没问过 ⇒ 第一次打开时弹一次。 */
   ccSwitchImportPrompted?: boolean;
+  /** 顶栏 GitHub 入口的小红点点过没。`undefined` = 还没点过 ⇒ 显示红点。 */
+  githubStarBadgeClicked?: boolean;
+  /** 「点个星支持」toast 出过没。`undefined` = 还没出过 ⇒ 首次注册成功后出一次。 */
+  githubStarToastShown?: boolean;
   /**
    * 统计**专属**的随机安装 id。
    *


### PR DESCRIPTION
## Summary / 概述

给项目加两个「求 star」的入口（GitHub 站内搜索对低 star 仓库不可见，获客要靠产品内引导）：

- **顶栏 GitHub 入口**（设置齿轮旁）：常驻按钮，首次带小红点，点击打开仓库后红点永久消失。
- **一次性支持 toast**：新用户首次注册中转站成功（`onboarding-register-completed`）后约 5 秒，用 sonner toast（非模态）轻推一次「去点个 ⭐」，出过永不再现。

设计要点：

- 两个一次性标志走 settings（`githubStarBadgeClicked` / `githubStarToastShown`），与 `ccSwitchImportPrompted` 等既有惯例一致；Rust 侧 `Option<bool>` + serde default，老 settings.json 缺键读作 `None`。
- 判据是「点过 / 出过」，不验证用户是否真的 star 了——GitHub 的 starred API 需要登录态授权，桌面客户端不该为验证一个 UI 提示去要它。
- 有意不做模态弹窗：模态求 star 是打扰型做法，且本仓有意删过上游首启欢迎弹窗。
- 手动「添加站点」路径的用户不推 toast（只有顶栏入口）：一条提示链路够了，不为覆盖全体用户加第二个触发点。
- 新组件 `GitHubStarButton` / `StarPromoToast` 自带全部状态，`App.tsx` 只加两行挂载 + 一个按钮，改动面最小。

## Related Issue / 关联 Issue

无

## Screenshots / 截图

待手动 UI 验证后补。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
  （本地 clippy 在 `src/vendor/bigmodel.rs:580` 报一个既有 `bool_assert_comparison`，CI 工具链无此 lint、main 同代码全绿，不在本 PR 范围）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
