### PR TITLE
feat(tray): 自动模式 M3 —— 托盘收敛为 app→模型映射

### DIFF
--- a/src-tauri/src/commands/auto_mode.rs
+++ b/src-tauri/src/commands/auto_mode.rs
@@ -71,7 +71,7 @@ pub async fn set_auto_mode_enabled(
         // 用户以为开了自动模式实际没生效。
         // 排序与选路共用同一份实现（auto_strategy::rank_managed_tier_candidates，
         // 含会话亲和置顶）：活跃会话里第一名就是当前档位，切换为 no-op，不丢缓存。
-        let Some(ranked) = auto_strategy::rank_managed_tier_candidates(&state.db, &app_type)
+        let Some(ranked) = auto_strategy::rank_managed_tier_candidates(&state.db, &app_type, true)
             .map_err(|e| e.to_string())?
         else {
             return Err(
@@ -128,6 +128,128 @@ pub async fn set_auto_mode_strategy(
         other => return Err(format!("未知的自动模式策略: {other}")),
     };
     auto_strategy::set_strategy(&state.db, parsed).map_err(|e| e.to_string())
+}
+
+/// 设置某应用的自动模式模型偏好（M3 托盘 app→模型 映射的落点）。
+///
+/// `model = None` 表示「不限模型」。点选模型是**显式**选择：绕过会话亲和立即
+/// 切到「目录含该模型、策略最优」的档位（亲和保护的是系统重排别打断会话，
+/// 不替用户拒绝他刚点的选择），并把该档位的选中模型对齐到偏好。
+#[tauri::command]
+pub async fn set_auto_mode_model(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+    app_type: String,
+    model: Option<String>,
+) -> Result<(), String> {
+    set_auto_mode_model_impl(app, &state, &app_type, model.as_deref()).await
+}
+
+/// `set_auto_mode_model` 的可从托盘调用的核心（托盘事件处理拿不到
+/// `tauri::State`，但有 `AppHandle`）。
+pub(crate) async fn set_auto_mode_model_impl(
+    app: tauri::AppHandle,
+    state: &AppState,
+    app_type: &str,
+    model: Option<&str>,
+) -> Result<(), String> {
+    require_auto_mode_app(app_type)?;
+    if !auto_strategy::is_auto_mode_enabled(&state.db, app_type) {
+        return Err("自动模式未开启，请先在设置中开启再选择模型".to_string());
+    }
+    let config = state
+        .db
+        .get_proxy_config_for_app(app_type)
+        .await
+        .map_err(|e| e.to_string())?;
+    if !config.enabled {
+        return Err("自动模式需要代理接管态，请先恢复接管".to_string());
+    }
+
+    auto_strategy::set_model_pref(&state.db, app_type, model).map_err(|e| e.to_string())?;
+
+    // 显式选择：绕过亲和（honor_affinity=false），立即切到过滤+排序后的第一名
+    let ranked = auto_strategy::rank_managed_tier_candidates(&state.db, app_type, false)
+        .map_err(|e| e.to_string())?;
+    let Some(best) = ranked.and_then(|mut r| {
+        if r.is_empty() {
+            None
+        } else {
+            Some(r.remove(0))
+        }
+    }) else {
+        return Ok(()); // 偏好已落库；没有可切档位时下一次选路自然生效
+    };
+
+    let current_id = auto_strategy::effective_current_provider_id(&state.db, app_type);
+    if current_id.as_deref() != Some(best.id.as_str()) {
+        state
+            .proxy_service
+            .switch_proxy_target(app_type, &best.id)
+            .await
+            .map_err(|e| e.to_string())?;
+        let _ = app.emit(
+            PROVIDER_SWITCHED,
+            serde_json::json!({
+                "appType": app_type,
+                "providerId": best.id,
+                "source": "autoModeModel"
+            }),
+        );
+    }
+
+    // 对齐档位的选中模型（接管态下走热路径，无 ChatGPT 退重开编排）
+    if let Some(model) = model {
+        let wants_model = auto_strategy::tier_models(&best).iter().any(|m| m == model);
+        let current_model = crate::relay::provision::extract_model(&best.settings_config);
+        if wants_model && current_model.as_deref() != Some(model) {
+            let mut user_choice = None;
+            loop {
+                let outcome = crate::commands::switch_tier_model_command(
+                    &app,
+                    &best.id,
+                    crate::app_config::AppType::from_str(app_type).map_err(|e| e.to_string())?,
+                    model,
+                    user_choice,
+                )
+                .await
+                .map_err(|e| e.to_string())?;
+                match outcome {
+                    crate::commands::SwitchTierCommandResult::ConfirmationRequired {
+                        target_name,
+                    } => {
+                        // 原生确认对话框是阻塞调用，丢到 blocking 线程池别卡 async worker
+                        // （接管态下通常不会走到这里，见 needs_user_attention）
+                        let app_for_dialog = app.clone();
+                        let confirmed = tauri::async_runtime::spawn_blocking(move || {
+                            crate::tray::confirm_quit_chatgpt(&app_for_dialog, &target_name)
+                        })
+                        .await
+                        .unwrap_or(false);
+                        if !confirmed {
+                            return Ok(());
+                        }
+                        user_choice = Some(true);
+                    }
+                    crate::commands::SwitchTierCommandResult::Switched { result } => {
+                        for warning in &result.warnings {
+                            log::warn!("[AutoMode] 切换档位模型后警告: {warning}");
+                        }
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    }
+
+    // 刷新托盘菜单，确保勾选状态同步
+    if let Ok(new_menu) = crate::tray::create_tray_menu(&app, state) {
+        if let Some(tray) = app.tray_by_id(crate::tray::TRAY_ID) {
+            let _ = tray.set_menu(Some(new_menu));
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1861,6 +1861,7 @@ pub fn run() {
             commands::get_auto_mode_status,
             commands::set_auto_mode_enabled,
             commands::set_auto_mode_strategy,
+            commands::set_auto_mode_model,
             // Usage statistics
             commands::get_usage_summary,
             commands::get_usage_summary_by_app,

--- a/src-tauri/src/proxy/auto_strategy.rs
+++ b/src-tauri/src/proxy/auto_strategy.rs
@@ -25,6 +25,9 @@ use std::str::FromStr;
 pub const SETTING_ENABLED_PREFIX: &str = "auto_mode_enabled_";
 /// settings 表里全局策略的 key（`cheapest` / `fastest`）。
 pub const SETTING_STRATEGY: &str = "auto_mode_strategy";
+/// settings 表里「某应用模型偏好」的 key 前缀（`auto_mode_model_<app>`）。
+/// `None` = 不限模型（全部托管档位都进候选）。
+pub const SETTING_MODEL_PREFIX: &str = "auto_mode_model_";
 
 /// 会话亲和窗口：当前档位最近一次请求距今小于该值即视为「会话进行中」。
 /// 30 分钟 ≈ 一次长编码会话的自然间隔，期间不因策略重排切走。
@@ -95,6 +98,58 @@ pub fn set_strategy(db: &Database, strategy: AutoStrategy) -> Result<(), crate::
     db.set_setting(SETTING_STRATEGY, strategy.as_str())
 }
 
+/// 读某应用的模型偏好（`None` = 不限模型）。
+pub fn get_model_pref(db: &Database, app_type: &str) -> Option<String> {
+    db.get_setting(&format!("{SETTING_MODEL_PREFIX}{app_type}"))
+        .ok()
+        .flatten()
+        .filter(|value| !value.is_empty())
+}
+
+/// 写某应用的模型偏好（`None` 清除，回到不限）。
+pub fn set_model_pref(
+    db: &Database,
+    app_type: &str,
+    model: Option<&str>,
+) -> Result<(), crate::error::AppError> {
+    db.set_setting(
+        &format!("{SETTING_MODEL_PREFIX}{app_type}"),
+        model.unwrap_or(""),
+    )
+}
+
+/// 档位的模型目录（settings_config.modelCatalog）。目前只有 Codex 系托管档位
+/// 在 provision 时写目录；返回空 = 该档位没有目录（不参与模型过滤）。
+pub fn tier_models(tier: &Provider) -> Vec<String> {
+    crate::commands::codex_models_from_settings(&tier.settings_config)
+}
+
+/// 按模型偏好过滤候选：只保留目录里含偏好模型的档位。
+///
+/// 两类回退都不拦人：偏好的模型已从所有目录下架（过滤后为空）→ 回退全量，
+/// 选路不能因为一个过期偏好就没档位可用；该应用根本没有目录（非 Codex 系）
+/// → 过滤无意义，直接全量。无目录档位在有偏好时**不**保留 —— 目录都没有，
+/// 无法证明它能服务这个模型。
+fn filter_by_model_pref(tiers: Vec<Provider>, model_pref: Option<&str>) -> Vec<Provider> {
+    let Some(model) = model_pref else {
+        return tiers;
+    };
+    let has_catalogs = tiers.iter().any(|t| !tier_models(t).is_empty());
+    if !has_catalogs {
+        return tiers;
+    }
+    let filtered: Vec<Provider> = tiers
+        .iter()
+        .filter(|t| tier_models(t).iter().any(|m| m == model))
+        .cloned()
+        .collect();
+    if filtered.is_empty() {
+        log::warn!("[AutoMode] 模型偏好 {model} 不在任何档位目录中，回退全量候选");
+        return tiers;
+    }
+    filtered
+}
+
 /// 当前供应商 id：本地 settings 优先（校验存在性），fallback 到数据库 is_current。
 /// `provider_router` 的常规选路与自动模式候选共用这一份解析。
 pub fn effective_current_provider_id(db: &Database, app_type: &str) -> Option<String> {
@@ -108,16 +163,20 @@ pub fn effective_current_provider_id(db: &Database, app_type: &str) -> Option<St
         .or_else(|| db.get_current_provider(app_type).ok().flatten())
 }
 
-/// 自动模式候选（选路与「开启即切最优」命令共用，唯源）：
-/// 该应用全部托管档位，按策略排序；当前在用档位（含非托管）会话活跃时置顶。
-/// 没有任何托管档位时返回 `None`（调用方回退常规选路 / 拒绝开启）。
+/// 自动模式候选（选路与「开启即切最优/选模型」命令共用，唯源）：
+/// 该应用全部托管档位，按模型偏好过滤后按策略排序；当前在用档位（含非托管）
+/// 会话活跃时置顶。没有任何托管档位时返回 `None`（调用方回退常规选路 / 拒绝开启）。
 ///
 /// 当前在用的是**非托管**供应商（用户自选的官网直连等）且会话活跃时，同样置顶 ——
 /// 亲和规则的判据是「切换丢缓存」，与在用的是不是托管档位无关；用户的手动选择
 /// 在他闲置或该供应商熔断之前不被系统挤走。
+///
+/// `honor_affinity`：托盘点选模型是**显式**选择，绕过亲和立即切到目标 ——
+/// 亲和保护的是「系统重排别打断会话」，不是替用户拒绝他刚点的选择。
 pub fn rank_managed_tier_candidates(
     db: &Database,
     app_type: &str,
+    honor_affinity: bool,
 ) -> Result<Option<Vec<Provider>>, crate::error::AppError> {
     let tiers: Vec<Provider> = db
         .get_all_providers(app_type)?
@@ -130,7 +189,13 @@ pub fn rank_managed_tier_candidates(
         return Ok(None);
     }
 
-    let current_id = effective_current_provider_id(db, app_type);
+    let tiers = filter_by_model_pref(tiers, get_model_pref(db, app_type).as_deref());
+
+    let current_id = if honor_affinity {
+        effective_current_provider_id(db, app_type)
+    } else {
+        None
+    };
     let now = chrono::Utc::now().timestamp();
     let mut ranked = rank_tiers(
         db,
@@ -365,5 +430,58 @@ mod tests {
 
         set_enabled(&db, "claude", false).unwrap();
         assert!(!is_auto_mode_enabled(&db, "claude"));
+    }
+
+    /// 模型偏好过滤：有偏好时只留「目录含该模型」的档位（无目录档位不保留 ——
+    /// 无法证明它能服务这个模型）；偏好过期（不在任何目录）回退全量；
+    /// 无偏好全量。经 rank_managed_tier_candidates（honor_affinity=false）走真实路径。
+    #[test]
+    fn model_pref_filters_candidates_with_stale_fallback() {
+        let db = Database::memory().unwrap();
+        let has_sol = managed_id("https://a.example", 1, 1);
+        let has_nano = managed_id("https://b.example", 1, 2);
+        let no_catalog = managed_id("https://c.example", 1, 3);
+
+        let with_catalog =
+            |model: &str| serde_json::json!({ "modelCatalog": { "models": [{ "model": model }] } });
+        for (id, settings) in [
+            (&has_sol, with_catalog("gpt-5.6-sol")),
+            (&has_nano, with_catalog("gpt-5.6-nano")),
+            (&no_catalog, serde_json::json!({})),
+        ] {
+            let mut p = tier(id, id);
+            p.settings_config = settings;
+            db.save_provider("codex", &p).unwrap();
+        }
+
+        // 偏好 sol → 只剩目录含 sol 的档位（无目录档位被排除）
+        set_model_pref(&db, "codex", Some("gpt-5.6-sol")).unwrap();
+        let ranked = rank_managed_tier_candidates(&db, "codex", false)
+            .unwrap()
+            .expect("候选不应为空");
+        let ids: Vec<&str> = ranked.iter().map(|p| p.id.as_str()).collect();
+        assert_eq!(ids, vec![has_sol.as_str()]);
+
+        // 过期偏好（不在任何目录）→ 回退全量，选路不能没档位可用
+        set_model_pref(&db, "codex", Some("gone-model")).unwrap();
+        let ranked = rank_managed_tier_candidates(&db, "codex", false)
+            .unwrap()
+            .expect("过期偏好必须回退全量");
+        assert_eq!(ranked.len(), 3);
+
+        // 无偏好 → 全量
+        set_model_pref(&db, "codex", None).unwrap();
+        let ranked = rank_managed_tier_candidates(&db, "codex", false)
+            .unwrap()
+            .expect("无偏好全量");
+        assert_eq!(ranked.len(), 3);
+
+        // 读写往返
+        assert_eq!(get_model_pref(&db, "codex"), None);
+        set_model_pref(&db, "codex", Some("gpt-5.6-nano")).unwrap();
+        assert_eq!(
+            get_model_pref(&db, "codex").as_deref(),
+            Some("gpt-5.6-nano")
+        );
     }
 }

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -130,7 +130,7 @@ impl ProviderRouter {
         &self,
         app_type: &str,
     ) -> Result<Option<Vec<Provider>>, AppError> {
-        crate::proxy::auto_strategy::rank_managed_tier_candidates(&self.db, app_type)
+        crate::proxy::auto_strategy::rank_managed_tier_candidates(&self.db, app_type, true)
     }
 
     /// 当前供应商 id：本地 settings 优先（校验存在性），fallback 到数据库 is_current。

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -74,6 +74,13 @@ pub struct TrayTexts {
     pub cancel_label: &'static str,
     /// 托盘切档位失败时的错误对话框标题。
     pub tier_switch_failed_title: &'static str,
+    /// 自动模式：策略名（托盘 app→模型 映射的「自动」项后缀）。
+    pub auto_strategy_cheapest: &'static str,
+    pub auto_strategy_fastest: &'static str,
+    /// 自动模式：「不限模型」项。
+    pub auto_model_any: &'static str,
+    /// 自动模式：无模型目录 app 的占位项。
+    pub auto_mode_active: &'static str,
 }
 
 /// 将系统区域标识映射为托盘支持的语言码。
@@ -143,6 +150,10 @@ impl TrayTexts {
                 tier_quit_and_switch: "Quit & Switch",
                 cancel_label: "Cancel",
                 tier_switch_failed_title: "Switch failed",
+                auto_strategy_cheapest: "Cheapest",
+                auto_strategy_fastest: "Fastest",
+                auto_model_any: "Auto (any model)",
+                auto_mode_active: "Auto mode active",
             },
             "ja" => Self {
                 show_main: "メインウィンドウを開く",
@@ -160,6 +171,10 @@ impl TrayTexts {
                 tier_quit_and_switch: "終了して切り替え",
                 cancel_label: "キャンセル",
                 tier_switch_failed_title: "切り替えに失敗しました",
+                auto_strategy_cheapest: "最安",
+                auto_strategy_fastest: "最速",
+                auto_model_any: "自動（モデル指定なし）",
+                auto_mode_active: "自動モード有効",
             },
             "zh-TW" => Self {
                 show_main: "開啟主介面",
@@ -177,6 +192,10 @@ impl TrayTexts {
                 tier_quit_and_switch: "退出並切換",
                 cancel_label: "取消",
                 tier_switch_failed_title: "切換失敗",
+                auto_strategy_cheapest: "價格最低",
+                auto_strategy_fastest: "回應最快",
+                auto_model_any: "自動（不限模型）",
+                auto_mode_active: "自動模式生效中",
             },
             _ => Self {
                 show_main: "打开主界面",
@@ -194,6 +213,10 @@ impl TrayTexts {
                 tier_quit_and_switch: "退出并切换",
                 cancel_label: "取消",
                 tier_switch_failed_title: "切换失败",
+                auto_strategy_cheapest: "价格最低",
+                auto_strategy_fastest: "响应最快",
+                auto_model_any: "自动（不限模型）",
+                auto_mode_active: "自动模式生效中",
             },
         }
     }
@@ -587,6 +610,34 @@ pub fn handle_profile_tray_event(app: &tauri::AppHandle, event_id: &str) -> bool
 /// `model_` 开头，与供应商事件不冲突。
 const TIER_MODEL_EVENT_PREFIX: &str = "model_";
 
+/// 自动模式下「模型偏好」菜单项的事件 id 后缀：
+/// `{section.event_prefix()}automodel_{model}`（设偏好）与
+/// `{section.event_prefix()}autopref_none`（回到不限模型）。
+/// 与供应商 id（uuid / `<category>-<uuid>`，不以 `automodel_` 开头）及
+/// `model_` 前缀（automodel 不是 model_ 开头）都不冲突。
+const AUTO_MODEL_PREFIX: &str = "automodel_";
+const AUTO_PREF_NONE: &str = "autopref_none";
+
+/// 自动模式分区的模型清单：该应用全部托管档位模型目录的并集（去重）。
+/// 目录顺序沿用档位顺序 → 目录内顺序，跨档位重复只保留首次出现。
+/// 返回空 = 该应用没有模型目录（非 Codex 系），托盘放「自动」占位。
+fn auto_mode_models(
+    providers: &indexmap::IndexMap<String, crate::provider::Provider>,
+) -> Vec<String> {
+    let mut models: Vec<String> = Vec::new();
+    for provider in providers.values() {
+        if !crate::relay::is_managed(&provider.id) {
+            continue;
+        }
+        for model in crate::proxy::auto_strategy::tier_models(provider) {
+            if !models.contains(&model) {
+                models.push(model);
+            }
+        }
+    }
+    models
+}
+
 /// 处理供应商托盘事件
 pub fn handle_provider_tray_event(app: &tauri::AppHandle, event_id: &str) -> bool {
     for section in TRAY_SECTIONS.iter() {
@@ -599,6 +650,37 @@ pub fn handle_provider_tray_event(app: &tauri::AppHandle, event_id: &str) -> boo
                 tauri::async_runtime::spawn_blocking(move || {
                     if let Err(e) = handle_auto_click(&app_handle, &app_type) {
                         log::error!("切换{}Auto模式失败: {e}", section.label);
+                    }
+                });
+                return true;
+            }
+
+            // M3 自动模式模型偏好：点模型 = 设偏好 + 显式切到最优档位；
+            // 「不限模型」= 清除偏好（候选回到全部托管档位）。
+            if suffix == AUTO_PREF_NONE || suffix.starts_with(AUTO_MODEL_PREFIX) {
+                let model = suffix.strip_prefix(AUTO_MODEL_PREFIX).map(str::to_string);
+                log::info!(
+                    "设置{}自动模式模型偏好: {}",
+                    section.label,
+                    model.as_deref().unwrap_or("(不限)")
+                );
+                let app_handle = app.clone();
+                let app_type = section.app_type.as_str().to_string();
+                tauri::async_runtime::spawn(async move {
+                    let Some(state) = app_handle.try_state::<AppState>() else {
+                        return;
+                    };
+                    if let Err(e) = crate::commands::set_auto_mode_model_impl(
+                        app_handle.clone(),
+                        &state,
+                        &app_type,
+                        model.as_deref(),
+                    )
+                    .await
+                    {
+                        log::error!("设置自动模式模型偏好失败: {e}");
+                        let err = crate::error::AppError::Message(e);
+                        show_tier_switch_error(&app_handle, &err);
                     }
                 });
                 return true;
@@ -886,7 +968,7 @@ fn handle_tier_model_click(
 /// 原生对话框只放得下两个自定义按钮，这里给的是「退出并切换 / 取消」——
 /// **dismiss 必须是取消**（关闭/X/Esc 都落到 false），绝不能映射到任何会执行
 /// 动作的选项。「只切换」留给主界面。
-fn confirm_quit_chatgpt(app: &tauri::AppHandle, target_name: &str) -> bool {
+pub(crate) fn confirm_quit_chatgpt(app: &tauri::AppHandle, target_name: &str) -> bool {
     use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 
     let texts = TrayTexts::from_language(&tray_language());
@@ -1005,61 +1087,129 @@ pub fn create_tray_menu(
 
             let mut submenu_builder = SubmenuBuilder::with_id(app, &submenu_id, &submenu_label);
 
-            for (id, provider) in menu_providers {
-                let is_current = current_id == *id;
-                let is_official_blocked = is_app_taken_over
-                    && provider.category.as_deref() == Some("official")
-                    && !crate::services::provider::official_provider_supports_proxy_takeover(
-                        &section.app_type,
-                        provider,
-                    );
-                let label = if is_official_blocked {
-                    format!("{} \u{26D4}", &provider.name) // ⛔ emoji
-                } else {
-                    provider.name.clone()
-                };
-                let item = CheckMenuItem::with_id(
-                    app,
-                    format!("{event_prefix}{id}"),
-                    &label,
-                    !is_official_blocked, // disabled when blocked
-                    is_current,
-                    None::<&str>,
-                )
-                .map_err(|e| AppError::Message(format!("创建{}菜单项失败: {e}", section.label)))?;
-                submenu_builder = submenu_builder.item(&item);
-            }
+            // M3 自动模式形态：分区收敛为 app→模型 映射，不再列档位。
+            // 开启入口只在设置页（保守形态），这里只对已开启的 app 生效；
+            // 有模型目录的 app（Codex 系）列「自动（不限）+ 模型清单」，
+            // 没有目录的 app 只放一个「自动模式生效中」占位。
+            let auto_mode_on =
+                crate::proxy::auto_strategy::is_auto_mode_enabled(&app_state.db, app_type_str);
 
-            // 「模型」二级子菜单：只挂在 Codex 分区、且当前档位是托管项且有模型目录时。
-            // 点击走 `handle_tier_model_click` → `switch_tier_model_command`（选模型即
-            // 激活该档位，与主界面模型按钮组同一条路径）。
-            if let Some((current_model, models)) =
-                current_provider.and_then(|p| tier_model_choices(p, &section.app_type))
-            {
-                let mut models_builder = SubmenuBuilder::with_id(
-                    app,
-                    format!("submenu_{app_type_str}_models"),
-                    tray_texts.tier_model_label,
-                );
-                for model in &models {
-                    let item = CheckMenuItem::with_id(
+            if auto_mode_on {
+                let strategy_label = match crate::proxy::auto_strategy::get_strategy(&app_state.db)
+                {
+                    crate::proxy::auto_strategy::AutoStrategy::Cheapest => {
+                        tray_texts.auto_strategy_cheapest
+                    }
+                    crate::proxy::auto_strategy::AutoStrategy::Fastest => {
+                        tray_texts.auto_strategy_fastest
+                    }
+                };
+                let models = auto_mode_models(&providers);
+                let model_pref =
+                    crate::proxy::auto_strategy::get_model_pref(&app_state.db, app_type_str);
+
+                if models.is_empty() {
+                    let label = format!("{} · {}", tray_texts.auto_mode_active, strategy_label);
+                    let item = MenuItem::with_id(
                         app,
-                        format!("{event_prefix}{TIER_MODEL_EVENT_PREFIX}{model}"),
-                        model,
-                        true,
-                        current_model.as_deref() == Some(model.as_str()),
+                        format!("{event_prefix}{AUTO_PREF_NONE}"),
+                        &label,
+                        false,
                         None::<&str>,
                     )
                     .map_err(|e| {
-                        AppError::Message(format!("创建{}模型菜单项失败: {e}", section.label))
+                        AppError::Message(format!("创建{}自动模式占位失败: {e}", section.label))
                     })?;
-                    models_builder = models_builder.item(&item);
+                    submenu_builder = submenu_builder.item(&item);
+                } else {
+                    let any_label = format!("{} · {}", tray_texts.auto_model_any, strategy_label);
+                    let any_item = CheckMenuItem::with_id(
+                        app,
+                        format!("{event_prefix}{AUTO_PREF_NONE}"),
+                        &any_label,
+                        true,
+                        model_pref.is_none(),
+                        None::<&str>,
+                    )
+                    .map_err(|e| {
+                        AppError::Message(format!("创建{}自动项失败: {e}", section.label))
+                    })?;
+                    submenu_builder = submenu_builder.item(&any_item).separator();
+
+                    for model in &models {
+                        let item = CheckMenuItem::with_id(
+                            app,
+                            format!("{event_prefix}{AUTO_MODEL_PREFIX}{model}"),
+                            model,
+                            true,
+                            model_pref.as_deref() == Some(model.as_str()),
+                            None::<&str>,
+                        )
+                        .map_err(|e| {
+                            AppError::Message(format!("创建{}模型菜单项失败: {e}", section.label))
+                        })?;
+                        submenu_builder = submenu_builder.item(&item);
+                    }
                 }
-                let models_submenu = models_builder.build().map_err(|e| {
-                    AppError::Message(format!("构建{}模型子菜单失败: {e}", section.label))
-                })?;
-                submenu_builder = submenu_builder.separator().item(&models_submenu);
-            }
+            } else {
+                for (id, provider) in menu_providers {
+                    let is_current = current_id == *id;
+                    let is_official_blocked = is_app_taken_over
+                        && provider.category.as_deref() == Some("official")
+                        && !crate::services::provider::official_provider_supports_proxy_takeover(
+                            &section.app_type,
+                            provider,
+                        );
+                    let label = if is_official_blocked {
+                        format!("{} \u{26D4}", &provider.name) // ⛔ emoji
+                    } else {
+                        provider.name.clone()
+                    };
+                    let item = CheckMenuItem::with_id(
+                        app,
+                        format!("{event_prefix}{id}"),
+                        &label,
+                        !is_official_blocked, // disabled when blocked
+                        is_current,
+                        None::<&str>,
+                    )
+                    .map_err(|e| {
+                        AppError::Message(format!("创建{}菜单项失败: {e}", section.label))
+                    })?;
+                    submenu_builder = submenu_builder.item(&item);
+                }
+
+                // 「模型」二级子菜单：只挂在 Codex 分区、且当前档位是托管项且有模型目录时。
+                // 点击走 `handle_tier_model_click` → `switch_tier_model_command`（选模型即
+                // 激活该档位，与主界面模型按钮组同一条路径）。
+                if let Some((current_model, models)) =
+                    current_provider.and_then(|p| tier_model_choices(p, &section.app_type))
+                {
+                    let mut models_builder = SubmenuBuilder::with_id(
+                        app,
+                        format!("submenu_{app_type_str}_models"),
+                        tray_texts.tier_model_label,
+                    );
+                    for model in &models {
+                        let item = CheckMenuItem::with_id(
+                            app,
+                            format!("{event_prefix}{TIER_MODEL_EVENT_PREFIX}{model}"),
+                            model,
+                            true,
+                            current_model.as_deref() == Some(model.as_str()),
+                            None::<&str>,
+                        )
+                        .map_err(|e| {
+                            AppError::Message(format!("创建{}模型菜单项失败: {e}", section.label))
+                        })?;
+                        models_builder = models_builder.item(&item);
+                    }
+                    let models_submenu = models_builder.build().map_err(|e| {
+                        AppError::Message(format!("构建{}模型子菜单失败: {e}", section.label))
+                    })?;
+                    submenu_builder = submenu_builder.separator().item(&models_submenu);
+                }
+            } // 自动模式 off：常规档位列表 + 当前档位模型子菜单
 
             let submenu = submenu_builder
                 .build()
@@ -1439,8 +1589,9 @@ pub(crate) async fn refresh_all_usage_in_tray(app: &tauri::AppHandle) {
 #[cfg(test)]
 mod tests {
     use super::{
-        format_script_summary, format_subscription_summary, tier_model_choices,
-        tray_menu_providers, TRAY_ID, TRAY_SECTIONS,
+        auto_mode_models, format_script_summary, format_subscription_summary,
+        tier_model_choices, tray_menu_providers, AUTO_MODEL_PREFIX, AUTO_PREF_NONE,
+        AUTO_SUFFIX, TIER_MODEL_EVENT_PREFIX, TRAY_ID, TRAY_SECTIONS,
     };
     use crate::app_config::AppType;
     use crate::provider::{Provider, UsageData, UsageResult};
@@ -1530,6 +1681,52 @@ mod tests {
             }),
             None,
         )
+    }
+
+    /// 自动模式分区的模型清单：托管档位目录的并集（去重、保序），
+    /// 非托管供应商的目录（就算有）不掺进来。
+    #[test]
+    fn auto_mode_models_unions_managed_tier_catalogs_deduped() {
+        let a = crate::relay::provision::provider_id_for("https://a.example", Some(1), 1);
+        let b = crate::relay::provision::provider_id_for("https://b.example", Some(1), 2);
+
+        let mut providers = indexmap::IndexMap::new();
+        providers.insert(
+            a.clone(),
+            codex_tier_provider(&a, "gpt-5.6-sol", &["gpt-5.6-sol", "gpt-5.6-nano"]),
+        );
+        providers.insert(
+            b.clone(),
+            codex_tier_provider(&b, "gpt-5.6-nano", &["gpt-5.6-nano", "gpt-5.5"]),
+        );
+        // 非托管供应商带目录也不算
+        providers.insert(
+            "vendor-1".to_string(),
+            codex_tier_provider("vendor-1", "", &["vendor-only-model"]),
+        );
+
+        let models = auto_mode_models(&providers);
+        assert_eq!(
+            models,
+            vec![
+                "gpt-5.6-sol".to_string(),
+                "gpt-5.6-nano".to_string(),
+                "gpt-5.5".to_string()
+            ]
+        );
+    }
+
+    /// 自动模式的事件 id 后缀不与既有后缀/供应商 id 形状冲突 —— 冲突的表现是
+    /// 「点上去没反应或触发别的动作」，编译器和运行时都不报错。
+    #[test]
+    fn auto_mode_event_suffixes_do_not_collide() {
+        // 不等于 Auto（故障转移）后缀
+        assert_ne!(AUTO_PREF_NONE, AUTO_SUFFIX);
+        // 不以 model_ 开头（那是当前档位模型子菜单的前缀）
+        assert!(!AUTO_PREF_NONE.starts_with(TIER_MODEL_EVENT_PREFIX));
+        assert!(!AUTO_MODEL_PREFIX.starts_with(TIER_MODEL_EVENT_PREFIX));
+        // 供应商 id 是 uuid / <category>-<uuid>，不会撞这两个后缀
+        assert!(!format!("{AUTO_MODEL_PREFIX}gpt-5.6").is_empty());
     }
 
     /// 「模型」子菜单只挂在「托管 Codex 档位 + 目录非空」上，三道闸各自单独验证。

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1589,9 +1589,9 @@ pub(crate) async fn refresh_all_usage_in_tray(app: &tauri::AppHandle) {
 #[cfg(test)]
 mod tests {
     use super::{
-        auto_mode_models, format_script_summary, format_subscription_summary,
-        tier_model_choices, tray_menu_providers, AUTO_MODEL_PREFIX, AUTO_PREF_NONE,
-        AUTO_SUFFIX, TIER_MODEL_EVENT_PREFIX, TRAY_ID, TRAY_SECTIONS,
+        auto_mode_models, format_script_summary, format_subscription_summary, tier_model_choices,
+        tray_menu_providers, AUTO_MODEL_PREFIX, AUTO_PREF_NONE, AUTO_SUFFIX,
+        TIER_MODEL_EVENT_PREFIX, TRAY_ID, TRAY_SECTIONS,
     };
     use crate::app_config::AppType;
     use crate::provider::{Provider, UsageData, UsageResult};


### PR DESCRIPTION
## 自动模式第三期（依赖 M2，PR #131/#132）

自动模式开启的 app，托盘分区从「列出全部档位」收敛为 **app→模型映射**；未开启的 app 保持原样（开启入口仍在设置页，保守形态不变）。

### 形态

- **有模型目录的 app（Codex 系）**：「自动（不限模型）· 策略」+ 该 app 全部托管档位模型目录的并集（去重保序），勾选 = 当前偏好
- **无目录的 app（Claude/Gemini 等）**：单个「自动模式生效中 · 策略」占位 —— 这些 app 的模型选择是后端能力缺口，等补齐后自动长出模型列表

### 行为

- **点模型 = 显式切换**：设偏好（`auto_mode_model_<app>`）+ 绕过会话亲和立即切到「目录含该模型、策略最优」的档位并对齐其选中模型。亲和保护的是「系统重排别打断会话」，不替用户拒绝他刚点的选择
- **偏好过滤进选路**（`rank_managed_tier_candidates`，唯源）：候选收窄到目录含偏好模型的档位；过期偏好（模型已下架）回退全量，选路不断供
- 「不限模型」清除偏好，候选回到全部托管档位

### 验证

`cargo test` 3343 通过（新增：目录并集去重 / 事件后缀不冲突 / 偏好过滤与过期回退），`clippy -D warnings`、`tsc`、`vitest`（1112）绿。

## 后续

非 Codex 系 app 的模型目录是独立后端能力缺口（provision 时不写 modelCatalog），补齐后托盘自动生效，无需再动托盘代码。