### PR TITLE
feat(relay): Claude/Gemini 档位落模型目录并放开选模型

### DIFF
--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -3058,13 +3058,14 @@ fn persist_provision_batch(
 
         let base_url = api::base_url_for(app_type, &op.site_origin, &candidate.api_base_url);
         let defaults = if matches!(app_type, AppType::Claude) {
-            provision::settings_config_with_roles(
+            provision::settings_config_with_roles_and_models(
                 app_type,
                 &candidate.api_key,
                 &display_name,
                 &base_url,
                 &candidate.model,
                 candidate.roles.clone(),
+                candidate.models.as_deref(),
             )
         } else if matches!(app_type, AppType::Codex) {
             provision::settings_config_with_models(
@@ -3073,6 +3074,17 @@ fn persist_provision_batch(
                 &display_name,
                 &base_url,
                 &candidate.model,
+                candidate.models.as_deref(),
+            )
+        } else if matches!(app_type, AppType::Gemini) {
+            // gemini 同样落模型目录（只收 gemini-* 家族，见生成侧注释）
+            provision::settings_config_with_roles_and_models(
+                app_type,
+                &candidate.api_key,
+                &display_name,
+                &base_url,
+                &candidate.model,
+                None,
                 candidate.models.as_deref(),
             )
         } else {
@@ -3118,10 +3130,8 @@ fn persist_provision_batch(
                         log::warn!("{display_name} 的配置里找不到放密钥的位置，已重置为默认配置");
                         defaults
                     }
-                } else if matches!(app_type, AppType::Codex) {
-                    preserve_supported_codex_model(defaults, &old.settings_config)
                 } else {
-                    defaults
+                    preserve_supported_model(app_type, defaults, &old.settings_config)
                 }
             }
             None => defaults,
@@ -3223,12 +3233,9 @@ fn persist_provision_batch(
             app_id: app_type.as_str().to_string(),
             group_name: candidate.group_name,
             display_name,
-            model: provision::extract_model(&provider.settings_config).unwrap_or_default(),
-            models: if matches!(app_type, AppType::Codex) {
-                codex_models_from_settings(&provider.settings_config)
-            } else {
-                Vec::new()
-            },
+            model: provision::selected_model(app_type, &provider.settings_config)
+                .unwrap_or_default(),
+            models: models_from_settings(&provider.settings_config),
             rate_multiplier,
             can_verify_models: verification_target::supports_app_type(app_type),
             user_edited: Some(user_edited),
@@ -3811,7 +3818,7 @@ fn reset_tier_config_in_state(
     // 默认模型，并保留目录本身。否则这个动作会把刚外露的模型列表清空，还可能把
     // 不支持 `DEFAULT_MODEL` 的分组重置成一条选中即 404 的配置。
     let codex_models = if matches!(app_type, AppType::Codex) {
-        codex_models_from_settings(&existing.settings_config)
+        models_from_settings(&existing.settings_config)
     } else {
         Vec::new()
     };
@@ -3999,7 +4006,7 @@ fn tiers_of_site(
 /// [`list_relays_impl`] 按站分组。命令层把它丢掉 —— 那是实现细节，不进对外契约。
 ///
 /// `pub(crate)`：托盘的「模型」子菜单也从这里取目录（同一份 `modelCatalog` 两个消费者）。
-pub(crate) fn codex_models_from_settings(settings: &serde_json::Value) -> Vec<String> {
+pub(crate) fn models_from_settings(settings: &serde_json::Value) -> Vec<String> {
     settings
         .get("modelCatalog")
         .and_then(|catalog| catalog.get("models"))
@@ -4026,13 +4033,31 @@ fn preserve_supported_codex_model(
     select_codex_model(&defaults, &model).unwrap_or(defaults)
 }
 
+/// [`preserve_supported_codex_model`] 的跨平台版：claude / gemini 走 env 形状
+/// （剥掉 `[1M]` 声明后对新目录查成员资格），其余平台没有「选模型」概念，
+/// 新默认直接接管。
+fn preserve_supported_model(
+    app_type: &AppType,
+    defaults: serde_json::Value,
+    previous: &serde_json::Value,
+) -> serde_json::Value {
+    match app_type {
+        AppType::Codex => preserve_supported_codex_model(defaults, previous),
+        AppType::Claude | AppType::Gemini => {
+            let catalog = models_from_settings(&defaults);
+            provision::preserve_supported_env_model(app_type, defaults, previous, &catalog)
+        }
+        _ => defaults,
+    }
+}
+
 fn select_codex_model(
     settings: &serde_json::Value,
     model: &str,
 ) -> Result<serde_json::Value, AppError> {
     let model = model.trim();
     if model.is_empty()
-        || !codex_models_from_settings(settings)
+        || !models_from_settings(settings)
             .iter()
             .any(|candidate| candidate == model)
     {
@@ -4058,9 +4083,8 @@ fn list_tiers_impl(state: &AppState, app_type: AppType) -> Result<Vec<OwnedTier>
     // 这条路按 app 查，所以结果天然同质 —— 每条档位的 `app_id` 就是被查的那个。
     // 先取出来：`app_type` 下一行就被 move 进 `list` 了。
     let app_id = app_type.as_str().to_string();
-    let exposes_codex_models = matches!(app_type, AppType::Codex);
     let can_verify_models = verification_target::supports_app_type(&app_type);
-    let providers = ProviderService::list(state, app_type)?;
+    let providers = ProviderService::list(state, app_type.clone())?;
 
     let mut tiers: Vec<OwnedTier> = providers
         .values()
@@ -4083,12 +4107,9 @@ fn list_tiers_impl(state: &AppState, app_type: AppType) -> Result<Vec<OwnedTier>
                     .unwrap_or(None),
                 group_name: p.name.clone(),
                 display_name: p.name.clone(),
-                model: provision::extract_model(&p.settings_config).unwrap_or_default(),
-                models: if exposes_codex_models {
-                    codex_models_from_settings(&p.settings_config)
-                } else {
-                    Vec::new()
-                },
+                model: provision::selected_model(&app_type, &p.settings_config).unwrap_or_default(),
+                // 目录没有就返回空 —— UI/托盘按「无目录」处理，不用按 app 分支
+                models: models_from_settings(&p.settings_config),
                 is_current: current == p.id,
                 can_verify_models,
                 // 判据要 `api_base_url`（按站点存），这里拿不到 ⇒ 留 None，
@@ -4242,14 +4263,16 @@ async fn select_tier_model_impl(
     model: &str,
     quit_chatgpt: bool,
 ) -> Result<SwitchTierResult, AppError> {
-    if !matches!(app_type, AppType::Codex) {
+    // 支持选模型的平台：codex（config TOML）/ claude（env.ANTHROPIC_MODEL）/
+    // gemini（env.GEMINI_MODEL）。目录（modelCatalog）三个平台同一份形状。
+    if !matches!(app_type, AppType::Codex | AppType::Claude | AppType::Gemini) {
         return Err(AppError::Config(
-            "模型选择目前只支持 Codex 档位".to_string(),
+            "模型选择目前只支持 Codex / Claude / Gemini 档位".to_string(),
         ));
     }
     if !crate::relay::is_managed(provider_id) {
         return Err(AppError::Config(
-            "只有 LoongPort 托管的 Codex 档位才能从模型列表切换".to_string(),
+            "只有 LoongPort 托管的档位才能从模型列表切换".to_string(),
         ));
     }
 
@@ -4257,9 +4280,25 @@ async fn select_tier_model_impl(
     let original_settings = state
         .db
         .get_provider_by_id(provider_id, app_type.as_str())?
-        .ok_or_else(|| AppError::Config("这个 Codex 档位不存在".to_string()))?
+        .ok_or_else(|| AppError::Config("这个档位不存在".to_string()))?
         .settings_config;
-    let settings = select_codex_model(&original_settings, model)?;
+    let settings = match &app_type {
+        AppType::Codex => select_codex_model(&original_settings, model)?,
+        // env 形状：成员资格对着目录校验（select_codex_model 内置，这里对齐）
+        _ => {
+            let bare = model.trim();
+            if bare.is_empty()
+                || !models_from_settings(&original_settings)
+                    .iter()
+                    .any(|candidate| candidate == bare)
+            {
+                return Err(AppError::Config(format!(
+                    "模型 {bare:?} 不在这个档位支持的模型列表中"
+                )));
+            }
+            provision::select_env_model(&app_type, &original_settings, bare)?
+        }
+    };
 
     state
         .db
@@ -5660,7 +5699,7 @@ mod tests {
         });
 
         assert!(
-            codex_models_from_settings(&settings).is_empty(),
+            models_from_settings(&settings).is_empty(),
             "旧 provider 只有当前模型时，不能把它冒充成完整支持列表"
         );
     }

--- a/src-tauri/src/proxy/auto_strategy.rs
+++ b/src-tauri/src/proxy/auto_strategy.rs
@@ -121,7 +121,7 @@ pub fn set_model_pref(
 /// 档位的模型目录（settings_config.modelCatalog）。目前只有 Codex 系托管档位
 /// 在 provision 时写目录；返回空 = 该档位没有目录（不参与模型过滤）。
 pub fn tier_models(tier: &Provider) -> Vec<String> {
-    crate::commands::codex_models_from_settings(&tier.settings_config)
+    crate::commands::models_from_settings(&tier.settings_config)
 }
 
 /// 按模型偏好过滤候选：只保留目录里含偏好模型的档位。

--- a/src-tauri/src/relay/provision.rs
+++ b/src-tauri/src/relay/provision.rs
@@ -670,7 +670,7 @@ pub fn settings_config_with_models(
     )
 }
 
-fn settings_config_with_roles_and_models(
+pub fn settings_config_with_roles_and_models(
     app_type: &AppType,
     api_key: &str,
     display_name: &str,
@@ -771,6 +771,32 @@ fn settings_config_with_roles_and_models(
             if matches!(app_type, AppType::Claude) {
                 config["language"] = serde_json::json!("chinese");
             }
+            // Claude / Gemini：把分组模型目录落进配置（主界面模型芯片与自动模式
+            // app→模型 映射的数据源，形状与 codex 的 modelCatalog 相同）。
+            // 与 codex 的 `is_image_model` 过滤同理按家族收口：
+            // - claude 分组可能混 gpt-* / deepseek-*（瓜子跨家族对齐，角色挑选本来就
+            //   跨家族），目录收全部**文本**模型；
+            // - gemini 走原生 URL 路由（`/v1beta/models/{model}:generateContent`），
+            //   只认 gemini-* 家族，目录只收 gemini-*。
+            if matches!(app_type, AppType::Claude | AppType::Gemini) {
+                if let Some(models) = models.filter(|models| !models.is_empty()) {
+                    let family: Vec<&String> = match app_type {
+                        AppType::Gemini => models
+                            .iter()
+                            .filter(|m| m.to_ascii_lowercase().starts_with("gemini-"))
+                            .collect(),
+                        _ => models.iter().filter(|m| !is_image_model(m)).collect(),
+                    };
+                    if !family.is_empty() {
+                        config["modelCatalog"] = serde_json::json!({
+                            "models": family
+                                .iter()
+                                .map(|model| serde_json::json!({ "model": model }))
+                                .collect::<Vec<_>>(),
+                        });
+                    }
+                }
+            }
             config
         })
 }
@@ -808,6 +834,82 @@ pub fn extract_model(settings_config: &serde_json::Value) -> Option<String> {
         return Some(unquoted.to_string());
     }
     None
+}
+
+/// 从 settings_config 读档位**选中的模型**（跨平台）。
+///
+/// codex 系读 config TOML 的 `model` 行（[`extract_model`]）；claude 读
+/// `env.ANTHROPIC_MODEL`；gemini 读 `env.GEMINI_MODEL`。其余平台（没有
+/// 「档位选模型」概念）返回 `None`。目录本身统一走 `modelCatalog`
+/// （`commands::models_from_settings`，与 codex 同一份形状）。
+pub fn selected_model(app_type: &AppType, settings: &serde_json::Value) -> Option<String> {
+    let env_key = match app_type {
+        AppType::Codex | AppType::CodexImage => return extract_model(settings),
+        AppType::Claude => "ANTHROPIC_MODEL",
+        AppType::Gemini => "GEMINI_MODEL",
+        _ => return None,
+    };
+    settings
+        .pointer(&format!("/env/{env_key}"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+}
+
+/// 把 claude / gemini 档位的选中模型（env 键）改成 `model`，返回改写后的配置。
+///
+/// claude 侧按 [`maybe_one_m`] 补 `[1M]` 能力声明 —— 与 provision 写入的形态
+/// 一致，否则用户一切模型就丢掉 1M 声明。成员资格校验由命令层对着目录做，
+/// 这里只负责写。找不到 `env` 对象 = 配置形状异常，报错而不是静默新建
+/// （静默新建会造出一份没有其它键的残缺 env）。
+pub fn select_env_model(
+    app_type: &AppType,
+    settings: &serde_json::Value,
+    model: &str,
+) -> Result<serde_json::Value, crate::error::AppError> {
+    let env_key = match app_type {
+        AppType::Claude => "ANTHROPIC_MODEL",
+        AppType::Gemini => "GEMINI_MODEL",
+        other => {
+            return Err(crate::error::AppError::Config(format!(
+                "{} 档位不支持选模型",
+                other.as_str()
+            )))
+        }
+    };
+    let mut config = settings.clone();
+    let Some(env) = config.get_mut("env").and_then(|env| env.as_object_mut()) else {
+        return Err(crate::error::AppError::Config(format!(
+            "配置里缺少 env 对象，无法写入 {env_key}"
+        )));
+    };
+    let value = if matches!(app_type, AppType::Claude) {
+        maybe_one_m(model)
+    } else {
+        model.to_string()
+    };
+    env.insert(env_key.to_string(), serde_json::json!(value));
+    Ok(config)
+}
+
+/// 重新 provision 时保留用户选过的模型（目录里还有它才保留，上游下架则新默认接管）。
+///
+/// codex 系委托 [`preserve_supported_codex_model`] 的等价逻辑在命令层
+/// （`preserve_supported_model`），这里只管 env 形状：读旧选中值、剥掉
+/// `[1M]` 声明后对新目录查成员资格，命中就把新默认的选中键改回旧值。
+pub fn preserve_supported_env_model(
+    app_type: &AppType,
+    defaults: serde_json::Value,
+    previous: &serde_json::Value,
+    catalog: &[String],
+) -> serde_json::Value {
+    let Some(old) = selected_model(app_type, previous) else {
+        return defaults;
+    };
+    let bare = old.trim_end_matches(crate::claude_desktop_config::ONE_M_CONTEXT_MARKER);
+    if !catalog.iter().any(|m| m == bare) {
+        return defaults;
+    }
+    select_env_model(app_type, &defaults, bare).unwrap_or(defaults)
 }
 
 /// codex 的默认模型（**文本对话**用）。
@@ -2116,6 +2218,131 @@ mod tests {
         assert!(
             image_settings.get("modelCatalog").is_none(),
             "生图栏不消费 Codex 主模型目录"
+        );
+    }
+
+    /// claude 档位落模型目录：收全部**文本**模型（跨家族是合法形态 —— 瓜子对齐），
+    /// 生图模型剔除；与 codex 目录同一份 JSON 形状。
+    #[test]
+    fn claude_settings_persist_the_text_model_catalog() {
+        let models = vec![
+            "claude-opus-5".to_string(),
+            "gpt-5.6-sol".to_string(),
+            "gpt-image-2".to_string(),
+        ];
+        let settings = settings_config_with_roles_and_models(
+            &AppType::Claude,
+            "sk-test",
+            "Test",
+            "https://api.example.com/v1",
+            "claude-opus-5",
+            None,
+            Some(&models),
+        )
+        .expect("Claude config");
+
+        assert_eq!(
+            settings["modelCatalog"]["models"],
+            serde_json::json!([
+                { "model": "claude-opus-5" },
+                { "model": "gpt-5.6-sol" }
+            ])
+        );
+        // 选中模型在 env 里可读（`[1m]` 后缀是 pick_tier_models 挑选时加的，
+        // 这里传什么写什么 —— 裸 id 进、裸 id 出）
+        assert_eq!(
+            selected_model(&AppType::Claude, &settings).as_deref(),
+            Some("claude-opus-5")
+        );
+    }
+
+    /// gemini 档位落模型目录：只收 gemini-*（原生 URL 路由不认其它家族），
+    /// 家族全空时不写目录（托盘回「自动」占位）。
+    #[test]
+    fn gemini_settings_persist_the_gemini_family_catalog_only() {
+        let mixed = vec![
+            "gemini-3-pro".to_string(),
+            "claude-opus-5".to_string(),
+            "gpt-5.6-sol".to_string(),
+        ];
+        let settings = settings_config_with_roles_and_models(
+            &AppType::Gemini,
+            "sk-test",
+            "Test",
+            "https://api.example.com/v1",
+            "gemini-3-pro",
+            None,
+            Some(&mixed),
+        )
+        .expect("Gemini config");
+        assert_eq!(
+            settings["modelCatalog"]["models"],
+            serde_json::json!([{ "model": "gemini-3-pro" }])
+        );
+        assert_eq!(
+            selected_model(&AppType::Gemini, &settings).as_deref(),
+            Some("gemini-3-pro")
+        );
+
+        let no_family = vec!["claude-opus-5".to_string(), "gpt-5.6-sol".to_string()];
+        let settings = settings_config_with_roles_and_models(
+            &AppType::Gemini,
+            "sk-test",
+            "Test",
+            "https://api.example.com/v1",
+            "claude-opus-5",
+            None,
+            Some(&no_family),
+        )
+        .expect("Gemini config");
+        assert!(
+            settings.get("modelCatalog").is_none(),
+            "没有 gemini-* 时不能写一个空目录"
+        );
+    }
+
+    /// env 形状的选模型：写 env 键（claude 补 [1M]）；保留偏好对「目录里还有」
+    /// 的旧选中值生效，上游下架则新默认接管。
+    #[test]
+    fn env_model_selection_and_preserve() {
+        let models = vec![
+            "claude-sonnet-5".to_string(),
+            "claude-haiku-4-5".to_string(),
+        ];
+        let settings = settings_config_with_roles_and_models(
+            &AppType::Claude,
+            "sk-test",
+            "Test",
+            "https://api.example.com/v1",
+            "claude-sonnet-5",
+            None,
+            Some(&models),
+        )
+        .expect("Claude config");
+
+        let switched = select_env_model(&AppType::Claude, &settings, "claude-haiku-4-5")
+            .expect("select env model");
+        assert_eq!(
+            selected_model(&AppType::Claude, &switched).as_deref(),
+            Some("claude-haiku-4-5[1m]")
+        );
+
+        // 保留偏好：旧选中值（带 [1M] 声明）在新目录里 → 新默认的选中键改回旧值
+        let defaults = settings.clone();
+        let preserved =
+            preserve_supported_env_model(&AppType::Claude, defaults.clone(), &switched, &models);
+        assert_eq!(
+            selected_model(&AppType::Claude, &preserved).as_deref(),
+            Some("claude-haiku-4-5[1m]")
+        );
+
+        // 上游下架：目录里没有旧值 → 新默认接管
+        let shrunk = vec!["claude-sonnet-5".to_string()];
+        let reset = preserve_supported_env_model(&AppType::Claude, defaults, &switched, &shrunk);
+        // 新默认接管：生成侧写入的是裸 id（[1m] 只在 pick/选模型时补）
+        assert_eq!(
+            selected_model(&AppType::Claude, &reset).as_deref(),
+            Some("claude-sonnet-5")
         );
     }
 

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -494,24 +494,25 @@ fn tray_menu_providers(
     sort_providers(providers)
 }
 
-/// 「模型」子菜单的数据来源：当前档位是**托管 Codex 项**且落库模型目录非空时，
+/// 「模型」子菜单的数据来源：当前档位是**托管项**且落库模型目录非空时，
 /// 返回 `(当前模型, 目录)`；其余情况 `None`（不挂子菜单）。
 ///
-/// 与主界面 `TierInfo.models` 同一份 `modelCatalog`（`codex_models_from_settings`），
-/// 非托管 provider / 非 Codex app 没有「选模型」这个概念，不预埋。
+/// 与主界面 `TierInfo.models` 同一份 `modelCatalog`（`models_from_settings`）。
+/// 目录按平台落库（codex / claude / gemini），没有目录的 app 自然不挂；
+/// 非托管 provider 没有「选模型」这个概念，不预埋。
 fn tier_model_choices(
     provider: &crate::provider::Provider,
     app_type: &AppType,
 ) -> Option<(Option<String>, Vec<String>)> {
-    if !matches!(app_type, AppType::Codex) || !crate::relay::is_managed(&provider.id) {
+    if !crate::relay::is_managed(&provider.id) {
         return None;
     }
-    let models = crate::commands::codex_models_from_settings(&provider.settings_config);
+    let models = crate::commands::models_from_settings(&provider.settings_config);
     if models.is_empty() {
         return None;
     }
     Some((
-        crate::relay::provision::extract_model(&provider.settings_config),
+        crate::relay::provision::selected_model(app_type, &provider.settings_config),
         models,
     ))
 }
@@ -907,9 +908,6 @@ fn handle_tier_model_click(
     app_type: &AppType,
     model: &str,
 ) -> Result<(), AppError> {
-    if !matches!(app_type, AppType::Codex) {
-        return Ok(());
-    }
     let Some(app_state) = app.try_state::<AppState>() else {
         return Ok(());
     };
@@ -1745,8 +1743,13 @@ mod tests {
             vec!["gpt-5.6-sol".to_string(), "gpt-5.6-nano".to_string()]
         );
 
-        // 非 Codex app（同一个 provider 行挂在 Claude 下）→ 不挂
-        assert!(tier_model_choices(&provider, &AppType::Claude).is_none());
+        // 目录按平台落库后 Claude 也挂子菜单 —— 选中模型按 env 形状读
+        // （这个 codex 形状的 provider 在 Claude 下读不到 env，当前模型为 None，
+        // 但目录照样暴露）
+        let (current, models) = tier_model_choices(&provider, &AppType::Claude)
+            .expect("claude tier with catalog should expose models too");
+        assert_eq!(current, None);
+        assert_eq!(models.len(), 2);
 
         // 自建 provider → 不挂
         let custom = codex_tier_provider("custom-1", "gpt-5.6-sol", &["gpt-5.6-sol"]);


### PR DESCRIPTION
## 补齐自动模式 M3 的后端缺口

M3 落地时 Claude/Gemini 档位没有 `modelCatalog`（provision 只给 Codex 写），托盘只能放占位。本 PR 补齐后端，**前端零改动**：主界面模型芯片、托盘 app→模型映射、自动模式选模型机制全部数据驱动，目录有了自动长出来。

### 改动

- **provision 落目录**：Claude 收全部文本模型（跨家族合法——瓜子对齐），Gemini 只收 `gemini-*`（原生 URL 路由不认其它家族）；与 Codex 同一份 JSON 形状；家族全空不写空目录。数据源与 Codex 同一份 `api::list_models`（NewAPI 路径早已把列表带给三种 app，只是落库时丢弃）
- **跨平台选中模型**：`selected_model`（Codex→TOML `model` 行 / Claude→`env.ANTHROPIC_MODEL` / Gemini→`env.GEMINI_MODEL`）；`select_env_model` 写 env 键（Claude 补 `[1M]` 能力声明，与 provision 形态一致）
- **选模型放开**：`select_tier_model_impl` 去掉 Codex 硬闸（成员资格对目录校验）；托盘模型子菜单/TierInfo 去掉 Codex-only 分支——目录有没有决定挂不挂；`codex_models_from_settings` 改名 `models_from_settings`
- **刷新保留偏好**：`preserve_supported_model` 跨平台（剥 `[1M]` 后对新目录查成员资格，上游下架则新默认接管）

### 已知限制

Gemini 接管态下模型由 CLI 的 URL 路由决定（档位无映射），模型切换在直连态/下一个 CLI 会话生效。

### 验证

`cargo test` 3346 通过（新增：Claude 文本目录 / Gemini 家族过滤与空家族不写 / env 选模型与保留偏好），`clippy -D warnings`、`tsc`、`vitest`（1112）绿。