### PR TITLE
fix(build): 补全 bundle.targets，本地 mac 构建直接出 app+dmg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -380,8 +380,9 @@ jobs:
           fi
           for attempt in $(seq 1 "$max_attempts"); do
             echo "=== macOS build/notarization attempt ${attempt}/${max_attempts} ==="
-            # tauri.conf.json keeps the global target list at NSIS for Windows releases;
-            # select the macOS app bundle explicitly so the asset-preparation step gets a .app.
+            # bundle.targets in tauri.conf.json lists every platform's release formats
+            # (so a bare local `pnpm tauri build` bundles correctly); CI still asks for
+            # the .app only — the release DMG is styled separately with create-dmg.
             if pnpm tauri build --target universal-apple-darwin --bundles app; then
               echo "✅ macOS build/notarization succeeded"
               exit 0

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,7 +37,7 @@
   "bundle": {
     "active": true,
     "publisher": "SailingLoong",
-    "targets": ["nsis"],
+    "targets": ["nsis", "app", "dmg", "appimage", "deb", "rpm"],
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",

--- a/tests/lib/windowsInstallerContract.test.ts
+++ b/tests/lib/windowsInstallerContract.test.ts
@@ -13,9 +13,15 @@ const read = (path: string) =>
  * 进入 Config.Msi rollback 路径，恢复 Error 1926。
  */
 describe("Windows NSIS 安装与自动更新契约", () => {
-  it("Tauri 默认 bundle 是 NSIS，并挂载旧 MSI 迁移 hook", () => {
+  it("Tauri 默认 bundle 含 NSIS（唯一 Windows 格式），并挂载旧 MSI 迁移 hook", () => {
     const config = JSON.parse(read("src-tauri/tauri.conf.json"));
-    expect(config.bundle.targets).toEqual(["nsis"]);
+    // 默认 targets 列全平台格式，让任何系统上裸 `pnpm tauri build` 都能出对应包；
+    // 本测试守的 Windows 不变量是「nsis 在列、且是唯一 Windows 安装格式」——
+    // msi/wix 一旦出现，安装器与 latest.json 的 NSIS 契约就分叉了（见文件头注释）。
+    // 各平台发布格式由 release.yml 显式 --bundles 指定（见下一条测试），不在此钉。
+    expect(config.bundle.targets).toContain("nsis");
+    expect(config.bundle.targets).not.toContain("msi");
+    expect(config.bundle.targets).not.toContain("wix");
     // Tauri 模板会先用 ProductName + Publisher 模糊命中 WiX，然后执行
     // 不带静默参数的 UninstallString。与历史 MSI 的 loongport 区分开，
     // 才会让下面按 UpgradeCode 精确识别的 hook 接管迁移。


### PR DESCRIPTION
## 问题

`bundle.targets` 只有 `["nsis"]`（Windows 安装器目标）。在 macOS 上跑本地 `pnpm tauri build`：

- 静默成功（exit 0），只产出 `target/release/LoongPort` 裸二进制
- `target/release/bundle/` 里的 .app / dmg 永远是旧构建的残留
- 结果拿旧代码当新包测试（2026-08-15 实踩）

## 修复

`targets` 补全为本仓实际发布的六种格式：`["nsis", "app", "dmg", "appimage", "deb", "rpm"]`

- 各平台自动取适用项，不适用的静默跳过（tauri 内置行为）
- 不用 `"all"`：会把 MSI/wix 拉进 Windows 本地构建，而本仓刻意只走 NSIS（release.yml 有注释：MSI 升级回滚文件被部分安全软件拦 + per-user WiX 模板 ICE38 校验问题）
- 顺带更新 release.yml 里记录旧权宜状态的注释（"config keeps global target list at NSIS"已不再成立）

## CI 影响

零。release.yml / windows-build.yml 每个平台的构建都显式传 `--bundles`，覆盖配置值；`tauri.windows.conf.json` 不碰 targets。

## 验证

- 本地 macOS `pnpm tauri build` 现在直接产出 app + dmg（dmg 内二进制与源码哈希链核对过）
- CI 不依赖此配置值（全部显式 --bundles）