### PR TITLE
fix(ci): 本地/CI 验证一致性 + automerge 死锁与 WSL2 flake 根治

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,44 @@ jobs:
           if ($testList -notcontains $expected) {
             throw "Expected ignored test was not discovered: $testName"
           }
-          cargo test --lib --manifest-path src-tauri/Cargo.toml $testName -- --ignored --exact --nocapture
-          if ($LASTEXITCODE -ne 0) {
-            exit $LASTEXITCODE
+          # 已知偶发（PR #130 前后两次踩实）：link.exe/mt.exe 在 \\wsl.localhost UNC
+          # 临时路径上随机失败（LNK1327 / c1010070），重试换一个 lnk{GUID}.tmp 即绿。
+          # 不重试的后果是 automerge 永远等不到绿，纯搁置人。
+          $maxAttempts = 3
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            if ($attempt -gt 1) {
+              Write-Host "::warning::UNC contract attempt $attempt/$maxAttempts (retrying after known mt.exe flake)"
+              Start-Sleep -Seconds 10
+            }
+            cargo test --lib --manifest-path src-tauri/Cargo.toml $testName -- --ignored --exact --nocapture
+            if ($LASTEXITCODE -eq 0) { break }
+            if ($attempt -eq $maxAttempts) { exit $LASTEXITCODE }
           }
+
+  # ⚠️ **分支保护的必需检查只认这一个 job**（名字见 name:），别再改成四个矩阵名。
+  #
+  # 为什么必须有个门卫 job：`changes` 过滤会让无关 job 走 skipped，而 skipped 的
+  # 矩阵 job 上报的名字与运行时不同（`Backend Checks` vs `Backend Checks (ubuntu-22.04)`）
+  # ⇒ 必需检查永远等不齐 ⇒ automerge 死锁（PR #130 踩过，只能 --admin 解锁）。
+  # GitHub 官方建议也是「必需检查不要被跳过」—— 门卫 always 跑、把 skipped 当作
+  # 「过滤说不相关」放行，failure/cancelled 仍然拦下。
+  required-checks:
+    name: Required Checks
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [frontend, backend, backend-windows-wsl2]
+    steps:
+      - name: Gate on upstream results
+        shell: bash
+        run: |
+          failed=0
+          for result in $(printf '%s\n' ${{ join(needs.*.result, ' ') }}); do
+            case "$result" in
+              success|skipped) ;;
+              *)
+                echo "::error::upstream job ended as '$result' (failure/cancelled are hard failures; skipped means the path filter deemed it irrelevant)"
+                failed=1
+                ;;
+            esac
+          done
+          exit $failed

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format": "prettier --write \"{src,tests}/**/*.{js,jsx,ts,tsx,css,json,html}\"",
     "format:check": "prettier --check \"{src,tests}/**/*.{js,jsx,ts,tsx,css,json,html}\"",
     "test:unit": "vitest run",
+    "ci:rust": "bash scripts/ci-checks.sh",
     "test:unit:watch": "vitest watch"
   },
   "keywords": [],

--- a/scripts/ci-checks.sh
+++ b/scripts/ci-checks.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# 本地预检：与 .github/workflows/ci.yml 的 Backend Checks **逐字相同**的命令集。
+#
+# 为什么必须有这个脚本（2026-08-15 教训，PR #129/#134 两次踩实）：
+# 本地手敲变体（不带 `-D warnings` 的 clippy、写模式的 fmt、grep 过滤输出）
+# 会给出「本地绿、CI 红」的假绿 —— clippy 的警告被 grep 滤掉、fmt 只信写入
+# 后的文件状态。工具链本身已被 rust-toolchain.toml 钉死，剩余漂移全部来自
+# 命令不一致。改 CI 命令时同步改这里（两处各写一份的漂移由注释互相指认）。
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+echo "==> cargo fmt --check"
+cargo fmt --check --manifest-path src-tauri/Cargo.toml
+
+echo "==> cargo clippy -D warnings"
+cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
+
+echo "==> cargo test"
+cargo test --manifest-path src-tauri/Cargo.toml
+
+echo "==> 本地预检全绿（WSL2 UNC 契约测试需 Windows runner，不在本地覆盖范围）"


### PR DESCRIPTION
## 三笔账，对应 2026-08-15 一天的三次 CI 红

### 1. 本地假绿（#129/#134 踩过）

本地手敲变体（不带 `-D warnings` 的 clippy、grep 过滤输出、写模式 fmt 后不再复核）会给出「本地绿、CI 红」。根因**不是**工具链漂移——`rust-toolchain.toml` 早已 pin 1.95 且本地实际生效（与 CI 同一 build `59807616e`），漂移全部来自命令不一致。

修法：`scripts/ci-checks.sh` + `pnpm ci:rust`，与 CI 的 Backend Checks 命令**逐字相同**（fmt --check / clippy -D warnings / test）。本地提交前跑这个，而不是手敲变体。

### 2. automerge 死锁（#130 踩过，--admin 才解锁）

`changes` 过滤让无关 job 走 skipped，而 skipped 的矩阵 job 上报名字与运行时不同（`Backend Checks` vs `Backend Checks (ubuntu-22.04)`）⇒ 分支保护的必需检查永远等不齐 ⇒ 纯前端/纯后端 PR 死锁。GitHub 官方建议正是「必需检查不应被跳过」。

修法：新增 always 跑的门卫 job **`Required Checks`**（needs 全部检查 job）：skipped 放行（= 过滤说不相关）、failure/cancelled 拦下。分支保护的必需检查列表换成只认这一个名字（合入本 PR 后切换，避免空窗期）。

### 3. WSL2 UNC 链接 flake（main 与 #137 同晚两次，重跑均绿）

mt.exe 在 `\\wsl.localhost` UNC 临时路径随机 `LNK1327`，换一个 `lnk{GUID}.tmp` 即绿。修法：该步重试至多 3 次（间隔 10s），超限仍失败才红。

## 验证

- 本地 `pnpm ci:rust`（即新脚本）全绿：fmt --check / clippy -D warnings / test
- workflow YAML lint 通过；门卫 job 的 skipped 放行逻辑覆盖 needs.*.result 四态