### PR TITLE
chore: release v3.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-switch",
-  "version": "3.27.0",
+  "version": "3.28.0",
   "description": "All-in-One Assistant for Claude Code, Codex & Gemini CLI",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "cc-switch"
-version = "3.27.0"
+version = "3.28.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # （裁决见 CLAUDE.md「三点五」）。面向用户的二进制名走 tauri.conf.json 的
 # `mainBinaryName`（已是 `LoongPort`）。
 name = "cc-switch"
-version = "3.27.0"
+version = "3.28.0"
 description = "同样的 Codex，成本省 95% 以上 —— 填一个域名、登录一次，其余自动配好"
 authors = ["SailingLoong", "Jason Young"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LoongPort",
   "mainBinaryName": "LoongPort",
-  "version": "3.27.0",
+  "version": "3.28.0",
   "identifier": "dev.loongport.desktop",
   "build": {
     "frontendDist": "../dist",
@@ -37,7 +37,14 @@
   "bundle": {
     "active": true,
     "publisher": "SailingLoong",
-    "targets": ["nsis", "app", "dmg", "appimage", "deb", "rpm"],
+    "targets": [
+      "nsis",
+      "app",
+      "dmg",
+      "appimage",
+      "deb",
+      "rpm"
+    ],
     "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
@@ -49,7 +56,12 @@
     "windows": {
       "nsis": {
         "installerHooks": "nsis/installer-hooks.nsh",
-        "languages": ["English", "SimpChinese", "TradChinese", "Japanese"]
+        "languages": [
+          "English",
+          "SimpChinese",
+          "TradChinese",
+          "Japanese"
+        ]
       },
       "wix": {
         "template": "wix/per-user-main.wxs"


### PR DESCRIPTION
版本号 bump：package.json / tauri.conf.json / Cargo.toml（Cargo.lock 随 cargo check 更新）。发布说明见 tag 正文（草稿在 design 仓）。