### PR TITLE
fix(relay): 余额快照只记变化，消掉对账表里的零信息窗口

### DIFF
--- a/src-tauri/src/database/loongport_schema.rs
+++ b/src-tauri/src/database/loongport_schema.rs
@@ -48,7 +48,7 @@ use crate::error::AppError;
 /// LoongPort 自己的 schema 版本。加迁移时 +1。
 ///
 /// **与 `SCHEMA_VERSION`（上游那个）无关**，两者各自独立计数。
-pub(crate) const LOONGPORT_SCHEMA_VERSION: i32 = 14;
+pub(crate) const LOONGPORT_SCHEMA_VERSION: i32 = 15;
 
 /// 存版本号的表。**只有一行**（`id = 1`）。
 ///
@@ -240,6 +240,14 @@ pub(crate) fn apply(conn: &Connection) -> Result<(), AppError> {
                 crate::relay::reconcile::create_table(conn)?;
                 set_version(conn, 14)?;
             }
+            // v14 → v15：清洗余额快照的存量重复行。写入侧已改成「只在余额有变时
+            // 落行」（`record_balance_snapshot`），这一步把 v14 及之前攒下的
+            // 「与上一条余额相同」的行删掉 —— 它们只会把对账窗口切成零信息行。
+            14 => {
+                log::info!("LoongPort 数据迁移 v14 → v15（余额快照去重：删余额未变的相邻行）");
+                dedupe_balance_snapshots(conn)?;
+                set_version(conn, 15)?;
+            }
             other => {
                 return Err(AppError::Database(format!(
                     "未知的 LoongPort 数据版本 {other}，无法迁移到 {LOONGPORT_SCHEMA_VERSION}"
@@ -249,6 +257,36 @@ pub(crate) fn apply(conn: &Connection) -> Result<(), AppError> {
         version = current_version(conn)?;
     }
 
+    Ok(())
+}
+
+/// 删除 `relay_balance_snapshots` 里「与同站上一条余额相同」的行 —— 每个等值
+/// 连续段只留最早一条，删完后相邻行必然相异（与 [`crate::relay::reconcile`]
+/// 写入侧的去重口径一致）。
+///
+/// 一趟 `LAG` 就够：被删的行都等于其直接前驱，按序传递 ⇒ 段内全等，留下的
+/// 最早一条与下一段的值必不同。
+fn dedupe_balance_snapshots(conn: &Connection) -> Result<(), AppError> {
+    let deleted = conn
+        .execute(
+            "DELETE FROM relay_balance_snapshots
+             WHERE id IN (
+                 SELECT id FROM (
+                     SELECT id,
+                            LAG(balance_usd) OVER (
+                                PARTITION BY relay_id
+                                ORDER BY created_at, id
+                            ) AS prev_balance
+                     FROM relay_balance_snapshots
+                 )
+                 WHERE prev_balance IS NOT NULL AND prev_balance = balance_usd
+             )",
+            [],
+        )
+        .map_err(|e| AppError::Database(format!("清洗余额快照重复行失败: {e}")))?;
+    if deleted > 0 {
+        log::info!("余额快照去重：删除 {deleted} 行零信息快照");
+    }
     Ok(())
 }
 
@@ -858,6 +896,51 @@ mod tests {
             [],
         )
         .expect("迁移后必须可写");
+        assert_eq!(current_version(&conn).unwrap(), LOONGPORT_SCHEMA_VERSION);
+    }
+
+    /// ⭐ v14→v15 清洗余额快照重复行：与同站上一条余额相同的行删掉、每个等值段留最早
+    /// 一条；余额回到旧值的行（与最新一条不同）必须留下。
+    #[test]
+    fn v14_to_v15_deletes_consecutive_duplicate_balance_snapshots() {
+        let conn = mem();
+        crate::relay::reconcile::create_table(&conn).expect("建快照表");
+        // relay 7：10 → 10（删）→ 8 → 10；relay 8：5 → 5（删）。跨站互不影响。
+        for (relay_id, created_at, balance) in [
+            (7, 100, 10.0),
+            (7, 200, 10.0),
+            (7, 300, 8.0),
+            (7, 400, 10.0),
+            (8, 150, 5.0),
+            (8, 250, 5.0),
+        ] {
+            conn.execute(
+                "INSERT INTO relay_balance_snapshots (relay_id, balance_usd, source, created_at)
+                 VALUES (?1, ?2, 'balance_query', ?3)",
+                rusqlite::params![relay_id, balance, created_at],
+            )
+            .expect("造 v14 存量数据");
+        }
+        ensure_version_table(&conn).expect("建版本表");
+        set_version(&conn, 14).expect("设为 v14");
+
+        apply(&conn).expect("迁移到 v15");
+
+        let rows: Vec<(i64, f64)> = conn
+            .prepare(
+                "SELECT relay_id, balance_usd FROM relay_balance_snapshots
+                      ORDER BY relay_id, created_at",
+            )
+            .expect("查表")
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .expect("读行")
+            .collect::<rusqlite::Result<_>>()
+            .expect("收集");
+        assert_eq!(
+            rows,
+            vec![(7, 10.0), (7, 8.0), (7, 10.0), (8, 5.0)],
+            "等值段留最早一条；回到旧值（≠最新一条）的行要留"
+        );
         assert_eq!(current_version(&conn).unwrap(), LOONGPORT_SCHEMA_VERSION);
     }
 

--- a/src-tauri/src/relay/reconcile.rs
+++ b/src-tauri/src/relay/reconcile.rs
@@ -3,7 +3,14 @@
 //! ## 快照从哪来
 //!
 //! 写入挂在 `relay_balance_impl` 成功解析余额之后（前端行级刷新、充值关窗都会触发），
-//! 本模块只负责表 + DAO；对账窗口计算是后续任务的事。
+//! 本模块只负责表 + DAO；对账窗口计算见下方「对账报告」一节。
+//!
+//! ## 只记变化：余额没变的观测不落行
+//!
+//! 这张表的唯一消费者是对账窗口（相邻快照配对）。余额与该站最新一条相同时再落一条，
+//! 只会把窗口切碎成「估算 0 + 变动 0」的零信息行 —— 所以写入侧就去重（见
+//! [`Database::record_balance_snapshot`]），**相邻快照必然相异**是本表的结构不变量。
+//! v15 之前落下的重复行由 LoongPort 迁移 v14 → v15 清洗。
 //!
 //! ## `created_at` 的单位：Unix 秒
 //!
@@ -59,22 +66,31 @@ pub fn create_table(conn: &Connection) -> Result<(), AppError> {
 }
 
 impl Database {
-    /// 记一条余额快照，返回行 id。`created_at` 取当前 Unix 秒。
-    pub fn insert_balance_snapshot(
+    /// 记一条余额快照，返回行 id；**余额与该站最新一条相同则不落行**，返回 `None`。
+    ///
+    /// 「只在有变时落行」是这张表的结构不变量（见模块文档），比对 + 落行收在
+    /// 一条 `INSERT … SELECT … WHERE` 里原子完成。`created_at` 取当前 Unix 秒。
+    pub fn record_balance_snapshot(
         &self,
         relay_id: i64,
         balance_usd: f64,
         source: &str,
-    ) -> Result<i64, AppError> {
+    ) -> Result<Option<i64>, AppError> {
         let conn = lock_conn!(self.conn);
         let created_at = chrono::Utc::now().timestamp();
+        // 标量子查询取该站最新一条的余额（表空得 NULL）；`IS NOT` 是 NULL 安全的
+        // 不等比较 —— 表空时 `NULL IS NOT ?2` 为真，首条照落。
         conn.execute(
             "INSERT INTO relay_balance_snapshots (relay_id, balance_usd, source, created_at)
-             VALUES (?1, ?2, ?3, ?4)",
+             SELECT ?1, ?2, ?3, ?4
+             WHERE (SELECT balance_usd FROM relay_balance_snapshots
+                    WHERE relay_id = ?1
+                    ORDER BY created_at DESC, id DESC
+                    LIMIT 1) IS NOT ?2",
             params![relay_id, balance_usd, source, created_at],
         )
         .map_err(|e| AppError::Database(format!("写入余额快照失败: {e}")))?;
-        Ok(conn.last_insert_rowid())
+        Ok((conn.changes() > 0).then(|| conn.last_insert_rowid()))
     }
 
     /// 列出某个中转站的快照，按时间升序（对账窗口要按先后配对）。
@@ -144,7 +160,7 @@ pub fn capture_balance_snapshot(db: &Database, relay_id: i64, usage: &UsageResul
     let Some(balance_usd) = resolved_usd_balance(usage) else {
         return;
     };
-    if let Err(error) = db.insert_balance_snapshot(relay_id, balance_usd, "balance_query") {
+    if let Err(error) = db.record_balance_snapshot(relay_id, balance_usd, "balance_query") {
         log::warn!("写入余额快照失败（不影响余额显示，对账页会显示快照不足）: {error}");
     }
 }
@@ -173,7 +189,7 @@ fn resolved_usd_balance(usage: &UsageResult) -> Option<f64> {
 /// 太老的比值没有判别力，只会稀释基线。
 const LOOKBACK_SECS: i64 = 30 * 24 * 3600;
 
-/// 返回窗口数上限（新 → 旧）。正常频率（每次余额刷新一枚快照）远够不到，
+/// 返回窗口数上限（新 → 旧）。正常频率（每次余额变化一枚快照）远够不到，
 /// 这是防「高频刷新把 payload 撑爆」的安全阀。基线仍按回看期内全部有效窗口算。
 const MAX_WINDOWS: usize = 50;
 
@@ -219,7 +235,7 @@ pub struct ReconciliationWindow {
 
 /// 窗口标记。判据是业务事实，由后端定（前端只展示）：
 ///
-/// - [`WindowFlag::SkippedTopUp`]：扣减 <= 0（充值/返利/赠送），不进比值、不进基线。
+/// - [`WindowFlag::SkippedTopUp`]：扣减 < 0，即余额增加（充值/返利/赠送），不进比值、不进基线。
 /// - [`WindowFlag::InsufficientData`]：没有可算的比值（扣减太小或窗口内无估算数据）。
 /// - [`WindowFlag::Suspicious`]：`ratio <= baseline × 0.5` 且基线存在 ——
 ///   实际扣减持续达到预期的 2 倍以上。
@@ -343,7 +359,9 @@ fn median_baseline(windows: &[ReconciliationWindow]) -> Option<f64> {
 /// 基线定完之后给窗口打标（[`WindowFlag`] 的判据见枚举文档）。
 fn classify(window: &ReconciliationWindow, baseline_ratio: Option<f64>) -> WindowFlag {
     let deduction = window.start_balance_usd - window.end_balance_usd;
-    if deduction <= 0.0 {
+    // 余额没变（deduction == 0）不算充值 —— 落到 InsufficientData：没有可算的比值。
+    // 快照写入侧去重后这种窗口不该出现，但判据本身要站得住。
+    if deduction < 0.0 {
         WindowFlag::SkippedTopUp
     } else if window.ratio.is_none() {
         WindowFlag::InsufficientData
@@ -380,11 +398,12 @@ mod tests {
     }
 
     #[test]
-    fn insert_then_read_roundtrips_every_field() {
+    fn record_then_read_roundtrips_every_field() {
         let db = db();
         let id = db
-            .insert_balance_snapshot(7, 12.5, "balance_query")
-            .expect("插入");
+            .record_balance_snapshot(7, 12.5, "balance_query")
+            .expect("记录")
+            .expect("表空，首条必须落行");
 
         let rows = db.list_balance_snapshots(7, None).expect("读取");
         assert_eq!(rows.len(), 1);
@@ -411,12 +430,15 @@ mod tests {
     #[test]
     fn snapshots_are_filtered_by_relay() {
         let db = db();
-        db.insert_balance_snapshot(1, 10.0, "balance_query")
-            .expect("插入");
-        db.insert_balance_snapshot(2, 20.0, "balance_query")
-            .expect("插入");
-        db.insert_balance_snapshot(1, 30.0, "balance_query")
-            .expect("插入");
+        db.record_balance_snapshot(1, 10.0, "balance_query")
+            .expect("记录")
+            .expect("落行");
+        db.record_balance_snapshot(2, 20.0, "balance_query")
+            .expect("记录")
+            .expect("落行");
+        db.record_balance_snapshot(1, 30.0, "balance_query")
+            .expect("记录")
+            .expect("落行");
 
         let rows = db.list_balance_snapshots(1, None).expect("读取");
         assert_eq!(
@@ -430,14 +452,17 @@ mod tests {
     fn snapshots_are_ordered_by_created_at_ascending() {
         let db = db();
         let a = db
-            .insert_balance_snapshot(3, 1.0, "balance_query")
-            .expect("插入");
+            .record_balance_snapshot(3, 1.0, "balance_query")
+            .expect("记录")
+            .expect("落行");
         let b = db
-            .insert_balance_snapshot(3, 2.0, "balance_query")
-            .expect("插入");
+            .record_balance_snapshot(3, 2.0, "balance_query")
+            .expect("记录")
+            .expect("落行");
         let c = db
-            .insert_balance_snapshot(3, 4.0, "balance_query")
-            .expect("插入");
+            .record_balance_snapshot(3, 4.0, "balance_query")
+            .expect("记录")
+            .expect("落行");
         // 故意让插入顺序与时间顺序相反。
         set_created_at(&db, a, 300);
         set_created_at(&db, b, 100);
@@ -455,14 +480,17 @@ mod tests {
     fn since_secs_keeps_snapshots_at_or_after_the_boundary() {
         let db = db();
         let a = db
-            .insert_balance_snapshot(4, 1.0, "balance_query")
-            .expect("插入");
+            .record_balance_snapshot(4, 1.0, "balance_query")
+            .expect("记录")
+            .expect("落行");
         let b = db
-            .insert_balance_snapshot(4, 2.0, "balance_query")
-            .expect("插入");
+            .record_balance_snapshot(4, 2.0, "balance_query")
+            .expect("记录")
+            .expect("落行");
         let c = db
-            .insert_balance_snapshot(4, 4.0, "balance_query")
-            .expect("插入");
+            .record_balance_snapshot(4, 4.0, "balance_query")
+            .expect("记录")
+            .expect("落行");
         set_created_at(&db, a, 100);
         set_created_at(&db, b, 200);
         set_created_at(&db, c, 300);
@@ -480,6 +508,50 @@ mod tests {
         let db = db();
         let conn = db.conn.lock().expect("拿连接");
         create_table(&conn).expect("再建一次不该报错");
+    }
+
+    #[test]
+    fn record_skips_unchanged_balance() {
+        let db = db();
+        assert!(
+            db.record_balance_snapshot(7, 12.5, "balance_query")
+                .expect("记录")
+                .is_some(),
+            "该站还没有快照，首条必须落"
+        );
+        assert!(
+            db.record_balance_snapshot(7, 12.5, "balance_query")
+                .expect("记录")
+                .is_none(),
+            "余额与最新一条相同 ⇒ 零信息观测，不落行"
+        );
+        assert!(
+            db.record_balance_snapshot(7, 12.0, "balance_query")
+                .expect("记录")
+                .is_some(),
+            "余额有变必须落行"
+        );
+        assert!(
+            db.record_balance_snapshot(7, 12.5, "balance_query")
+                .expect("记录")
+                .is_some(),
+            "回到见过的旧值也算有变 —— 只与最新一条比"
+        );
+        // 不同站各自独立：relay 8 的首条与 relay 7 的最新值无关。
+        assert!(db
+            .record_balance_snapshot(8, 12.5, "balance_query")
+            .expect("记录")
+            .is_some());
+
+        assert_eq!(
+            db.list_balance_snapshots(7, None)
+                .expect("读取")
+                .iter()
+                .map(|r| r.balance_usd)
+                .collect::<Vec<_>>(),
+            vec![12.5, 12.0, 12.5]
+        );
+        assert_eq!(db.list_balance_snapshots(8, None).expect("读取").len(), 1);
     }
 
     // ------------------------------------------------------------------
@@ -582,11 +654,13 @@ mod tests {
         vec![(OWNED_PID.to_string(), "codex".to_string())]
     }
 
-    /// 插一条快照并把 `created_at` 改成指定值（测试没法等真实时钟拉开差距）。
+    /// 记一条快照并把 `created_at` 改成指定值（测试没法等真实时钟拉开差距）。
+    /// 各测试里相邻余额都相异，去重不会拦。
     fn snapshot_at(db: &Database, relay_id: i64, balance_usd: f64, created_at: i64) {
         let id = db
-            .insert_balance_snapshot(relay_id, balance_usd, "balance_query")
-            .expect("插快照");
+            .record_balance_snapshot(relay_id, balance_usd, "balance_query")
+            .expect("记快照")
+            .expect("相邻余额相异，必须落行");
         set_created_at(db, id, created_at);
     }
 
@@ -705,6 +779,24 @@ mod tests {
         let tiny = &report.windows[2]; // [100,200)
         assert_eq!(tiny.ratio, None);
         assert_eq!(tiny.flag, WindowFlag::InsufficientData);
+    }
+
+    #[test]
+    fn zero_delta_window_is_not_a_topup() {
+        // 写入侧去重后 delta == 0 的窗口不该再出现；但 classify 自身的语义要钉住：
+        // 余额没变不是充值 —— 0 落进 InsufficientData（前端无徽标），而不是 SkippedTopUp。
+        let window = ReconciliationWindow {
+            start_secs: 100,
+            end_secs: 200,
+            start_balance_usd: 10.0,
+            end_balance_usd: 10.0,
+            balance_delta_usd: 0.0,
+            estimated_cost_usd: 0.0,
+            ratio: None,
+            flag: WindowFlag::Normal,
+        };
+        assert_eq!(classify(&window, None), WindowFlag::InsufficientData);
+        assert_eq!(classify(&window, Some(0.5)), WindowFlag::InsufficientData);
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

对账弹窗里出现「估算 `$0.0000` + 变动 `$0.00` + 充值徽标」的行：两次采样之间余额没变，这对快照表（唯一消费者就是对账窗口）是零信息，却被原样存下来、配成零变动窗口，还被 `classify` 的 `<= 0` 边界误标成充值。修根而非在展示层过滤：

- **写入侧去重**：`insert_balance_snapshot` → `record_balance_snapshot`，余额与该站最新一条相同就不落行（单条 `INSERT … SELECT … WHERE` 原子完成比对 + 落行）。「相邻快照必然相异」成为表的结构不变量 —— 零变动窗口从根上不存在，展示侧不需要任何过滤代码
- **v14 → v15 迁移**：`LAG` 一趟删除存量「与上一条余额相同」的行（每个等值段留最早一条，按站分区），清掉 30 天回看期内的旧噪声；空表 / 全新库天然空转
- **classify 判据修正**：扣减 `< 0`（余额增加）才是充值；余额没变落 `InsufficientData`（前端本就不出徽标），徽标文案「余额增加（充值、返利或赠送）」从此与事实一致

前端无改动：零信息行消失，真实充值行仍照常展示。

## Related Issue / 关联 Issue

Fixes #

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查（本地 tsc 通过；prettier/vitest 因 worktree 未装 node_modules 留给 CI，本 PR 未动任何前端文件）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（`--all-targets -- -D warnings` 全绿；`cargo test` 全量、`cargo fmt --check` 均通过）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（无用户可见文本变化）
