### PR TITLE
feat(relay): 强删账号后受影响 app 自动切回官方登录

### DIFF
--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -4510,18 +4510,28 @@ fn list_sites_impl(state: &AppState) -> Result<Vec<SiteInfo>, AppError> {
 /// 正是他要的（「我不想再用这个站了」），与那条裁决不矛盾 —— 判据从「档位还活着吗」
 /// 变成「用户知道自己在删什么吗」。
 ///
-/// 顺序：**先删档位再删站点**。反过来的话，站点行没了而 `site_origin` 是档位归属的唯一
-/// 依据 —— 删站点之后就再也认不出哪些档位属于它，那些记录会永久留在 provider 列表里。
+/// 顺序：**（force 时）先切官方 → 先删档位再删站点**。反过来的话，站点行没了而
+/// `site_origin` 是档位归属的唯一依据 —— 删站点之后就再也认不出哪些档位属于它，
+/// 那些记录会永久留在 provider 列表里。切官方放在删档位之前，则是让被安置的档位
+/// 先卸下「当前项」身份、删除全走常规路径（见 [`switch_affected_apps_to_official`]）。
 #[tauri::command]
 pub fn relay_remove_site(
+    app: tauri::AppHandle,
     state: State<'_, AppState>,
     id: i64,
     force: Option<bool>,
 ) -> Result<(), String> {
-    remove_site_impl(state.inner(), id, force.unwrap_or(false)).map_err(|e| e.to_string())
+    remove_site_impl(state.inner(), id, force.unwrap_or(false), Some(&app))
+        .map_err(|e| e.to_string())
 }
 
-fn remove_site_impl(state: &AppState, id: i64, force: bool) -> Result<(), AppError> {
+fn remove_site_impl(
+    state: &AppState,
+    id: i64,
+    force: bool,
+    // `None` = 单测（没有 AppHandle）：切官方照常执行，只是不发事件、不刷托盘。
+    app: Option<&tauri::AppHandle>,
+) -> Result<(), AppError> {
     // 先取归属信息 —— 删掉那行之后就没法知道该清哪些档位了。
     //
     // ⚠️ **`account_id` 与 `site_origin` 一样必须取**：删的是**一个账号**（一行），
@@ -4542,11 +4552,6 @@ fn remove_site_impl(state: &AppState, id: i64, force: bool) -> Result<(), AppErr
     // 文案点名**哪个平台、哪个档位**：只说「有档位在使用中」的话，用户得自己去六个 tab
     // 里翻是哪一个。他要做的处置（切走 / 或回弹窗里选强制删）完全取决于这个信息。
     //
-    // force 路径对「被删掉的当前项」不做额外处置：`prune_stale_tiers` 的当前项旁路
-    // （直连 db 删）+ 悬空 current 指针自愈（`get_effective_current_provider`）与
-    // provision 清死档位是同一条路；受影响 app 的 live 配置继续沿用旧设置直到用户
-    // 重选 —— 有意**不**自动切到别的供应商：静默改掉 CLI 正在用的配置比留一份
-    // 还能跑的旧配置更不可预期。
     let in_use = apps_using_this_accounts_tiers(state, &site_origin, account_id);
     if !in_use.is_empty() && !force {
         let detail = in_use
@@ -4557,6 +4562,27 @@ fn remove_site_impl(state: &AppState, id: i64, force: bool) -> Result<(), AppErr
         return Err(AppError::Config(format!(
             "这个账号名下还有档位正在使用中：{detail}。请先在对应平台切换到别的供应商，再删除这个账号。"
         )));
+    }
+
+    // force 路径对「被删掉的当前项」的安置：**先切回官方 seed provider，再删档位**
+    // （[`switch_affected_apps_to_official`] 的文档写了完整理由 —— 删本地登录态不会
+    // 吊销服务端 sk，留旧配置等于 CLI 继续把请求打向一个用户明确要删掉的站）。
+    // 切过去之后档位不再是当前项，`prune_stale_tiers` 全走常规删除路径。
+    //
+    // 切不动的（codex-image 无官方 seed / seed 被删 / 代理接管禁止切官方）降级成
+    // 悬空自愈（`get_effective_current_provider`）—— 宁可降级也不让「删账号」失败。
+    if force && !in_use.is_empty() {
+        let switched = switch_affected_apps_to_official(state, &in_use);
+        if let Some(app) = app {
+            for (app_type, provider_id) in &switched {
+                // 背后切了 current 就必须广播（2026-08-04 的教训：不发事件的症状是
+                // provider 页 / 中转站页静默陈旧，用户以为删除功能坏了）。
+                emit_provider_switched(app, app_type, provider_id);
+            }
+            if !switched.is_empty() {
+                crate::tray::refresh_tray_menu(app);
+            }
+        }
     }
 
     // 空 `keep` = 这一行名下的托管档位全不保留。
@@ -4596,6 +4622,60 @@ fn remove_site_impl(state: &AppState, id: i64, force: bool) -> Result<(), AppErr
     }
 
     with_conn(state, |conn| creds::remove(conn, id))
+}
+
+/// force 删的收尾一步：把受影响的 app 切回各自的官方 seed provider。
+///
+/// ## 为什么是「切官方」而不是留着旧配置
+///
+/// 删登录态只是本地动作，**服务端的 sk 并没有被吊销** —— 留着 live 旧配置等于
+/// CLI 继续把请求（和扣费）打向一个用户刚刚明确删掉的站，那才是违背「我不想再
+/// 用这个站」的意图。官方 seed 的「空 env / 空 config」正是该 CLI 刚装好时的
+/// 默认认证状态（seed 注释原文）：纯中转站用户下次运行会被引导登录；本来就有
+/// 官方登录的直接用回它（那份登录与中转站无关，保留正是预期）。
+///
+/// ## 复用与边界
+///
+/// live 配置怎么清、current 怎么写、MCP 怎么同步全是 `ProviderService::switch`
+/// 现成的，这里只编排「谁该被切」。没有官方 seed 的 app（codex-image 生图）跳过；
+/// 切失败（seed 被用户删了 / 代理接管下 switch 主动拒绝切官方 —— 防封号）记日志
+/// 降级成悬空自愈，**不让删账号失败** —— 安置是收尾，不是闸。
+///
+/// 返回成功切到官方的 `(app_type, official_id)`，调用方拿它发 `PROVIDER_SWITCHED`
+/// 与刷托盘。
+fn switch_affected_apps_to_official(
+    state: &AppState,
+    affected: &[(AppType, String)],
+) -> Vec<(AppType, String)> {
+    let mut switched = Vec::new();
+    for (app_type, tier_name) in affected {
+        let Some(official_id) = crate::database::official_seed_id(app_type) else {
+            log::info!(
+                "{} 没有官方 seed 可回落（原在用档位「{tier_name}」随删除悬空自愈）",
+                app_type.as_str()
+            );
+            continue;
+        };
+        match ProviderService::switch(state, app_type.clone(), official_id) {
+            Ok(result) => {
+                for warning in &result.warnings {
+                    log::info!("强删后 {} 切回官方的提示：{warning}", app_type.as_str());
+                }
+                log::info!(
+                    "强删后把 {} 切回官方 provider（原在用档位：{tier_name}）",
+                    app_type.as_str()
+                );
+                switched.push((app_type.clone(), official_id.to_string()));
+            }
+            Err(e) => {
+                log::warn!(
+                    "强删后把 {} 切回官方失败（current 将悬空自愈，不影响删除）：{e}",
+                    app_type.as_str()
+                );
+            }
+        }
+    }
+    switched
 }
 
 /// 一行名下**全部托管档位**里的 base_url 与 sk。
@@ -8441,7 +8521,7 @@ mod tests {
             .expect("set codex current");
 
         // 用户此刻停在 claude tab 上（那边这一行没有当前项）—— 前端会放行，后端必须拦。
-        let err = remove_site_impl(&state, row_id, false)
+        let err = remove_site_impl(&state, row_id, false, None)
             .expect_err("⭐ 名下有档位是别的平台的当前项时，删除必须失败");
         let msg = err.to_string();
         assert!(
@@ -8486,7 +8566,7 @@ mod tests {
             .expect("seed");
         // **不设 current** —— 别的 provider 是当前项，或压根没有当前项。
 
-        remove_site_impl(&state, row_id, false).expect("没人在用它时删除该成功");
+        remove_site_impl(&state, row_id, false, None).expect("没人在用它时删除该成功");
 
         assert!(
             db.get_provider_by_id(&tier, "codex")
@@ -8509,8 +8589,12 @@ mod tests {
     /// 也能过前两条。钉住的语义：
     ///
     /// - force 放行后**全有或全无**：档位、账号行都得没了（不留孤儿记录）；
-    /// - 被删的是 codex 的**当前项** —— `prune_stale_tiers` 的当前项旁路在这条路上
-    ///   生效（这正是 force 依赖的机制，见 `remove_site_impl` 闸注释）。
+    /// - 被删的是 codex 的**当前项** —— 这条测试的内存库里**没有官方 seed**
+    ///   （`init_default_official_providers` 只在真应用启动时跑），切官方必然失败
+    ///   ⇒ 它同时钉住降级路径：**安置失败不阻断删除**，current 悬空自愈。
+    ///   （正向「切回官方」那条没法单测 —— `ProviderService::switch` 会写真实
+    ///   live 配置文件，codex/claude 没有测试沙箱；映射由
+    ///   `official_seed_id_maps_text_apps_and_denies_codex_image` 把守。）
     #[test]
     fn forced_removal_deletes_even_while_another_app_uses_its_tier() {
         let site = "https://bestapi.store";
@@ -8547,7 +8631,7 @@ mod tests {
         db.set_current_provider("codex", &codex_tier)
             .expect("set codex current");
 
-        remove_site_impl(&state, row_id, true).expect("force 是用户知情后的选择，该放行");
+        remove_site_impl(&state, row_id, true, None).expect("force 是用户知情后的选择，该放行");
 
         assert!(
             db.get_provider_by_id(&codex_tier, "codex")

--- a/src-tauri/src/database/dao/providers_seed.rs
+++ b/src-tauri/src/database/dao/providers_seed.rs
@@ -90,6 +90,21 @@ pub(crate) fn is_official_seed_id(id: &str) -> bool {
     OFFICIAL_SEEDS.iter().any(|seed| seed.id == id)
 }
 
+/// 这个 app 有没有官方 seed provider；有则返回它的固定 id。
+///
+/// 官方 seed 的「空 env / 空 config」就是该 CLI 刚装好时的默认认证状态（各 seed
+/// 的注释原文），所以「切到官方」=「回默认认证」。强删中转站账号的收尾拿它把
+/// 受影响 app 安置回官方（`commands::relay::switch_affected_apps_to_official`）。
+///
+/// 返回 `None` 的 app（codex-image 生图，及 additive 类）没有这个回落 —— 调用方
+/// 维持悬空自愈。与 `is_official_seed_id` 同一份 `OFFICIAL_SEEDS`，别另列清单。
+pub(crate) fn official_seed_id(app_type: &AppType) -> Option<&'static str> {
+    OFFICIAL_SEEDS
+        .iter()
+        .find(|seed| seed.app_type == *app_type)
+        .map(|seed| seed.id)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -116,5 +131,29 @@ mod tests {
         assert!(is_official_seed_id(GROKBUILD_OFFICIAL_PROVIDER_ID));
         // 空 config = 官方登录态：切换时不注入自定义模型表
         assert_eq!(seed.settings_config_json, r#"{"config":""}"#);
+    }
+
+    /// 强删收尾靠这份映射决定「哪个 app 能回落官方」。**会红的改法**：给新 app
+    /// 加官方 seed 却忘了这里（单源扫描，加 seed 即自动覆盖）；或有人把 codex-image
+    /// 的回落写成依赖它 —— 它没有 seed，这里必须是 `None`。
+    #[test]
+    fn official_seed_id_maps_text_apps_and_denies_codex_image() {
+        assert_eq!(official_seed_id(&AppType::Claude), Some("claude-official"));
+        assert_eq!(
+            official_seed_id(&AppType::ClaudeDesktop),
+            Some(CLAUDE_DESKTOP_OFFICIAL_PROVIDER_ID)
+        );
+        assert_eq!(
+            official_seed_id(&AppType::Codex),
+            Some(CODEX_OFFICIAL_PROVIDER_ID)
+        );
+        assert_eq!(official_seed_id(&AppType::Gemini), Some("gemini-official"));
+        assert_eq!(
+            official_seed_id(&AppType::GrokBuild),
+            Some(GROKBUILD_OFFICIAL_PROVIDER_ID)
+        );
+        // 生图没有「官方登录」可回；additive 类 app 永远进不了在用名单（current 恒空）
+        assert_eq!(official_seed_id(&AppType::CodexImage), None);
+        assert_eq!(official_seed_id(&AppType::OpenCode), None);
     }
 }

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -35,8 +35,8 @@ mod tests;
 
 // DAO 类型导出供外部使用
 pub(crate) use dao::providers_seed::{
-    is_official_seed_id, CLAUDE_DESKTOP_OFFICIAL_PROVIDER_ID, CODEX_OFFICIAL_PROVIDER_ID,
-    GROKBUILD_OFFICIAL_PROVIDER_ID,
+    is_official_seed_id, official_seed_id, CLAUDE_DESKTOP_OFFICIAL_PROVIDER_ID,
+    CODEX_OFFICIAL_PROVIDER_ID, GROKBUILD_OFFICIAL_PROVIDER_ID,
 };
 pub(crate) use dao::proxy::{
     validate_cost_multiplier, validate_pricing_source, PRICING_SOURCE_REQUEST,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3204,7 +3204,7 @@
       "remove": "Delete account and connection profiles",
       "removeInUseHint": "Some connection profiles are in use — you can still delete, with confirmation",
       "removeConfirmUsageItem": "{{tier}} ({{app}})",
-      "removeConfirmMessageInUse": "Connection profiles of “{{label}}” are in use: {{usages}}. After deletion these apps lose their active provider (running CLIs keep the old config until you pick another). This deletes the sign-in session and its {{count}} connection profiles; your balance remains with the relay service.",
+      "removeConfirmMessageInUse": "Connection profiles of “{{label}}” are in use: {{usages}}. After deletion these apps switch back to their official sign-in; apps without their own sign-in will be guided to sign in again on next run (restart running CLIs to apply). This deletes the sign-in session and its {{count}} connection profiles; your balance remains with the relay service.",
       "removeConfirmTitle": "Delete this account?",
       "removeConfirmMessage": "This deletes the sign-in session for “{{label}}” and its {{count}} connection profiles. Your balance remains with the relay service, and you can sign in again later.",
       "removeConfirmMessageNeverLoggedIn": "This deletes “{{label}}” and its {{count}} connection profiles. You can add the account again later."

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3204,7 +3204,7 @@
       "remove": "アカウントと接続プロファイルを削除",
       "removeInUseHint": "使用中の接続プロファイルがあります。確認のうえ削除できます",
       "removeConfirmUsageItem": "{{tier}}（{{app}}）",
-      "removeConfirmMessageInUse": "「{{label}}」の接続プロファイルが使用中です：{{usages}}。削除するとこれらのアプリは現在使用中のプロバイダーを失います（実行中の CLI は再選択まで旧設定を使い続けます）。ログイン情報と {{count}} 件の接続プロファイルを削除します。中継サービスの残高は保持されます。",
+      "removeConfirmMessageInUse": "「{{label}}」の接続プロファイルが使用中です：{{usages}}。削除後、これらのアプリは公式ログインに切り替わります。独自のログインがないアプリは次回起動時にログイン案内が表示されます（実行中の CLI は再起動で反映されます）。ログイン情報と {{count}} 件の接続プロファイルを削除します。中継サービスの残高は保持されます。",
       "removeConfirmTitle": "このアカウントを削除しますか？",
       "removeConfirmMessage": "「{{label}}」のログイン情報と {{count}} 件の接続プロファイルを削除します。中継サービスの残高は保持され、後から再ログインできます。",
       "removeConfirmMessageNeverLoggedIn": "「{{label}}」と {{count}} 件の接続プロファイルを削除します。後からこのアカウントを再度追加できます。"

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3205,7 +3205,7 @@
       "remove": "刪除帳號與連線設定檔",
       "removeInUseHint": "有連線設定檔正在使用——仍可刪除，需在彈出視窗中確認",
       "removeConfirmUsageItem": "{{tier}}（{{app}}）",
-      "removeConfirmMessageInUse": "「{{label}}」的連線設定檔正在被使用：{{usages}}。刪除後這些 app 將失去目前供應商（執行中的 CLI 會繼續沿用舊設定，重新選擇後生效）。將刪除該帳號的登入資訊及其 {{count}} 個連線設定檔；中轉站內的餘額不會受到影響。",
+      "removeConfirmMessageInUse": "「{{label}}」的連線設定檔正在被使用：{{usages}}。刪除後這些 app 將切回官方登入；沒有自身登入的會在下次執行時引導重新登入（執行中的需重新啟動生效）。將刪除該帳號的登入資訊及其 {{count}} 個連線設定檔；中轉站內的餘額不會受到影響。",
       "removeConfirmTitle": "刪除此帳號？",
       "removeConfirmMessage": "將刪除「{{label}}」的登入資訊及其 {{count}} 個連線設定檔。中轉站內的餘額不會受到影響；之後可重新登入繼續使用。",
       "removeConfirmMessageNeverLoggedIn": "將刪除「{{label}}」及其 {{count}} 個連線設定檔。之後可重新新增此帳號。"

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -3204,7 +3204,7 @@
       "remove": "删除账号及接入配置",
       "removeInUseHint": "有接入配置正在使用——仍可删除，需在弹窗中确认",
       "removeConfirmUsageItem": "{{tier}}（{{app}}）",
-      "removeConfirmMessageInUse": "「{{label}}」的接入配置正在被使用：{{usages}}。删除后这些 app 将失去当前供应商（正在运行的 CLI 会继续沿用旧配置，重新选择后生效）。将删除该账号的登录信息及其 {{count}} 个接入配置；中转站中的余额不会受影响。",
+      "removeConfirmMessageInUse": "「{{label}}」的接入配置正在被使用：{{usages}}。删除后这些 app 将切回官方登录；没有自身登录的会在下次运行时引导重新登录（正在运行的需重启生效）。将删除该账号的登录信息及其 {{count}} 个接入配置；中转站中的余额不会受影响。",
       "removeConfirmTitle": "删除此账号？",
       "removeConfirmMessage": "将删除「{{label}}」的登录信息及其 {{count}} 个接入配置。中转站中的余额不会受影响；之后可重新登录恢复使用。",
       "removeConfirmMessageNeverLoggedIn": "将删除「{{label}}」及其 {{count}} 个接入配置。之后可重新添加此账号。"

--- a/src/lib/api/relay.ts
+++ b/src/lib/api/relay.ts
@@ -432,7 +432,8 @@ export const relayApi = {
    * （后端 `relay_remove_site` 的文档写了完整理由）。
    *
    * `force` 只在 `row.usageBlockers` 非空、用户已在点名 app 的弹窗里确认后传 true；
-   * 后端默认仍会拦下在用档位（那道闸不信任任何前端按钮态）。
+   * 后端默认仍会拦下在用档位（那道闸不信任任何前端按钮态）。force 放行后后端会把
+   * 受影响 app 切回各自的官方 seed provider（切不动则悬空自愈，均不阻断删除）。
    */
   removeSite: (id: number, force = false): Promise<void> =>
     invoke("relay_remove_site", { id, force }),


### PR DESCRIPTION
## 背景

#147 让「有档位在用」的中转站行可以强删，但在用档位被删后 live 配置留在原地。维护者点破了其中的矛盾：**删登录态并不吊销服务端 sk**——留旧配置等于 CLI 继续把请求（和扣费）打向一个用户明确要删掉的站。

## 方案

force 收尾新增一步：**先把受影响 app 切回各自的官方 seed provider，再删档位**。

- 官方 seed 的「空 env / 空 config」就是该 CLI 刚装好时的默认认证状态（seed 注释原文）——纯中转站用户下次运行会被引导登录；本来就有官方登录的直接用回它（那份 OAuth 与中转站无关，保留正是预期，所以不做退 ChatGPT / 删 auth.json 那套编排）。
- 切过去之后档位不再是当前项，`prune_stale_tiers` 全走常规删除路径。
- 复用 `ProviderService::switch` + `OFFICIAL_SEEDS`（新增 `official_seed_id` 单源映射）。切不动的都**降级成悬空自愈、不阻断删除**：codex-image 无官方 seed、代理接管下 switch 主动拒绝切官方（防封号）、seed 被用户删了。
- 背后切了 current 就广播：每个切成的 app 发 `PROVIDER_SWITCHED` + 刷托盘（2026-08-04 静默陈旧的教训）。
- 强删弹窗文案（4 locales）从「沿用旧配置」改为「切回官方登录；没有自身登录的会在下次运行时引导重新登录」。

## 测试

- `official_seed_id` 映射闸：五个文本 app（claude / claude-desktop / codex / gemini / grokbuild）有 seed，codex-image 与 additive 类没有。
- forced 删除测试同时钉住降级路径（内存库无 seed ⇒ 切官方失败照样删干净）。
- 正向「切回官方」无法单测：`ProviderService::switch` 会写真实 live 配置文件，codex/claude 没有测试沙箱（Pi 有 `TestAgentDir` 但 pi 是 additive、永远进不了在用名单）。
- `cargo test --lib` 3381 过、clippy 干净；`pnpm vitest run` 1119 过、typecheck / format 干净。