### PR TITLE
fix(relay): 切换确认结果补 rename_all_fields，确认弹窗恢复弹出

### DIFF
--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -418,7 +418,14 @@ pub fn switch_provider_test_hook(
 /// 默认行为（它们没有弹确认框的机会，而未经用户同意就关掉他正开着的 app 是不能接受的）。
 /// 只有前端在弹过确认框、用户同意之后才传 `Some(true)`。
 #[derive(Debug, serde::Serialize)]
-#[serde(tag = "status", rename_all = "camelCase")]
+// `rename_all` 只转变体名；变体字段要另加 `rename_all_fields`（serde 1.0.185+）。
+// 漏掉它时 `target_name`/`routing_notice` 蛇形下发、前端读 undefined ——
+// 闸在 switch_command_result_wire_tests。
+#[serde(
+    tag = "status",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
 pub enum ProviderSwitchCommandResult {
     ConfirmationRequired {
         target_name: String,
@@ -2175,5 +2182,41 @@ mod native_query_credentials_tests {
 
         assert_eq!(base_url, "https://provider.zenmux.example/v1");
         assert_eq!(api_key, "sk-provider");
+    }
+}
+
+#[cfg(test)]
+mod switch_command_result_wire_tests {
+    use super::*;
+
+    /// 契约闸：前端 `src/lib/api/providers.ts` 的 `SwitchResult` 手写断言这份形状。
+    /// enum 级 `rename_all` 不覆盖变体字段，这里钉住驼峰契约（与 relay 侧同款事故）。
+    #[test]
+    fn provider_switch_command_result_wire_contract_is_camel_case() {
+        let confirmation =
+            serde_json::to_value(ProviderSwitchCommandResult::ConfirmationRequired {
+                target_name: "供应商".into(),
+            })
+            .unwrap();
+        assert_eq!(confirmation["status"], "confirmationRequired");
+        assert!(
+            confirmation.get("targetName").is_some(),
+            "变体字段必须驼峰下发：{confirmation}"
+        );
+        assert!(
+            confirmation.get("target_name").is_none(),
+            "蛇形键意味着前端读到 undefined：{confirmation}"
+        );
+
+        let switched = serde_json::to_value(ProviderSwitchCommandResult::Switched {
+            warnings: vec![],
+            routing_notice: None,
+        })
+        .unwrap();
+        assert_eq!(switched["status"], "switched");
+        assert!(
+            switched.get("routingNotice").is_some(),
+            "变体字段必须驼峰下发：{switched}"
+        );
     }
 }

--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -913,7 +913,14 @@ pub struct SwitchTierResult {
 }
 
 #[derive(Debug, Serialize)]
-#[serde(tag = "status", rename_all = "camelCase")]
+// `rename_all` 只转变体名；变体字段要另加 `rename_all_fields`（serde 1.0.185+）。
+// 漏掉它时 `target_name` 蛇形下发、前端读 `targetName` 得 undefined，
+// 确认弹窗静默打不开 —— 闸在 tests::switch_tier_command_result_wire_contract。
+#[serde(
+    tag = "status",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
 pub enum SwitchTierCommandResult {
     ConfirmationRequired {
         target_name: String,
@@ -5149,6 +5156,42 @@ pub fn relay_sync_imagegen_mcp(state: State<'_, AppState>) -> Result<(), AppErro
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// 契约闸：前端 TS 类型手写断言了这份 wire 形状（`src/lib/api/relay.ts` 的
+    /// `SwitchTierCommandResult`），serde 的 enum 级 `rename_all` 只转变体名、
+    /// 不转变体字段 —— 没有这条闸的话 casing 分叉编译期完全静默
+    /// （2026-08-16 线上事故：`target_name` 蛇形下发，确认弹窗永不打开）。
+    #[test]
+    fn switch_tier_command_result_wire_contract_is_camel_case() {
+        let confirmation = serde_json::to_value(SwitchTierCommandResult::ConfirmationRequired {
+            target_name: "站点 · 分组".into(),
+        })
+        .unwrap();
+        assert_eq!(confirmation["status"], "confirmationRequired");
+        assert!(
+            confirmation.get("targetName").is_some(),
+            "变体字段必须驼峰下发：{confirmation}"
+        );
+        assert!(
+            confirmation.get("target_name").is_none(),
+            "蛇形键意味着前端读到 undefined：{confirmation}"
+        );
+
+        let switched = serde_json::to_value(SwitchTierCommandResult::Switched {
+            result: SwitchTierResult {
+                provider_name: "p".into(),
+                chatgpt_was_running: false,
+                chatgpt_relaunched: false,
+                warnings: vec![],
+            },
+        })
+        .unwrap();
+        assert_eq!(switched["status"], "switched");
+        assert!(
+            switched.get("providerName").is_some(),
+            "flatten 的结构体字段同样是驼峰契约：{switched}"
+        );
+    }
 
     fn purchase_capability_relay(backend_kind: creds::BackendKind) -> creds::Relay {
         creds::Relay {


### PR DESCRIPTION
## 症状

切 codex 档位 / provider 页「启用」：按钮闪一下「正在切换」后回到原状——确认弹窗（取消/只切换/退出并切换）永远不出现，四条确认链（中转站档位、选模型、vendor、provider 页守卫）全部静默无操作。托盘入口正常（原生对话框不经过这条前端链）。

## 根因

7f8b5ed7 引入的 `confirmationRequired` 契约里，serde 的 enum 级 `rename_all = "camelCase"` **只转变体名，不转变体字段**：`target_name` 蛇形下发，前端 TS 类型读 `targetName` 得 `undefined`，`SwitchTierConfirmDialog` 的 `targetName={undefined ?? null}` 恒为 null，弹窗永不打开。typecheck/现有测试全抓不住（TS 类型是手写断言，无契约闸）。

受影响枚举共两个：`SwitchTierCommandResult`（relay + vendor 复用）、`ProviderSwitchCommandResult`（还有 `routing_notice`）。

## 修复

- 两个枚举补 `rename_all_fields = "camelCase"`（serde 1.0.185+ 为该场景的官方属性），与全仓既有驼峰 wire 契约对齐（struct 侧早已是 rename_all="camelCase"，本次是把仅有的两处蛇形孤例收回来）；
- 各加一条序列化契约测试钉住 JSON 键名（先红后绿验证过：红时实锤 `{"status":"confirmationRequired","target_name":...}`）。

## 验证

- 契约测试 2 条先红后绿；
- `cargo test --lib` 3385 全绿；`cargo fmt`；`cargo clippy --all-targets` 干净。