### PR TITLE
feat(ui): 聚合页迭代——手填域名直连回归、空态虚框直跳、默认综合榜

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,7 +81,7 @@ import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { SettingsPage } from "@/components/settings/SettingsPage";
 import { UpdateBadge } from "@/components/UpdateBadge";
 import { GitHubStarButton } from "@/components/GitHubStarButton";
-import { AddHubPage } from "@/components/relay/AddHubPage";
+import { AddHubPage, type AddHubTab } from "@/components/relay/AddHubPage";
 import { StarRewardDialog } from "@/components/StarRewardDialog";
 import { EnvWarningBanner } from "@/components/env/EnvWarningBanner";
 import { ProxyToggle } from "@/components/proxy/ProxyToggle";
@@ -106,7 +106,6 @@ import UnifiedSkillsPanel, {
 import { DeepLinkImportDialog } from "@/components/DeepLinkImportDialog";
 import { CcSwitchImportEntry } from "@/components/settings/CcSwitchImportEntry";
 import { RelaySection } from "@/components/relay/RelaySection";
-import type { LeaderboardKind } from "@/lib/api/relay";
 import { StatsNoticeDialog } from "@/components/relay/StatsNoticeDialog";
 import { useCodexSwitchGuard } from "@/components/relay/useCodexSwitchGuard";
 import { AgentsPanel } from "@/components/agents/AgentsPanel";
@@ -202,8 +201,9 @@ function App() {
   const sharedFeatureApp: AppId =
     activeApp === "claude-desktop" ? "claude" : activeApp;
   const [currentView, setCurrentView] = useState<View>(getInitialView);
-  const [directoryInitialKind, setDirectoryInitialKind] =
-    useState<LeaderboardKind>();
+  // 聚合页进来落在哪个标签（顶栏 + / 空态占位 / 首启引导共用一个入口状态）。
+  const [addHubInitialTab, setAddHubInitialTab] =
+    useState<AddHubTab>("directory");
   const [skillsDiscoverySource, setSkillsDiscoverySource] =
     useState<SkillsPageSource>("repos");
   const [settingsDefaultTab, setSettingsDefaultTab] = useState("general");
@@ -991,9 +991,9 @@ function App() {
     setCurrentView("skillsDiscovery");
   };
 
-  /** 普通添加（顶栏 + / ProviderList 空态）不带榜单偏好；首启引导落综合榜。 */
-  const handleOpenAddHub = useCallback((directoryKind?: "overall") => {
-    setDirectoryInitialKind(directoryKind);
+  /** 打开聚合页；`tab` 缺省落「中转站」（首启引导同）。 */
+  const handleOpenAddHub = useCallback((tab: AddHubTab = "directory") => {
+    setAddHubInitialTab(tab);
     setCurrentView("addHub");
   }, []);
 
@@ -1004,7 +1004,7 @@ function App() {
           return (
             <AddHubPage
               sourceAppId={activeApp}
-              initialDirectoryKind={directoryInitialKind}
+              initialTab={addHubInitialTab}
               onBack={() => setCurrentView("providers")}
               onAddProvider={addProvider}
             />
@@ -1110,7 +1110,7 @@ function App() {
                         聚合页，三标签就地切换）。 */}
                     <RelaySection
                       appId={activeApp}
-                      onOpenDirectory={() => handleOpenAddHub("overall")}
+                      onOpenAddHub={handleOpenAddHub}
                     />
 
                     {/* 「其他」块：cc-switch 的供应商列表原样复用，添加入口在顶栏 +。

--- a/src/components/relay/AddHubPage.tsx
+++ b/src/components/relay/AddHubPage.tsx
@@ -1,10 +1,10 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ArrowLeft, Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { AppId } from "@/lib/api";
-import type { LeaderboardKind } from "@/lib/api/relay";
 import { useVendorSupportedQuery } from "@/lib/query/vendor";
 import {
   AddProviderForm,
@@ -14,39 +14,47 @@ import {
 import { RelayDirectoryPage } from "./directory/RelayDirectoryPage";
 import { OfficialApiPage } from "./OfficialApiPage";
 
+/** 聚合页的三个标签。 */
+export type AddHubTab = "directory" | "official" | "manual";
+
 /**
  * 顶栏大「+」的统一添加聚合页：点一次「+」直接进来，三个标签就地切换 ——
  * **中转站广场（默认）** / 官方 API / 手动添加。用户不用先在菜单里选一遍
  * 再跳页面（下拉菜单那版要两次点击，这正是它被替换的原因）。
  *
  * 三个标签的内容都是既有组件的 `embedded` 形态（不带返回箭头与页面级容器）：
- * - 中转站 → `RelayDirectoryPage`（首启引导进来时固定落综合榜，普通添加按
- *   当前 app 选榜 —— `initialDirectoryKind` 沿用原入口的语义）；
+ * - 中转站 → `RelayDirectoryPage`，默认落「综合」榜（按 app 选榜是旧独立
+ *   入口的语义，聚合页统一从全局看）；白名单外的站可在页尾手填域名直连；
  * - 官方 API → `OfficialApiPage`（是否出现这个标签由后端
  *   `vendor_list_accounts.supported` 说了算，与 `VendorBlock` 整块同一来源）；
  * - 手动添加 → `AddProviderForm`（原 `AddProviderDialog` 的表单体）。
+ *
+ * `initialTab` 让区块空态这类「指名道姓」的入口直落对应标签（如官方 API
+ * 区块的空态占位点进来就落「官方 API」）。
  *
  * 返回与「添加成功/取消」的收尾统一走 `onBack`；本页是供应商页的临时子流程，
  * 不进 `LAST_VIEW`（与被它替换的两个独立视图同一条规则）。
  */
 export function AddHubPage({
   sourceAppId,
-  initialDirectoryKind,
+  initialTab = "directory",
   onBack,
   onAddProvider,
 }: {
   sourceAppId: AppId;
-  /** 首启引导传 `"overall"`（落综合榜）；普通添加不传（按当前 app 选榜）。 */
-  initialDirectoryKind?: LeaderboardKind;
+  /** 进来落在哪个标签；顶栏大「+」与首启引导不传（落默认「中转站」）。 */
+  initialTab?: AddHubTab;
   onBack: () => void;
   onAddProvider: AddProviderFormProps["onSubmit"];
 }) {
   const { t } = useTranslation();
   const vendorSupported = useVendorSupportedQuery(sourceAppId);
+  const [tab, setTab] = useState<AddHubTab>(initialTab);
 
   return (
     <Tabs
-      defaultValue="directory"
+      value={tab}
+      onValueChange={(v) => setTab(v as AddHubTab)}
       className="mx-auto flex h-full w-full max-w-[1180px] flex-col px-6 pb-6"
     >
       <div className="flex shrink-0 items-center gap-4 border-b border-border-default py-3">
@@ -79,7 +87,7 @@ export function AddHubPage({
       <TabsContent value="directory" className="mt-0 min-h-0 flex-1">
         <RelayDirectoryPage
           sourceAppId={sourceAppId}
-          initialKind={initialDirectoryKind}
+          initialKind="overall"
           onBack={onBack}
           embedded
         />

--- a/src/components/relay/RelaySection.tsx
+++ b/src/components/relay/RelaySection.tsx
@@ -90,9 +90,9 @@ export interface RelaySectionProps {
    * 且把「这是个受限取值域」这个事实写进类型里。
    */
   appId: AppId;
-  /** 打开独立中转站广场；首启入口固定落综合榜，普通添加按当前 app 选榜。
-   * 普通添加入口（`"add"`）已上收到顶栏大「+」，这里只剩首启引导在用。 */
-  onOpenDirectory: (entry: "firstRun") => void;
+  /** 打开统一添加聚合页的指定标签。首启引导落「中转站」（综合榜）；
+   * 两个区块的空态占位也经它指名跳转（中转站→directory / 官方 API→official）。 */
+  onOpenAddHub: (tab: "directory" | "official") => void;
 }
 
 /**
@@ -111,7 +111,7 @@ export interface RelaySectionProps {
  */
 let autoPromptedThisProcess = false;
 
-export function RelaySection({ appId, onOpenDirectory }: RelaySectionProps) {
+export function RelaySection({ appId, onOpenAddHub }: RelaySectionProps) {
   /**
    * 当前这一屏是不是生图页。
    *
@@ -293,11 +293,11 @@ export function RelaySection({ appId, onOpenDirectory }: RelaySectionProps) {
       // 无论弹不弹，新人都落到中转站广场 —— 注册窗不再自动弹，它是 star
       // 走通之后的终点，不是起点。
       void promptOnboardingStarReward();
-      onOpenDirectory("firstRun");
+      onOpenAddHub("directory");
     } catch {
       // 状态读不到时不猜业务事实；保留最后一次完整后端视图。
     }
-  }, [isImageTab, onOpenDirectory]);
+  }, [isImageTab, onOpenAddHub]);
 
   const presentRefreshResult = useCallback(
     (result: RefreshResult) => {
@@ -902,6 +902,7 @@ export function RelaySection({ appId, onOpenDirectory }: RelaySectionProps) {
       <RelayTierList
         relays={relays}
         busy={busy}
+        onAddSite={() => onOpenAddHub("directory")}
         onLogin={(relayId) => void handleLogin(relayId)}
         onProvision={handleProvision}
         onReorder={(ids) => void handleReorder(ids)}
@@ -986,6 +987,7 @@ export function RelaySection({ appId, onOpenDirectory }: RelaySectionProps) {
             onReorder: (ids) => void handleVendorReorder(ids),
           }}
           busy={busy}
+          onAddAccount={() => onOpenAddHub("official")}
         />
       )}
 

--- a/src/components/relay/RelayTierList.tsx
+++ b/src/components/relay/RelayTierList.tsx
@@ -64,6 +64,8 @@ export interface RelayTierListProps {
    * 不该跟着灰掉。见 `useRowBusy` 的文档。
    */
   busy: ReadonlySet<string>;
+  /** 空态占位（「尚未添加中转站」虚框）整块的点击动作：跳聚合页「中转站」。 */
+  onAddSite: () => void;
   /** 行内动作，**都显式带 relayId**（后端命令直接吃它，不再靠全局「当前站」）。 */
   onLogin: (relayId: number) => void;
   onProvision: (relayId: number) => void | Promise<void>;
@@ -160,6 +162,7 @@ function initialOpenState(relays: RelayRowData[]): Record<RowKey, boolean> {
 export function RelayTierList({
   relays,
   busy,
+  onAddSite,
   onLogin,
   onProvision,
   onSwitchTier,
@@ -248,9 +251,16 @@ export function RelayTierList({
       <h2 className="text-sm font-medium">{t("loongport.sections.relay")}</h2>
 
       {relays.length === 0 ? (
-        <p className="rounded-xl border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+        // 空态占位整块是碰撞框：点一下直达聚合页「中转站」标签。
+        <button
+          type="button"
+          onClick={onAddSite}
+          title={t("loongport.tierList.addSite")}
+          aria-label={t("loongport.tierList.addSite")}
+          className="w-full rounded-xl border border-dashed border-border p-6 text-center text-sm text-muted-foreground transition-colors hover:border-blue-400/60 hover:bg-muted/40 hover:text-foreground"
+        >
           {t("loongport.tierList.empty")}
-        </p>
+        </button>
       ) : (
         <DndContext
           sensors={sensors}

--- a/src/components/relay/VendorBlock.tsx
+++ b/src/components/relay/VendorBlock.tsx
@@ -77,9 +77,11 @@ export interface VendorBlockProps {
    * （`"vendorLogin:<rowId>"` 等）。
    */
   busy: ReadonlySet<string>;
+  /** 空态占位（「尚未添加服务商账号」虚框）整块的点击动作：跳聚合页「官方 API」。 */
+  onAddAccount: () => void;
 }
 
-export function VendorBlock({ vendor, busy }: VendorBlockProps) {
+export function VendorBlock({ vendor, busy, onAddAccount }: VendorBlockProps) {
   const { t } = useTranslation();
   const accounts = vendor.accounts;
 
@@ -120,9 +122,16 @@ export function VendorBlock({ vendor, busy }: VendorBlockProps) {
       </h2>
 
       {accounts.length === 0 ? (
-        <p className="rounded-xl border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+        // 空态占位整块是碰撞框：点一下直达聚合页「官方 API」标签。
+        <button
+          type="button"
+          onClick={onAddAccount}
+          title={t("loongport.officialApi.title")}
+          aria-label={t("loongport.officialApi.title")}
+          className="w-full rounded-xl border border-dashed border-border p-6 text-center text-sm text-muted-foreground transition-colors hover:border-blue-400/60 hover:bg-muted/40 hover:text-foreground"
+        >
           {t("loongport.vendor.empty")}
-        </p>
+        </button>
       ) : (
         <DndContext
           sensors={sensors}

--- a/src/components/relay/__tests__/RelaySection.modelVerification.test.tsx
+++ b/src/components/relay/__tests__/RelaySection.modelVerification.test.tsx
@@ -171,7 +171,7 @@ function renderSection(appId: "codex" | "claude" | "codex-image" | "gemini") {
   const queryClient = createTestQueryClient();
   return render(
     <QueryClientProvider client={queryClient}>
-      <RelaySection appId={appId} onOpenDirectory={vi.fn()} />
+      <RelaySection appId={appId} onOpenAddHub={vi.fn()} />
     </QueryClientProvider>,
   );
 }
@@ -532,7 +532,7 @@ describe("RelaySection model verification ownership", () => {
     const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
     render(
       <QueryClientProvider client={queryClient}>
-        <RelaySection appId="codex" onOpenDirectory={vi.fn()} />
+        <RelaySection appId="codex" onOpenAddHub={vi.fn()} />
       </QueryClientProvider>,
     );
 

--- a/src/components/relay/directory/RelayDirectoryPage.tsx
+++ b/src/components/relay/directory/RelayDirectoryPage.tsx
@@ -66,6 +66,7 @@ export function RelayDirectoryPage({
   const [authenticatingHost, setAuthenticatingHost] = useState<string | null>(
     null,
   );
+  const [customSite, setCustomSite] = useState("");
   const authenticationInProgress = useRef(false);
 
   const directoryQuery = useQuery({
@@ -123,12 +124,19 @@ export function RelayDirectoryPage({
     return message || t("loongport.addSite.importFailed");
   };
 
-  const authenticate = async (entryUrl: string, host: string) => {
+  const authenticate = async (
+    entryUrl: string,
+    host: string,
+    source: "directory" | "manual" = "directory",
+  ) => {
     if (authenticationInProgress.current) return;
     authenticationInProgress.current = true;
     setAuthenticatingHost(host);
     try {
-      const result = await relayApi.importDirectorySite(entryUrl);
+      // manual = 用户手填域名（不在白名单里）：走保守的 Manual 打开规则。
+      const result = await (source === "directory"
+        ? relayApi.importDirectorySite(entryUrl)
+        : relayApi.importSite(entryUrl));
       toast.success(
         t("loongport.addSite.connected", { name: result.siteName }),
       );
@@ -329,6 +337,35 @@ export function RelayDirectoryPage({
             <ChevronRight className="h-3.5 w-3.5" />
           </Button>
         </div>
+      </div>
+
+      {/* 白名单里没有的站，用户自己填域名直连（Manual 来源，保守打开规则；
+          探针不通 / 协议不识别以可读 toast 报错）。 */}
+      <div className="flex items-center gap-2 border-t border-border-default pt-3">
+        <Input
+          value={customSite}
+          disabled={authenticatingHost !== null}
+          onChange={(event) => setCustomSite(event.target.value)}
+          placeholder={t("loongport.directory.customSitePlaceholder")}
+          onKeyDown={(event) => {
+            if (
+              event.key === "Enter" &&
+              customSite.trim() &&
+              !authenticationInProgress.current
+            ) {
+              void authenticate(customSite, customSite.trim(), "manual");
+            }
+          }}
+        />
+        <Button
+          variant="outline"
+          disabled={!customSite.trim() || authenticatingHost !== null}
+          onClick={() =>
+            void authenticate(customSite, customSite.trim(), "manual")
+          }
+        >
+          {t("loongport.directory.actions.useOtherSite")}
+        </Button>
       </div>
     </div>
   );

--- a/src/components/relay/directory/__tests__/RelayDirectoryPage.test.tsx
+++ b/src/components/relay/directory/__tests__/RelayDirectoryPage.test.tsx
@@ -284,6 +284,28 @@ describe("RelayDirectoryPage", () => {
     expect(openInBrowser).not.toHaveBeenCalledWith("https://site-2.example");
   });
 
+  it("imports a manually entered site outside the whitelist", async () => {
+    const user = userEvent.setup();
+    renderDirectory({ sourceAppId: "codex", onBack: () => {} });
+    await waitFor(() => expect(listDirectory).toHaveBeenCalled());
+
+    await user.type(
+      screen.getByPlaceholderText("loongport.directory.customSitePlaceholder"),
+      "https://my-own-relay.example",
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "loongport.directory.actions.useOtherSite",
+      }),
+    );
+
+    // 手填域名走 Manual 导入（保守打开规则），不是白名单行的目录导入。
+    await waitFor(() =>
+      expect(importSite).toHaveBeenCalledWith("https://my-own-relay.example"),
+    );
+    expect(importDirectorySite).not.toHaveBeenCalled();
+  });
+
   it("labels a managed detail-page completion without inventing a rank", async () => {
     listDirectory.mockResolvedValue(
       leaderboard("gemini", {
@@ -554,19 +576,20 @@ describe("RelayDirectoryPage", () => {
     });
   });
 
-  it("no longer offers a custom-site input", async () => {
-    // 白名单语义：广场只展示受管站点，手动输域名的入口已删。
+  it("keeps the custom-site input alongside the whitelist rows", async () => {
+    // 白名单仍是展示集合的所有者；手填域名是绕开它的兜底直连（2026-08-16 应
+    // 用户要求恢复 —— 白名单外的站也该能连，错误以可读 toast 呈现）。
     renderDirectory({ sourceAppId: "codex", onBack: () => {} });
     await screen.findByText("BestAPI");
 
     expect(
-      screen.queryByPlaceholderText(
-        "loongport.directory.customSitePlaceholder",
-      ),
-    ).not.toBeInTheDocument();
+      screen.getByPlaceholderText("loongport.directory.customSitePlaceholder"),
+    ).toBeInTheDocument();
     expect(
-      screen.queryByText("loongport.directory.actions.useOtherSite"),
-    ).not.toBeInTheDocument();
+      screen.getByRole("button", {
+        name: "loongport.directory.actions.useOtherSite",
+      }),
+    ).toBeInTheDocument();
     expect(importSite).not.toHaveBeenCalled();
   });
 });

--- a/src/components/relay/directory/__tests__/RelayDirectoryRouting.test.tsx
+++ b/src/components/relay/directory/__tests__/RelayDirectoryRouting.test.tsx
@@ -33,11 +33,11 @@ vi.mock("@tauri-apps/api/window", () => ({
 }));
 
 vi.mock("@/components/relay/RelaySection", () => ({
-  RelaySection: ({ appId, onOpenDirectory }: any) => (
+  RelaySection: ({ appId, onOpenAddHub }: any) => (
     <div data-testid="relay-section">
       <span data-testid="relay-source-app">{appId}</span>
-      {/* 普通添加入口已上收到顶栏大「+」（聚合页默认落当前 app 的榜）。 */}
-      <button onClick={() => onOpenDirectory("firstRun")}>
+      {/* 普通添加入口已上收到顶栏大「+」（聚合页默认落综合榜）。 */}
+      <button onClick={() => onOpenAddHub("directory")}>
         open-first-run-directory
       </button>
     </div>
@@ -89,14 +89,9 @@ describe("relay directory routing", () => {
     localStorage.setItem(LAST_APP_STORAGE_KEY, "claude");
   });
 
-  it.each([
-    ["claude", "claude"],
-    ["codex", "openai"],
-    ["gemini", "gemini"],
-    ["openclaw", "overall"],
-  ])(
-    "opens an independent directory from %s with the %s leaderboard",
-    async (appId, expectedKind) => {
+  it.each([["claude"], ["codex"], ["gemini"], ["openclaw"]])(
+    "opens the add hub from %s with the overall leaderboard",
+    async (appId) => {
       localStorage.setItem(LAST_APP_STORAGE_KEY, appId);
       renderApp();
 
@@ -112,9 +107,7 @@ describe("relay directory routing", () => {
       expect(screen.getByTestId("directory-source-app")).toHaveTextContent(
         appId,
       );
-      expect(screen.getByTestId("directory-kind")).toHaveTextContent(
-        expectedKind,
-      );
+      expect(screen.getByTestId("directory-kind")).toHaveTextContent("overall");
       expect(screen.queryByTestId("app-switcher")).not.toBeInTheDocument();
       expect(document.querySelector("header")).toHaveAttribute("hidden");
       expect(localStorage.getItem(LAST_VIEW_STORAGE_KEY)).toBe("providers");

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3134,6 +3134,7 @@
       "other": "Other"
     },
     "directory": {
+      "customSitePlaceholder": "Can't find it? Enter another relay URL",
       "title": "Relay directory",
       "description": "Choose a site using VeriDrop's public test results. It is added to LoongPort only after registration or sign-in succeeds.",
       "tabs": {
@@ -3161,6 +3162,7 @@
         "supplementalRank": "Added"
       },
       "actions": {
+        "useOtherSite": "Use another site",
         "authenticate": "Register or sign in",
         "autoAddHint": "Added automatically when complete",
         "history": "Full history",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3134,6 +3134,7 @@
       "other": "その他"
     },
     "directory": {
+      "customSitePlaceholder": "見つからない場合は別の中継サイト URL を入力",
       "title": "中継サイト一覧",
       "description": "VeriDrop の公開検証結果からサイトを選びます。登録またはログインに成功した場合のみ LoongPort に追加されます。",
       "tabs": {
@@ -3161,6 +3162,7 @@
         "supplementalRank": "補足"
       },
       "actions": {
+        "useOtherSite": "別のサイトを使用",
         "authenticate": "登録またはログイン",
         "autoAddHint": "完了後に自動追加",
         "history": "全履歴",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3135,6 +3135,7 @@
       "other": "其他"
     },
     "directory": {
+      "customSitePlaceholder": "沒有找到？輸入其他中轉站網址",
       "title": "中轉站廣場",
       "description": "根據 VeriDrop 公開檢測結果選擇站點，完成註冊或登入後自動加入 LoongPort。",
       "tabs": {
@@ -3162,6 +3163,7 @@
         "supplementalRank": "補充"
       },
       "actions": {
+        "useOtherSite": "使用其他站點",
         "authenticate": "註冊或登入",
         "autoAddHint": "完成後自動加入",
         "history": "完整記錄",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -3134,6 +3134,7 @@
       "other": "其他"
     },
     "directory": {
+      "customSitePlaceholder": "没有找到？输入其他中转站网址",
       "title": "中转站广场",
       "description": "基于 VeriDrop 公开检测结果选择站点，完成注册或登录后自动添加到 LoongPort。",
       "tabs": {
@@ -3161,6 +3162,7 @@
         "supplementalRank": "补充"
       },
       "actions": {
+        "useOtherSite": "使用其他站点",
         "authenticate": "注册或登录",
         "autoAddHint": "完成后自动添加",
         "history": "完整历史",

--- a/src/lib/api/relay.ts
+++ b/src/lib/api/relay.ts
@@ -344,6 +344,15 @@ export const relayApi = {
     invoke("relay_import_directory_site", { site }),
 
   /**
+   * 手动导入任意站点（用户自己填的域名，绕开广场白名单）。与目录导入分开：
+   * 后端走 `BrowserEntrySource::Manual` 的保守打开规则（origin 或协议登录页，
+   * 不认目录声明的专属入口）。未验证站点可能探针不通 / 协议不识别——
+   * 错误会以可读 toast 呈现，不静默。
+   */
+  importSite: (site: string): Promise<ImportResult> =>
+    invoke("relay_import_site", { site }),
+
+  /**
    * 探一遍每一行凭据是不是真的还活着，返回**这次被清掉凭据的行 id**（空 = 全都好）。
    *
    * 曾经它探「当前站」一行、返回 bool —— 那个形状只对单站界面成立。

--- a/tests/components/AddHubPage.test.tsx
+++ b/tests/components/AddHubPage.test.tsx
@@ -89,6 +89,23 @@ describe("AddHubPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("lands on the official tab when entered from the official empty state", async () => {
+    listVendorAccounts.mockResolvedValue({ supported: true, accounts: [] });
+    render(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <AddHubPage
+          sourceAppId="codex"
+          initialTab="official"
+          onBack={vi.fn()}
+          onAddProvider={vi.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+    // 指名进来直落「官方 API」，不用再点一遍标签。
+    expect(await screen.findByTestId("official-content")).toBeInTheDocument();
+  });
+
   it("invokes onBack from the back button", async () => {
     const user = userEvent.setup();
     listVendorAccounts.mockResolvedValue({ supported: true, accounts: [] });

--- a/tests/config/loongportLocales.test.ts
+++ b/tests/config/loongportLocales.test.ts
@@ -28,6 +28,7 @@ const requiredKeys = [
   // 独立中转站广场。四个榜单、数据来源、评分证据、认证动作、缓存状态和分页
   // 都是用户直接看到的主流程文案；漏一个 locale 会直接显示 key 名。
   "directory.title",
+  "directory.customSitePlaceholder",
   "directory.description",
   "directory.tabs.overall",
   "directory.tabs.claude",
@@ -55,6 +56,7 @@ const requiredKeys = [
   "directory.meta.samples",
   "directory.meta.latest",
   "directory.actions.authenticate",
+  "directory.actions.useOtherSite",
   "directory.actions.autoAddHint",
   "directory.actions.history",
   "directory.actions.refresh",

--- a/tests/lib/relayApiTargeting.test.ts
+++ b/tests/lib/relayApiTargeting.test.ts
@@ -34,9 +34,13 @@ describe("relayApi 的中转站定位参数", () => {
     invokeMock.mockResolvedValue(undefined);
   });
 
-  it("不再暴露手动输入专用的 importSite 入口", () => {
-    // 广场白名单化后手动添加已删（2026-08-15），前端只剩目录导入一条路。
-    expect("importSite" in relayApi).toBe(false);
+  it("importSite 走 Manual 来源的保守导入命令（手填域名兜底直连）", async () => {
+    // 白名单是展示集合的所有者，但白名单外的站也要能连（2026-08-16 恢复）；
+    // 与目录导入分开成两条命令：Manual 不认目录声明的专属入口。
+    await relayApi.importSite("https://my-own-relay.example");
+    expect(invokeMock).toHaveBeenCalledWith("relay_import_site", {
+      site: "https://my-own-relay.example",
+    });
   });
 
   it("importDirectorySite 走后端重新核验签名目录的专用命令", async () => {


### PR DESCRIPTION
## 背景

用户实测 v3.28.0 聚合页的三条反馈：手填域名直连不能丢、空态虚框应该是整块碰撞框、默认榜要「综合」。

## 改动

1. **手填域名直连回归**（v3.27.0 白名单化时移除，本次恢复）：
   - `relayApi.importSite` 重新暴露，走后端一直保留的 `relay_import_site`（Manual 来源：不认目录声明的专属入口，按保守规则打开 origin 或协议登录页）
   - 广场页尾恢复输入行 + 「使用其他站点」按钮（i18n 四 locale 从历史恢复）
   - 白名单仍是展示集合的所有者；手填是绕开它的兜底，错误以可读 toast 呈现
2. **空态虚框整块可点**：中转站「尚未添加中转站」与官方 API「尚未添加服务商账号」两个虚线占位改成 button，整块是碰撞框（hover 有反馈），点击直达聚合页对应标签 —— `AddHubPage` 新增 `initialTab`，App 以 tab 状态替代原榜单偏好状态
3. **默认综合榜**：聚合页中转站标签固定落「综合」（原来是按当前 app 选榜；`directoryInitialKind` 状态随之删除）

## 验收

- 全量 vitest **171 文件 / 1122 用例通过**；`tsc` / `format:check` ✅（纯前端）
- 新增/改写测试：手填导入走 `importSite`（非目录导入）、输入行与白名单行共存、`initialTab` 指名落标签、路由测试默认综合榜、`relayApi` 契约测试翻转
