### PR TITLE
feat(relay): 站点探针健康层——后台三分类探测、曝光闸与漏斗日志

### DIFF
--- a/src-tauri/src/maintenance/mod.rs
+++ b/src-tauri/src/maintenance/mod.rs
@@ -55,7 +55,11 @@ fn start_veridrop_directory_refresh(app: tauri::AppHandle) {
         let app = app.clone();
         async move {
             crate::relay::remote_config::refresh_and_cache().await;
-            crate::refresh_stale_directories(app).await
+            crate::refresh_stale_directories(app).await?;
+            // 漏斗收尾（探针 + 三层日志）：best-effort，不把它记成任务失败 ——
+            // 探针的单站失败已经作为 NetworkBlocked 落进了结果里。
+            crate::relay::leaderboard::refresh_site_probes_for_directory().await;
+            Ok(())
         }
     });
 }

--- a/src-tauri/src/relay/discovery.rs
+++ b/src-tauri/src/relay/discovery.rs
@@ -391,6 +391,38 @@ pub async fn probe_site(site_origin: &str) -> Result<DetectedSite, DiscoveryErro
 
 /// 原生 HTTP 探测所有候选，再复用 WebView 原始回传使用的同一收敛规则。
 pub async fn discover_site(site_origin: &str) -> Result<DetectedSite, DiscoveryError> {
+    let responses = probe_candidates(site_origin).await?;
+    // 与旧内联实现同一条判据：**没有任何候选完成过一次 HTTP 往返**才算传输失败
+    // （连不上 / 中途断流）；只要有一个候选拿到过响应（哪怕 404 / 超大），
+    // 就按「站点答了话但认不出」走 UnsupportedSite。
+    let completed = responses
+        .iter()
+        .any(|response| response.status.is_some() && response.error_kind.is_none());
+    if !completed {
+        let detail = responses
+            .iter()
+            .find_map(|response| response.error_kind.clone())
+            .unwrap_or_default();
+        return Err(DiscoveryError::new(
+            DiscoveryErrorKind::Transport,
+            format!("连接站点失败: {detail}"),
+        ));
+    }
+
+    converge_probe_responses(&responses)
+}
+
+/// 原生探测一轮，返回**逐候选**的元数据（失败候选也记录 `status` / `error_kind`，
+/// `body` 为空）——`discover_site` 的收敛与 [`crate::relay::site_probe`] 的三分类
+/// 都吃这一份原始数据，谁也不用重打一遍网络请求。
+///
+/// 每个候选的落表口径：发送失败 `status=None + error_kind`；读到 HTTP 响应但
+/// 状态非 2xx `status=Some + 空 body`；2xx 且读完正文 `status + body`；正文超上限
+/// （与浏览器路径同一个源大小上限）按「答了话但指纹读不了」记 `status + 空 body`
+/// —— 与非 2xx 同形状，靠 status 区分，**不算 error**（站点活着，别当传输失败）。
+pub(crate) async fn probe_candidates(
+    site_origin: &str,
+) -> Result<Vec<ProbeResponse>, DiscoveryError> {
     let client = api::build_client().map_err(|error| {
         DiscoveryError::new(
             DiscoveryErrorKind::Transport,
@@ -398,20 +430,29 @@ pub async fn discover_site(site_origin: &str) -> Result<DetectedSite, DiscoveryE
         )
     })?;
     let mut responses = Vec::new();
-    let mut completed_candidate = false;
-    let mut last_transport_error = None;
 
     for candidate in PROBE_CANDIDATES {
         let url = format!("{site_origin}{}", candidate.path);
-        let response = match client.get(&url).send().await {
-            Ok(response) => response,
+        let mut response = ProbeResponse {
+            candidate_id: candidate.id.to_string(),
+            ..ProbeResponse::default()
+        };
+        let sent = match client.get(&url).send().await {
+            Ok(sent) => sent,
             Err(error) => {
-                last_transport_error = Some(error.to_string());
+                response.error_kind = Some(sanitize_probe_log_value(&error.to_string(), 64));
+                responses.push(response);
                 continue;
             }
         };
-        if !response.status().is_success() {
-            completed_candidate = true;
+        response.status = Some(sent.status().as_u16());
+        response.content_type = sent
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned);
+        if !sent.status().is_success() {
+            responses.push(response);
             continue;
         }
 
@@ -419,62 +460,50 @@ pub async fn discover_site(site_origin: &str) -> Result<DetectedSite, DiscoveryE
         // 站点把大段用户可见配置塞进公共设置里是常事（实测 bestapi.store 已 143 KiB），
         // 在 64 KiB 就丢弃会把一个完全正常的 sub2api 站误判成「协议无法识别」。
         // 真正的指纹只有几个字段，读完再投影即可。
-        if response
+        if sent
             .content_length()
             .is_some_and(|length| length > MAX_PROBE_COMPACT_SOURCE_BYTES as u64)
         {
-            completed_candidate = true;
+            responses.push(response);
             continue;
         }
 
         let mut body = Vec::new();
-        let mut stream = response.bytes_stream();
-        let mut body_failed = false;
+        let mut oversized = false;
+        let mut stream = sent.bytes_stream();
         while let Some(chunk) = stream.next().await {
             match chunk {
                 Ok(chunk) if body.len() + chunk.len() <= MAX_PROBE_COMPACT_SOURCE_BYTES => {
                     body.extend_from_slice(&chunk);
                 }
                 Ok(_) => {
-                    completed_candidate = true;
-                    body_failed = true;
+                    oversized = true;
                     break;
                 }
                 Err(error) => {
-                    last_transport_error = Some(error.to_string());
-                    body_failed = true;
+                    response.error_kind = Some(sanitize_probe_log_value(&error.to_string(), 64));
                     break;
                 }
             }
         }
-        if body_failed {
+        if response.error_kind.is_some() || oversized {
+            // 读流中断（error）之外的两种「没读到指纹」都按答话处理：正文超上限
+            // 时丢弃半截正文 —— 存 2 MiB 解不开的 JSON 没有意义，status 已说明一切。
+            responses.push(response);
             continue;
         }
-        completed_candidate = true;
-        responses.push(ProbeResponse {
-            candidate_id: candidate.id.to_string(),
-            body_bytes: body.len(),
-            detector_body_bytes: body.len(),
-            json_like: body
-                .iter()
-                .copied()
-                .find(|byte| !byte.is_ascii_whitespace())
-                .is_some_and(|byte| byte == b'{' || byte == b'['),
-            body: String::from_utf8_lossy(&body).into_owned(),
-            ..ProbeResponse::default()
-        });
+        response.body_bytes = body.len();
+        response.detector_body_bytes = body.len();
+        response.json_like = body
+            .iter()
+            .copied()
+            .find(|byte| !byte.is_ascii_whitespace())
+            .is_some_and(|byte| byte == b'{' || byte == b'[');
+        response.body = String::from_utf8_lossy(&body).into_owned();
+        responses.push(response);
     }
 
-    if responses.is_empty() && !completed_candidate {
-        return Err(DiscoveryError::new(
-            DiscoveryErrorKind::Transport,
-            last_transport_error
-                .map(|error| format!("连接站点失败: {error}"))
-                .unwrap_or_else(|| "连接站点失败".into()),
-        ));
-    }
-
-    converge_probe_responses(&responses)
+    Ok(responses)
 }
 
 /// 在 Rust 侧按候选 id 分派严格 detector。

--- a/src-tauri/src/relay/leaderboard.rs
+++ b/src-tauri/src/relay/leaderboard.rs
@@ -576,6 +576,91 @@ fn managed_veridrop_hosts(config: &RemoteConfig) -> Vec<String> {
         .collect()
 }
 
+/// 受管站点（去 blocked）的**本站 host** 清单 —— 这些是真实可导入的 origin，
+/// 探针名单用这份（`managed_veridrop_hosts` 是 veridrop 空间的别名，探它没意义）。
+pub(crate) fn managed_site_hosts(config: &RemoteConfig) -> Vec<String> {
+    let policy = normalized_policy(&config.relay_directory);
+    let blocked: BTreeSet<_> = policy.blocked_hosts.iter().cloned().collect();
+    policy
+        .sites
+        .into_keys()
+        .filter(|host| !host.is_empty() && !blocked.contains(host))
+        .collect()
+}
+
+/// 四个榜单缓存里出现过的 veridrop host 全集 —— 漏斗第 1/2 层的对照面。
+fn cached_veridrop_hosts() -> BTreeSet<String> {
+    LeaderboardKind::ALL
+        .into_iter()
+        .filter_map(read_cache)
+        .flat_map(|cached| cached.items)
+        .map(|item| item.veridrop_host)
+        .collect()
+}
+
+/// 目录漏斗的周期收尾：**三层过滤逐层留痕** + 受管站探针落盘。
+///
+/// 由 `maintenance` 的 veridrop-directory 定时任务在配置与榜单刷新之后调用，
+/// 每个周期（6 小时）输出三条 INFO：
+///
+/// 1. `whitelist_filter` —— 榜单在、白名单不在（未收录，不展示）；
+/// 2. `leaderboard_missing` —— 白名单在、榜单没有行（无排名数据但仍可展示）；
+/// 3. `probe`（逐站一条）—— 探针三分类 + 连续 miss 计数 + 是否仍曝光。
+///
+/// 下一轮排查「这个站为什么不在广场」时，逐层翻日志就能回答。
+pub(crate) async fn refresh_site_probes_for_directory() {
+    let config = crate::relay::remote_config::load_cached().unwrap_or_default();
+    let managed_hosts = managed_site_hosts(&config);
+    if managed_hosts.is_empty() {
+        log::info!(
+            "{}",
+            crate::diagnostics::DiagnosticEvent::new("relay.directory_funnel", "skipped")
+                .field("reason", "no_managed_sites")
+        );
+        return;
+    }
+
+    let managed_veridrop: BTreeSet<_> = managed_veridrop_hosts(&config).into_iter().collect();
+    let cached_hosts = cached_veridrop_hosts();
+    let not_managed: Vec<_> = cached_hosts
+        .difference(&managed_veridrop)
+        .cloned()
+        .collect();
+    let missing_from_board: Vec<_> = managed_veridrop
+        .difference(&cached_hosts)
+        .cloned()
+        .collect();
+    log::info!(
+        "{}",
+        crate::diagnostics::DiagnosticEvent::new("relay.directory_funnel", "whitelist_filter")
+            .field("dropped", not_managed.join(","))
+            .field("dropped_count", not_managed.len())
+    );
+    log::info!(
+        "{}",
+        crate::diagnostics::DiagnosticEvent::new("relay.directory_funnel", "leaderboard_missing")
+            .field("hosts", missing_from_board.join(","))
+            .field("count", missing_from_board.len())
+    );
+
+    let origins = managed_hosts
+        .iter()
+        .map(|host| format!("https://{host}"))
+        .collect::<Vec<_>>();
+    for record in crate::relay::site_probe::probe_and_record(&origins).await {
+        log::info!(
+            "{}",
+            crate::diagnostics::DiagnosticEvent::new("relay.directory_funnel", "probe")
+                .field("host", record.host)
+                .field("verdict", format!("{:?}", record.verdict))
+                .field("backend", format!("{:?}", record.backend))
+                .field("consecutive_panel_misses", record.consecutive_panel_misses)
+                .field("exposed", record.exposed)
+                .field("detail", record.detail)
+        );
+    }
+}
+
 pub fn apply_policy(
     parsed: Vec<ParsedLeaderboardItem>,
     config: &RemoteConfig,
@@ -671,9 +756,27 @@ fn read_cache(kind: LeaderboardKind) -> Option<CachedLeaderboard> {
 fn apply_policy_to_cached(cached: CachedLeaderboard, config: &RemoteConfig) -> RelayLeaderboard {
     RelayLeaderboard {
         kind: cached.kind,
-        items: apply_policy(cached.items, config),
+        items: apply_probe_gate(apply_policy(cached.items, config)),
         synced_at: cached.synced_at,
     }
+}
+
+/// 曝光闸：白名单（`apply_policy`）之后再过一遍**探针健康**——连续多轮「协议认不出」
+/// 的站从广场摘掉。见 [`crate::relay::site_probe`] 的三分类（网络失败不摘）。
+fn apply_probe_gate(items: Vec<RelayDirectoryItem>) -> Vec<RelayDirectoryItem> {
+    let store = crate::relay::site_probe::SiteProbeStore::load();
+    filter_probe_gated(items, &store)
+}
+
+/// `apply_probe_gate` 的纯函数核——测试直接喂 store，不碰磁盘。
+fn filter_probe_gated(
+    items: Vec<RelayDirectoryItem>,
+    store: &crate::relay::site_probe::SiteProbeStore,
+) -> Vec<RelayDirectoryItem> {
+    items
+        .into_iter()
+        .filter(|item| store.should_expose(&item.site_host))
+        .collect()
 }
 
 fn write_cache(leaderboard: &CachedLeaderboard) -> Result<(), AppError> {
@@ -822,7 +925,9 @@ async fn refresh_with(
     })?;
     Ok(RelayLeaderboard {
         kind,
-        items,
+        // 返回给 UI 的这份过探针闸；缓存里存的始终是未过滤的 parsed，
+        // 摘除闸解除后无需重新抓取即可恢复展示。
+        items: apply_probe_gate(items),
         synced_at,
     })
 }
@@ -1773,5 +1878,62 @@ mod tests {
             .protocol_scores
             .iter()
             .any(|protocol| protocol.protocol == "Gemini"));
+    }
+
+    /// 曝光闸：连续多轮「协议认不出」的站从广场摘掉；网络失败 / 没探过的站不摘。
+    /// 钉的是 `filter_probe_gated` 与 `SiteProbeStore::should_expose` 的合谋行为。
+    #[test]
+    fn probe_gate_hides_sites_with_consecutive_panel_misses() {
+        use crate::relay::site_probe::{
+            ProbeOutcome, ProbeVerdict, SiteProbeStore, HIDE_AFTER_CONSECUTIVE_PANEL_MISSES,
+        };
+
+        fn outcome(verdict: ProbeVerdict) -> ProbeOutcome {
+            ProbeOutcome {
+                verdict,
+                backend: None,
+                detail: "test".into(),
+                probed_at: 1,
+            }
+        }
+
+        let mut store = SiteProbeStore::default();
+        for _ in 0..HIDE_AFTER_CONSECUTIVE_PANEL_MISSES {
+            store.record("koozhan.example", &outcome(ProbeVerdict::UnrecognizedPanel));
+        }
+        store.record("cf-blocked.example", &outcome(ProbeVerdict::NetworkBlocked));
+
+        fn gated_item(site_host: &str) -> RelayDirectoryItem {
+            RelayDirectoryItem {
+                site_host: site_host.into(),
+                veridrop_host: site_host.into(),
+                display_name: site_host.into(),
+                rank: None,
+                score: 90,
+                samples: 30,
+                latest_date: "2026-08-16".into(),
+                detail_url: format!("https://veridrop.org/site/{site_host}"),
+                protocol_scores: vec![],
+                claude_signature_rate: None,
+                scenarios: vec![],
+                issues: vec![],
+                entry_url: format!("https://{site_host}"),
+                auto_add: true,
+            }
+        }
+
+        let items = vec![
+            gated_item("koozhan.example"),
+            gated_item("cf-blocked.example"),
+            gated_item("fresh.example"),
+        ];
+        let remaining = filter_probe_gated(items, &store)
+            .into_iter()
+            .map(|item| item.site_host)
+            .collect::<Vec<_>>();
+
+        assert!(!remaining.contains(&"koozhan.example".to_owned()));
+        assert!(remaining.contains(&"cf-blocked.example".to_owned()));
+        assert!(remaining.contains(&"fresh.example".to_owned()));
     }
 }

--- a/src-tauri/src/relay/mod.rs
+++ b/src-tauri/src/relay/mod.rs
@@ -83,6 +83,7 @@ pub mod purchase;
 pub mod purchase_session;
 pub mod reconcile;
 pub mod remote_config;
+pub mod site_probe;
 pub mod stats;
 
 pub use managed::{is_managed, reject_if_managed};

--- a/src-tauri/src/relay/site_probe.rs
+++ b/src-tauri/src/relay/site_probe.rs
@@ -1,0 +1,449 @@
+//! 站点探针健康层：把「这个站的协议现在通不通」变成**可持久化、可复用**的事实。
+//!
+//! ## 与站点来源解耦（这是本模块存在的形状约束）
+//!
+//! 本模块**不知道**站点从哪来：签名目录、用户自建站（自定义站点那条特性线）都只是
+//! 探针名单的一个输入源。对外只给四样东西：
+//!
+//! - [`probe_origin`]：探一个站，三分类；
+//! - [`probe_and_record`]：探一批站 + 落盘 + 供漏斗日志用的逐站记录；
+//! - [`SiteProbeStore`]：结果缓存与「该不该曝光」的闸；
+//! - [`ProbeVerdict`]：三分类判据。
+//!
+//! 「哪些站该探」的编排（目录漏斗、自定义站点）住在各自领域里，别往这里搬。
+//!
+//! ## 三分类：网络失败 ≠ 站点不兼容
+//!
+//! 原生探针（reqwest）过不了 Cloudflare 托管挑战，而那种站**导入时走浏览器兜底
+//! 是能成功的**（这正是 `commands::relay` 做浏览器辅助发现的理由）。所以：
+//!
+//! - **Supported**：严格 detector 识别出 sub2api / newapi —— 一定可用；
+//! - **NetworkBlocked**：连一次完整 HTTP 往返都没有，或所有响应都是挑战形态
+//!   （403/429/503 且无 JSON）—— 是**这台机器/这个网络**的问题，**不隐藏**；
+//! - **UnrecognizedPanel**：站点答了话但协议认不出（404 / 形状不匹配 / 双协议冲突）
+//!   —— 大概率是不兼容面板，连续 [`HIDE_AFTER_CONSECUTIVE_PANEL_MISSES`] 轮
+//!   不过才从曝光里摘掉（防单次抖动闪进闪出）。
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::relay::backend::BackendKind;
+use crate::relay::discovery::{self, ProbeResponse};
+
+/// 连续多少轮 UnrecognizedPanel 之后从曝光摘除。周期 6 小时 ⇒ 3 轮 ≈ 18 小时。
+pub const HIDE_AFTER_CONSECUTIVE_PANEL_MISSES: u32 = 3;
+
+/// 一轮探针的并发上限 —— 与 `leaderboard` 抓详情的 `MANAGED_DETAIL_CONCURRENCY`
+/// 同量级：这是后台任务，不该为了快把用户的出口带宽打满。
+const PROBE_CONCURRENCY: usize = 4;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProbeVerdict {
+    Supported,
+    NetworkBlocked,
+    UnrecognizedPanel,
+}
+
+/// 一个站这一轮探针的结论。`detail` 是逐候选摘要（`probe_batch_summary` 形状），
+/// 只含状态/类型/字节数，不含正文——可安全进日志与本地缓存。
+#[derive(Debug, Clone)]
+pub struct ProbeOutcome {
+    pub verdict: ProbeVerdict,
+    pub backend: Option<BackendKind>,
+    pub detail: String,
+    pub probed_at: i64,
+}
+
+/// 探一个站（原生路径，无浏览器兜底）并三分类。
+pub async fn probe_origin(site_origin: &str) -> ProbeOutcome {
+    let responses = match discovery::probe_candidates(site_origin).await {
+        Ok(responses) => responses,
+        Err(error) => {
+            // 连 HTTP 客户端都建不起来 —— 环境问题，不是站点的问题。
+            return ProbeOutcome {
+                verdict: ProbeVerdict::NetworkBlocked,
+                backend: None,
+                detail: format!("client: {error}"),
+                probed_at: now_ts(),
+            };
+        }
+    };
+    classify_probe_responses(&responses)
+}
+
+/// 三分类的纯函数核心（不打网络）—— 测试直接喂 [`ProbeResponse`]。
+pub(crate) fn classify_probe_responses(responses: &[ProbeResponse]) -> ProbeOutcome {
+    let detail = discovery::probe_batch_summary(responses);
+    let at = now_ts();
+    match discovery::converge_probe_responses(responses) {
+        Ok(detected) => ProbeOutcome {
+            verdict: ProbeVerdict::Supported,
+            backend: Some(detected.backend_kind),
+            detail,
+            probed_at: at,
+        },
+        Err(error) if error.kind == discovery::DiscoveryErrorKind::ProtocolConflict => {
+            // 站点同时回两种协议 —— 站方配置坏了，归「站点侧认不出」而不是环境。
+            ProbeOutcome {
+                verdict: ProbeVerdict::UnrecognizedPanel,
+                backend: None,
+                detail: format!("{}; {detail}", error.message),
+                probed_at: at,
+            }
+        }
+        Err(_) => {
+            let responded = responses.iter().any(|response| response.status.is_some());
+            let challenge_only = responses
+                .iter()
+                .filter(|response| response.status.is_some())
+                .all(|response| {
+                    matches!(response.status, Some(403 | 429 | 503)) && !response.json_like
+                });
+            let verdict = if !responded || challenge_only {
+                ProbeVerdict::NetworkBlocked
+            } else {
+                ProbeVerdict::UnrecognizedPanel
+            };
+            ProbeOutcome {
+                verdict,
+                backend: None,
+                detail,
+                probed_at: at,
+            }
+        }
+    }
+}
+
+fn now_ts() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
+/// 探针记录：漏斗日志一行的事实来源。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProbeRecord {
+    pub host: String,
+    pub verdict: ProbeVerdict,
+    pub backend: Option<BackendKind>,
+    pub detail: String,
+    /// 摘除闸：连续第几轮 UnrecognizedPanel（其他判据清零）。
+    pub consecutive_panel_misses: u32,
+    /// 这一轮过后该站是否仍在曝光集合里。
+    pub exposed: bool,
+}
+
+/// 并发探一批站、把结果记入本地缓存，返回逐站记录（调用方拿去落漏斗日志）。
+///
+/// 失败不抛：探针是尽力而为的后台动作，单站失败本身就是一轮 NetworkBlocked
+/// 记录（会把上一轮的 miss 计数清零 —— 环境故障不该累计成「摘除」）。
+pub async fn probe_and_record(origins: &[String]) -> Vec<ProbeRecord> {
+    use futures::StreamExt;
+
+    let outcomes = futures::stream::iter(origins.to_vec())
+        .map(|origin| async move {
+            let outcome = probe_origin(&origin).await;
+            (origin, outcome)
+        })
+        .buffer_unordered(PROBE_CONCURRENCY)
+        .collect::<Vec<_>>()
+        .await;
+
+    let mut store = SiteProbeStore::load();
+    let records = outcomes
+        .into_iter()
+        .map(|(origin, outcome)| {
+            // 名单给的是 origin（含 scheme）；缓存键与曝光闸统一用 host。
+            let host = host_of(&origin);
+            let entry = store.record(&host, &outcome);
+            ProbeRecord {
+                host,
+                verdict: outcome.verdict,
+                backend: outcome.backend,
+                detail: outcome.detail,
+                consecutive_panel_misses: entry.consecutive_panel_misses,
+                exposed: entry.exposed(),
+            }
+        })
+        .collect();
+    if let Err(error) = store.save() {
+        log::warn!("探针结果落盘失败（曝光闸继续用上一份缓存）: {error}");
+    }
+    records
+}
+
+fn host_of(origin: &str) -> String {
+    url::Url::parse(origin)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_owned))
+        .unwrap_or_else(|| origin.trim().to_owned())
+}
+
+/// 每站的最近一次探针结论 + 连续摘除计数。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SiteProbeEntry {
+    pub verdict: ProbeVerdict,
+    pub backend: Option<BackendKind>,
+    pub detail: String,
+    pub probed_at: i64,
+    #[serde(default)]
+    pub consecutive_panel_misses: u32,
+}
+
+impl SiteProbeEntry {
+    /// 摘除闸：只有「连续多轮认定不兼容面板」才摘；没探过 / 网络失败 / 识别成功都曝光。
+    fn exposed(&self) -> bool {
+        !(self.verdict == ProbeVerdict::UnrecognizedPanel
+            && self.consecutive_panel_misses >= HIDE_AFTER_CONSECUTIVE_PANEL_MISSES)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SiteProbeStore {
+    pub schema_version: u8,
+    pub entries: BTreeMap<String, SiteProbeEntry>,
+}
+
+impl Default for SiteProbeStore {
+    fn default() -> Self {
+        Self {
+            schema_version: 1,
+            entries: BTreeMap::new(),
+        }
+    }
+}
+
+impl SiteProbeStore {
+    pub fn load() -> Self {
+        Self::load_from(&store_path()).unwrap_or_default()
+    }
+
+    fn load_from(path: &std::path::Path) -> Option<Self> {
+        let bytes = std::fs::read(path).ok()?;
+        match serde_json::from_slice::<SiteProbeStore>(&bytes) {
+            Ok(store) if store.schema_version == 1 => Some(store),
+            Ok(_) => {
+                log::warn!("探针缓存 schema 不认识，按空处理");
+                None
+            }
+            Err(error) => {
+                log::warn!("探针缓存损坏，按空处理: {error}");
+                None
+            }
+        }
+    }
+
+    fn save_to(&self, path: &std::path::Path) -> Result<(), crate::error::AppError> {
+        let bytes = serde_json::to_vec(self)
+            .map_err(|source| crate::error::AppError::JsonSerialize { source })?;
+        crate::config::atomic_write(path, &bytes)
+    }
+
+    pub fn save(&self) -> Result<(), crate::error::AppError> {
+        self.save_to(&store_path())
+    }
+
+    /// 记一轮结果并返回更新后的条目（计数规则见 [`SiteProbeEntry::exposed`]）。
+    pub fn record(&mut self, host: &str, outcome: &ProbeOutcome) -> SiteProbeEntry {
+        let previous = self.entries.get(host);
+        let consecutive_panel_misses = match outcome.verdict {
+            ProbeVerdict::UnrecognizedPanel => previous
+                .map(|entry| entry.consecutive_panel_misses.saturating_add(1))
+                .unwrap_or(1),
+            // 识别成功 / 网络失败都清零：网络故障不该累计成「摘除」。
+            ProbeVerdict::Supported | ProbeVerdict::NetworkBlocked => 0,
+        };
+        let entry = SiteProbeEntry {
+            verdict: outcome.verdict,
+            backend: outcome.backend,
+            detail: outcome.detail.clone(),
+            probed_at: outcome.probed_at,
+            consecutive_panel_misses,
+        };
+        self.entries.insert(host.to_owned(), entry.clone());
+        entry
+    }
+
+    /// 曝光闸。没探过的站**不摘** —— 探针 5 秒后首轮就会补上，先到先展示。
+    pub fn should_expose(&self, host: &str) -> bool {
+        self.entries
+            .get(host)
+            .map(SiteProbeEntry::exposed)
+            .unwrap_or(true)
+    }
+}
+
+fn store_path() -> std::path::PathBuf {
+    crate::config::get_home_dir()
+        .join(crate::config::APP_DIR_NAME)
+        .join("site-probes.json")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn newapi_body() -> String {
+        r#"{"success":true,"message":"","data":{"version":"1.2.3","system_name":"New API","theme":"default","register_enabled":true,"password_login_enabled":true}}"#.into()
+    }
+
+    fn sub2api_body() -> String {
+        r#"{"code":0,"message":"success","data":{"site_name":"Best","version":"1.0.0","api_base_url":"","registration_enabled":true,"promo_code_enabled":false,"invitation_code_enabled":false}}"#.into()
+    }
+
+    fn response(candidate: &str, body: &str, status: Option<u16>) -> ProbeResponse {
+        let trimmed = body.trim();
+        ProbeResponse {
+            candidate_id: candidate.into(),
+            body: body.to_owned(),
+            status,
+            content_type: Some("application/json".into()),
+            body_bytes: body.len(),
+            detector_body_bytes: body.len(),
+            json_like: trimmed.starts_with('{') || trimmed.starts_with('['),
+            error_kind: None,
+        }
+    }
+
+    fn failed(candidate: &str, error_kind: &str) -> ProbeResponse {
+        ProbeResponse {
+            candidate_id: candidate.into(),
+            error_kind: Some(error_kind.into()),
+            ..ProbeResponse::default()
+        }
+    }
+
+    #[test]
+    fn recognized_backend_is_supported() {
+        let outcome = classify_probe_responses(&[response("newapi", &newapi_body(), Some(200))]);
+        assert_eq!(outcome.verdict, ProbeVerdict::Supported);
+        assert_eq!(outcome.backend, Some(BackendKind::NewApi));
+    }
+
+    #[test]
+    fn answered_but_unrecognized_is_a_panel_miss() {
+        // 双端点 404：站点活着但不是我们认识的面板（koozhan 实测形态）。
+        let responses = [
+            response("sub2api", "", Some(404)),
+            response("newapi", "", Some(404)),
+        ];
+        assert_eq!(
+            classify_probe_responses(&responses).verdict,
+            ProbeVerdict::UnrecognizedPanel
+        );
+    }
+
+    #[test]
+    fn protocol_conflict_counts_against_the_site_not_the_network() {
+        // 同站同时回两种协议 —— 站方配置坏了（weekly-day 类之外的另一种「认不出」）。
+        let responses = [
+            response("sub2api", &sub2api_body(), Some(200)),
+            response("newapi", &newapi_body(), Some(200)),
+        ];
+        assert_eq!(
+            classify_probe_responses(&responses).verdict,
+            ProbeVerdict::UnrecognizedPanel
+        );
+    }
+
+    #[test]
+    fn no_http_exchange_at_all_is_network_blocked() {
+        let responses = [
+            failed("sub2api", "ConnectError"),
+            failed("newapi", "Timeout"),
+        ];
+        assert_eq!(
+            classify_probe_responses(&responses).verdict,
+            ProbeVerdict::NetworkBlocked
+        );
+    }
+
+    #[test]
+    fn challenge_shaped_responses_are_network_blocked() {
+        // 403 + 非 JSON = Cloudflare 托管挑战页 —— 环境拦的，浏览器路径可能仍能过。
+        let challenge = ProbeResponse {
+            candidate_id: "newapi".into(),
+            status: Some(403),
+            content_type: Some("text/html".into()),
+            body_bytes: 4040,
+            json_like: false,
+            ..ProbeResponse::default()
+        };
+        assert_eq!(
+            classify_probe_responses(&[challenge]).verdict,
+            ProbeVerdict::NetworkBlocked
+        );
+    }
+
+    #[test]
+    fn mixed_404_and_network_error_still_counts_as_answered() {
+        // 只要有一个端点答了话（404 也是答话），就不是纯环境问题。
+        let responses = [
+            response("sub2api", "", Some(404)),
+            failed("newapi", "Timeout"),
+        ];
+        assert_eq!(
+            classify_probe_responses(&responses).verdict,
+            ProbeVerdict::UnrecognizedPanel
+        );
+    }
+
+    #[test]
+    fn consecutive_misses_gate_exposure_and_other_verdicts_reset_them() {
+        let mut store = SiteProbeStore::default();
+        let miss = ProbeOutcome {
+            verdict: ProbeVerdict::UnrecognizedPanel,
+            backend: None,
+            detail: "x".into(),
+            probed_at: 1,
+        };
+        for round in 1..=HIDE_AFTER_CONSECUTIVE_PANEL_MISSES {
+            let entry = store.record("koozhan.example", &miss);
+            assert_eq!(entry.consecutive_panel_misses, round);
+            // 只有到了阈值那一轮才摘除。
+            assert_eq!(
+                store.should_expose("koozhan.example"),
+                round < HIDE_AFTER_CONSECUTIVE_PANEL_MISSES
+            );
+        }
+
+        // 一轮网络失败就把计数清零 —— 环境故障不该累计成摘除。
+        let blocked = ProbeOutcome {
+            verdict: ProbeVerdict::NetworkBlocked,
+            backend: None,
+            detail: "x".into(),
+            probed_at: 2,
+        };
+        let entry = store.record("koozhan.example", &blocked);
+        assert_eq!(entry.consecutive_panel_misses, 0);
+        assert!(store.should_expose("koozhan.example"));
+    }
+
+    #[test]
+    fn never_probed_hosts_stay_exposed() {
+        assert!(SiteProbeStore::default().should_expose("fresh.example"));
+    }
+
+    #[test]
+    fn store_round_trips_through_disk() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("site-probes.json");
+        let mut store = SiteProbeStore::default();
+        store.record(
+            "bestapi.store",
+            &ProbeOutcome {
+                verdict: ProbeVerdict::Supported,
+                backend: Some(BackendKind::Sub2Api),
+                detail: "ok".into(),
+                probed_at: 42,
+            },
+        );
+        store.save_to(&path).expect("save");
+        let loaded = SiteProbeStore::load_from(&path).expect("load");
+        assert_eq!(
+            loaded.entries.get("bestapi.store").map(|e| e.verdict),
+            Some(ProbeVerdict::Supported)
+        );
+        assert!(loaded.should_expose("bestapi.store"));
+    }
+}


### PR DESCRIPTION
## 动机

广场曝光目前只看白名单（策展），不看站点当下通不通——白名单里的站面板坏了/被网络拦了，用户点「接入」才失败，而且没有留下任何「为什么」的痕迹（上一轮排查「很多站点无法识别」时翻日志翻不到过滤明细）。

## 方案

复用既有 `veridrop-directory` 定时任务（6h 一轮）：配置 + 榜单刷新之后，对受管站点跑一轮**原生协议探针**，结果落盘 `~/.loongport/site-probes.json`，广场列表过一道探针闸，每周期输出三层漏斗日志。

### 三分类：网络失败 ≠ 站点不兼容（核心裁决）

- **Supported**：严格 detector 识别出 sub2api / newapi；
- **NetworkBlocked**：连一次完整 HTTP 往返都没有，或所有响应都是挑战形态（403/429/503 且无 JSON）——原生探针过不了 Cloudflare，但导入走浏览器兜底仍可成功，**这种站不摘**；
- **UnrecognizedPanel**：站点答了话但协议认不出（404 / 形状不匹配 / 双协议冲突）——**连续 3 轮（≈18h）**才从广场摘除（防单次抖动闪进闪出）；识别成功与网络失败都清零计数。

### 解耦（为自定义站点特性线预留）

`site_probe` 模块不知道站点从哪来，只提供 `probe_origin` / `probe_and_record` / `SiteProbeStore` / 三分类；「探哪些站」的编排留在目录领域。自定义站点（另一条线在做的本地写入）以后直接调同一套 API 探针/落盘/判曝光。

`discovery` 拆出 `probe_candidates`：逐候选元数据（失败候选也记 status / error_kind），收敛与三分类共用同一份原始响应，不重打网络；`discover_site` 的 Transport/Unsupported 语义与既有测试（含超大流早断）全部保持。

### 漏斗日志（每周期三层 INFO）

- `whitelist_filter`：榜单在、白名单不在（未收录）；
- `leaderboard_missing`：白名单在、榜单没有行；
- `probe`（逐站）：verdict + 连续 miss 计数 + 是否仍曝光 + 逐候选摘要。

下次再有「这个站为什么不在广场」，翻日志逐层可答。

### 细节

- 榜单缓存存的始终是未过滤 parsed——摘除解除后无需重抓即恢复展示；
- 探针并发 4（与榜单详情抓取同量级），best-effort 不让定时任务失败；
- 没探过的站不摘（启动 5 秒后首轮探测就会补上）。

## 测试

三分类六个形态（识别/双 404/双协议冲突/全网络失败/挑战页/404+超时混合）、连续计数与清零、闸门纯函数、磁盘往返；discovery 15 项既有测试全绿（重构无语义漂移）。`cargo test --lib` 3396 过，clippy 0 告警。纯后端改动，前端零变更。