### PR TITLE
feat(ui): 手填域名合并进搜索框——搜不到就地转添加

### DIFF
--- a/src/components/relay/directory/RelayDirectoryPage.tsx
+++ b/src/components/relay/directory/RelayDirectoryPage.tsx
@@ -7,6 +7,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Loader2,
+  Plus,
   RefreshCw,
   Search,
 } from "lucide-react";
@@ -66,7 +67,6 @@ export function RelayDirectoryPage({
   const [authenticatingHost, setAuthenticatingHost] = useState<string | null>(
     null,
   );
-  const [customSite, setCustomSite] = useState("");
   const authenticationInProgress = useRef(false);
 
   const directoryQuery = useQuery({
@@ -251,6 +251,18 @@ export function RelayDirectoryPage({
             onChange={(event) =>
               dispatch({ type: "search", search: event.target.value })
             }
+            onKeyDown={(event) => {
+              // 搜不到时回车 = 把搜索词作为站点直连导入（与虚框按钮同一动作）。
+              if (
+                event.key === "Enter" &&
+                paged.items.length === 0 &&
+                view.search.trim() &&
+                !authenticationInProgress.current
+              ) {
+                const site = view.search.trim();
+                void authenticate(site, site, "manual");
+              }
+            }}
             placeholder={t("loongport.directory.searchPlaceholder")}
             className="pl-9"
           />
@@ -283,6 +295,34 @@ export function RelayDirectoryPage({
               </AlertDescription>
             </Alert>
           </div>
+        ) : paged.items.length === 0 && view.search.trim() ? (
+          // 搜不到就地转添加：白名单没有的站，搜索词就是要连的地址 —— 整块
+          // 虚框是碰撞框（与区块空态同一个交互语言），回车同效。
+          <button
+            type="button"
+            disabled={authenticatingHost !== null}
+            onClick={() => {
+              const site = view.search.trim();
+              void authenticate(site, site, "manual");
+            }}
+            className="m-4 flex w-[calc(100%-2rem)] flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-border p-6 text-sm text-muted-foreground transition-colors hover:border-blue-400/60 hover:bg-muted/40 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <span>
+              {t("loongport.directory.noMatch", {
+                query: view.search.trim(),
+              })}
+            </span>
+            <span className="inline-flex items-center gap-1.5 font-medium text-blue-600 dark:text-blue-400">
+              {authenticatingHost === view.search.trim() ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Plus className="h-3.5 w-3.5" />
+              )}
+              {t("loongport.directory.addAsSite", {
+                query: view.search.trim(),
+              })}
+            </span>
+          </button>
         ) : paged.items.length === 0 ? (
           <div className="flex h-48 flex-col items-center justify-center gap-2 text-sm text-muted-foreground">
             <span>{t("loongport.directory.empty")}</span>
@@ -337,35 +377,6 @@ export function RelayDirectoryPage({
             <ChevronRight className="h-3.5 w-3.5" />
           </Button>
         </div>
-      </div>
-
-      {/* 白名单里没有的站，用户自己填域名直连（Manual 来源，保守打开规则；
-          探针不通 / 协议不识别以可读 toast 报错）。 */}
-      <div className="flex items-center gap-2 border-t border-border-default pt-3">
-        <Input
-          value={customSite}
-          disabled={authenticatingHost !== null}
-          onChange={(event) => setCustomSite(event.target.value)}
-          placeholder={t("loongport.directory.customSitePlaceholder")}
-          onKeyDown={(event) => {
-            if (
-              event.key === "Enter" &&
-              customSite.trim() &&
-              !authenticationInProgress.current
-            ) {
-              void authenticate(customSite, customSite.trim(), "manual");
-            }
-          }}
-        />
-        <Button
-          variant="outline"
-          disabled={!customSite.trim() || authenticatingHost !== null}
-          onClick={() =>
-            void authenticate(customSite, customSite.trim(), "manual")
-          }
-        >
-          {t("loongport.directory.actions.useOtherSite")}
-        </Button>
       </div>
     </div>
   );

--- a/src/components/relay/directory/__tests__/RelayDirectoryPage.test.tsx
+++ b/src/components/relay/directory/__tests__/RelayDirectoryPage.test.tsx
@@ -284,22 +284,22 @@ describe("RelayDirectoryPage", () => {
     expect(openInBrowser).not.toHaveBeenCalledWith("https://site-2.example");
   });
 
-  it("imports a manually entered site outside the whitelist", async () => {
+  it("adds the unmatched search text as a site via the manual import", async () => {
     const user = userEvent.setup();
     renderDirectory({ sourceAppId: "codex", onBack: () => {} });
     await waitFor(() => expect(listDirectory).toHaveBeenCalled());
 
     await user.type(
-      screen.getByPlaceholderText("loongport.directory.customSitePlaceholder"),
+      screen.getByPlaceholderText("loongport.directory.searchPlaceholder"),
       "https://my-own-relay.example",
     );
     await user.click(
-      screen.getByRole("button", {
-        name: "loongport.directory.actions.useOtherSite",
+      await screen.findByRole("button", {
+        name: /loongport.directory.addAsSite/,
       }),
     );
 
-    // 手填域名走 Manual 导入（保守打开规则），不是白名单行的目录导入。
+    // 搜索词直连走 Manual 导入（保守打开规则），不是白名单行的目录导入。
     await waitFor(() =>
       expect(importSite).toHaveBeenCalledWith("https://my-own-relay.example"),
     );
@@ -576,18 +576,33 @@ describe("RelayDirectoryPage", () => {
     });
   });
 
-  it("keeps the custom-site input alongside the whitelist rows", async () => {
-    // 白名单仍是展示集合的所有者；手填域名是绕开它的兜底直连（2026-08-16 应
-    // 用户要求恢复 —— 白名单外的站也该能连，错误以可读 toast 呈现）。
+  it("offers the search text as a manual add only when nothing matches", async () => {
+    // 手填域名合并进搜索框：搜不到 → 列表区变成「把搜索词添加为中转站」的
+    // 整块虚框（白名单外的站也该能连，错误以可读 toast 呈现）；搜得到就不出现。
+    const user = userEvent.setup();
     renderDirectory({ sourceAppId: "codex", onBack: () => {} });
     await screen.findByText("BestAPI");
 
+    // 搜到白名单行：没有转添加的兜底。
+    await user.type(
+      screen.getByPlaceholderText("loongport.directory.searchPlaceholder"),
+      "Best",
+    );
     expect(
-      screen.getByPlaceholderText("loongport.directory.customSitePlaceholder"),
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: /loongport.directory.addAsSite/ }),
+    ).not.toBeInTheDocument();
+
+    // 搜不到：兜底出现。
+    await user.clear(
+      screen.getByPlaceholderText("loongport.directory.searchPlaceholder"),
+    );
+    await user.type(
+      screen.getByPlaceholderText("loongport.directory.searchPlaceholder"),
+      "my-own-relay.example",
+    );
     expect(
-      screen.getByRole("button", {
-        name: "loongport.directory.actions.useOtherSite",
+      await screen.findByRole("button", {
+        name: /loongport.directory.addAsSite/,
       }),
     ).toBeInTheDocument();
     expect(importSite).not.toHaveBeenCalled();

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3134,7 +3134,6 @@
       "other": "Other"
     },
     "directory": {
-      "customSitePlaceholder": "Can't find it? Enter another relay URL",
       "title": "Relay directory",
       "description": "Choose a site using VeriDrop's public test results. It is added to LoongPort only after registration or sign-in succeeds.",
       "tabs": {
@@ -3162,7 +3161,6 @@
         "supplementalRank": "Added"
       },
       "actions": {
-        "useOtherSite": "Use another site",
         "authenticate": "Register or sign in",
         "autoAddHint": "Added automatically when complete",
         "history": "Full history",
@@ -3173,7 +3171,9 @@
         "range": "{{from}}–{{to}} / {{total}}",
         "previous": "Previous page",
         "next": "Next page"
-      }
+      },
+      "noMatch": "No relay matches “{{query}}”",
+      "addAsSite": "Add {{query}} as a relay"
     },
     "officialApi": {
       "title": "Official APIs",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3134,7 +3134,6 @@
       "other": "その他"
     },
     "directory": {
-      "customSitePlaceholder": "見つからない場合は別の中継サイト URL を入力",
       "title": "中継サイト一覧",
       "description": "VeriDrop の公開検証結果からサイトを選びます。登録またはログインに成功した場合のみ LoongPort に追加されます。",
       "tabs": {
@@ -3162,7 +3161,6 @@
         "supplementalRank": "補足"
       },
       "actions": {
-        "useOtherSite": "別のサイトを使用",
         "authenticate": "登録またはログイン",
         "autoAddHint": "完了後に自動追加",
         "history": "全履歴",
@@ -3173,7 +3171,9 @@
         "range": "{{from}}–{{to}} / {{total}}",
         "previous": "前のページ",
         "next": "次のページ"
-      }
+      },
+      "noMatch": "「{{query}}」に一致する中継サイトがありません",
+      "addAsSite": "{{query}} を中継サイトとして追加"
     },
     "officialApi": {
       "title": "公式 API",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3135,7 +3135,6 @@
       "other": "其他"
     },
     "directory": {
-      "customSitePlaceholder": "沒有找到？輸入其他中轉站網址",
       "title": "中轉站廣場",
       "description": "根據 VeriDrop 公開檢測結果選擇站點，完成註冊或登入後自動加入 LoongPort。",
       "tabs": {
@@ -3163,7 +3162,6 @@
         "supplementalRank": "補充"
       },
       "actions": {
-        "useOtherSite": "使用其他站點",
         "authenticate": "註冊或登入",
         "autoAddHint": "完成後自動加入",
         "history": "完整記錄",
@@ -3174,7 +3172,9 @@
         "range": "{{from}}–{{to}} / {{total}}",
         "previous": "上一頁",
         "next": "下一頁"
-      }
+      },
+      "noMatch": "沒有找到「{{query}}」相關的中轉站",
+      "addAsSite": "把 {{query}} 新增為中轉站"
     },
     "officialApi": {
       "title": "官方 API",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -3134,7 +3134,6 @@
       "other": "其他"
     },
     "directory": {
-      "customSitePlaceholder": "没有找到？输入其他中转站网址",
       "title": "中转站广场",
       "description": "基于 VeriDrop 公开检测结果选择站点，完成注册或登录后自动添加到 LoongPort。",
       "tabs": {
@@ -3162,7 +3161,6 @@
         "supplementalRank": "补充"
       },
       "actions": {
-        "useOtherSite": "使用其他站点",
         "authenticate": "注册或登录",
         "autoAddHint": "完成后自动添加",
         "history": "完整历史",
@@ -3173,7 +3171,9 @@
         "range": "{{from}}–{{to}} / {{total}}",
         "previous": "上一页",
         "next": "下一页"
-      }
+      },
+      "noMatch": "没有找到「{{query}}」相关的中转站",
+      "addAsSite": "把 {{query}} 添加为中转站"
     },
     "officialApi": {
       "title": "官方 API",

--- a/tests/config/loongportLocales.test.ts
+++ b/tests/config/loongportLocales.test.ts
@@ -28,7 +28,8 @@ const requiredKeys = [
   // 独立中转站广场。四个榜单、数据来源、评分证据、认证动作、缓存状态和分页
   // 都是用户直接看到的主流程文案；漏一个 locale 会直接显示 key 名。
   "directory.title",
-  "directory.customSitePlaceholder",
+  "directory.noMatch",
+  "directory.addAsSite",
   "directory.description",
   "directory.tabs.overall",
   "directory.tabs.claude",
@@ -56,7 +57,6 @@ const requiredKeys = [
   "directory.meta.samples",
   "directory.meta.latest",
   "directory.actions.authenticate",
-  "directory.actions.useOtherSite",
   "directory.actions.autoAddHint",
   "directory.actions.history",
   "directory.actions.refresh",


### PR DESCRIPTION
## 背景

用户反馈：手填域名的框可以上移合并进搜索框——「搜不到默认添加」。

## 改动

- 广场页底部的手填域名输入行删除；搜索框成为唯一入口：
  - 搜索**无结果**时，列表区变成整块虚线的「把 <搜索词> 添加为中转站」按钮（沿用区块空态的碰撞框交互），点击即走 Manual 导入直连；**回车同效**
  - 搜索**有结果**时不出现兜底，防止把白名单站名误当域名加
- Manual 导入语义不变（保守打开规则；探针不通/协议不识别可读 toast）

## 验收

- `tsc` / `format:check` ✅；全量 vitest 整轮通过（376 套件 success）
- 广场页测试改写：无结果出现兜底 / 有结果不出现 / 点击兜底走 `importSite`（非目录导入）
