### PR TITLE
fix(relay): 曝光/导入闸/探针三份清单收敛到同一受管全集

### DIFF
--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -1203,9 +1203,10 @@ pub async fn relay_import_site(
 /// 与手工输入分开成一个命令：目录策略可以声明 `/keys` 这类站点专属入口，
 /// 但调用方不能靠传一个布尔值把任意业务路径升级成受信入口。这里重新读取并验证
 /// 当前签名配置：完全匹配其中 HTTPS `entry_url` 的地址会保留 path/query/fragment；
-/// 普通榜单站点仍按手工输入的安全规则打开 origin 或协议登录页。
+/// 其余受管站点（sponsors / aff / promo —— **与广场曝光同一份名单**，见
+/// `leaderboard::managed_site_hosts`）按手工输入的安全规则打开 origin 或协议登录页。
 ///
-/// 两种拒绝（配置缓存缺失 / 站点不在目录）都报 `NotInDirectory` 而不是
+/// 两种拒绝（配置缓存缺失 / 站点不在受管名单）都报 `NotInDirectory` 而不是
 /// `UnsupportedSite`：前者的正确指引是「换手动输入框添加」，后者的指引是
 /// 「完成网页验证」——把不同指引压进同一个 kind，前端只能对一半场景说对话。
 #[tauri::command]
@@ -1284,7 +1285,9 @@ fn directory_entry_source(
     let Ok(candidate) = browser_entry_url(input) else {
         return None;
     };
-    config
+    // 第一段：签名目录条目享有专属入口（`/keys`、`/register` 这类受信 path），
+    // 完全匹配才给 `SignedDirectory`。
+    let signed = config
         .relay_directory
         .sites
         .iter()
@@ -1298,6 +1301,19 @@ fn directory_entry_source(
 
             (!host.is_empty() && browser_entry_url(host).ok()? == candidate)
                 .then_some(BrowserEntrySource::Manual)
+        });
+    if signed.is_some() {
+        return signed;
+    }
+
+    // 第二段：受管全集（sponsors / aff / promo 也算 —— **与广场曝光同一份名单**，
+    // 见 `leaderboard::managed_site_hosts` 的唯源注释）按 Manual 保守规则回落。
+    // 只认**裸 origin**：带 path 的输入不匹配，防止任意业务路径被当成受信入口。
+    // wawapi.top 实测踩出的洞就在这：aff 名单让它进了广场，第一段却拒了它的接入。
+    crate::relay::leaderboard::managed_site_hosts(config)
+        .iter()
+        .find_map(|host| {
+            (browser_entry_url(host).ok()? == candidate).then_some(BrowserEntrySource::Manual)
         })
 }
 
@@ -5480,6 +5496,52 @@ mod tests {
         );
         assert_eq!(
             directory_entry_source(&config, "https://broken.example/keys"),
+            None
+        );
+    }
+
+    /// wawapi.top 实测踩出的洞：aff / sponsor 名单里的站进了广场（曝光集合），
+    /// 导入闸却只认 relay_directory ⇒ 点「接入」被 NotInDirectory 拒。第二段回落
+    /// 补上：受管全集按 Manual 放行裸 origin；带 path / blocked / 名单外仍拒。
+    #[test]
+    fn directory_entry_source_falls_back_to_the_full_managed_set() {
+        let config = crate::relay::remote_config::RemoteConfig {
+            relay_directory: crate::relay::remote_config::RelayDirectoryPolicy {
+                blocked_hosts: vec!["blocked.example".into()],
+                sites: std::collections::BTreeMap::new(),
+            },
+            sponsors: vec![crate::relay::remote_config::Sponsor {
+                site_origin: "https://www.WawAPII.com".into(),
+                display_name: "WawAPI".into(),
+                tagline: String::new(),
+            }],
+            aff_codes: std::collections::BTreeMap::from([
+                ("wawapi.top".to_string(), "AFF".to_string()),
+                ("blocked.example".to_string(), "AFF".to_string()),
+            ]),
+            ..crate::relay::remote_config::RemoteConfig::default()
+        };
+
+        assert_eq!(
+            directory_entry_source(&config, "https://wawapi.top"),
+            Some(BrowserEntrySource::Manual)
+        );
+        // sponsor 的 www / 大小写变体归一后也要命中
+        assert_eq!(
+            directory_entry_source(&config, "https://wawapii.com"),
+            Some(BrowserEntrySource::Manual)
+        );
+        // Manual 回落只认裸 origin —— 带 path 的输入不给受信处理
+        assert_eq!(
+            directory_entry_source(&config, "https://wawapi.top/register"),
+            None
+        );
+        assert_eq!(
+            directory_entry_source(&config, "https://blocked.example"),
+            None
+        );
+        assert_eq!(
+            directory_entry_source(&config, "https://unknown.example"),
             None
         );
     }

--- a/src-tauri/src/relay/leaderboard.rs
+++ b/src-tauri/src/relay/leaderboard.rs
@@ -576,14 +576,36 @@ fn managed_veridrop_hosts(config: &RemoteConfig) -> Vec<String> {
         .collect()
 }
 
-/// 受管站点（去 blocked）的**本站 host** 清单 —— 这些是真实可导入的 origin，
-/// 探针名单用这份（`managed_veridrop_hosts` 是 veridrop 空间的别名，探它没意义）。
+/// 受管站点的**真实 origin** host 全集（sponsors ∪ aff_codes ∪ promo_codes ∪
+/// relay_directory，统一归一后去 blocked）。
+///
+/// ⭐ 三份清单的**唯一源**（wawapi.top 实测踩出的洞：aff 名单里的站进了广场，
+/// 导入闸却只认 relay_directory ⇒ 广场显示、点接入被拒）。广场曝光
+/// （`managed_veridrop_hosts` 是这份在 veridrop 空间的别名视图）、目录导入闸的
+/// 回落匹配（`commands::relay::directory_entry_source`）、探针名单
+/// （`refresh_site_probes_for_directory`）全部从这份派生 —— 任何一份单独收窄，
+/// 就会重现「广场显示但点不进 / 探针名单漏探」，三处必须同宽。
 pub(crate) fn managed_site_hosts(config: &RemoteConfig) -> Vec<String> {
     let policy = normalized_policy(&config.relay_directory);
     let blocked: BTreeSet<_> = policy.blocked_hosts.iter().cloned().collect();
-    policy
-        .sites
-        .into_keys()
+    let mut hosts: BTreeSet<String> = policy.sites.into_keys().collect();
+    for sponsor in &config.sponsors {
+        hosts.insert(crate::relay::aff::lookup_host(&sponsor.site_origin));
+    }
+    hosts.extend(
+        config
+            .aff_codes
+            .keys()
+            .map(|host| crate::relay::aff::lookup_host(host)),
+    );
+    hosts.extend(
+        config
+            .promo_codes
+            .keys()
+            .map(|host| crate::relay::aff::lookup_host(host)),
+    );
+    hosts
+        .into_iter()
         .filter(|host| !host.is_empty() && !blocked.contains(host))
         .collect()
 }
@@ -1935,5 +1957,43 @@ mod tests {
         assert!(!remaining.contains(&"koozhan.example".to_owned()));
         assert!(remaining.contains(&"cf-blocked.example".to_owned()));
         assert!(remaining.contains(&"fresh.example".to_owned()));
+    }
+
+    /// 三份清单的唯一源：sponsors / aff / promo / directory **全部**要进这份名单，
+    /// 统一归一（www、大小写）并去 blocked。**会红的改法**：把任何一类从并集里
+    /// 拿掉 —— 那正是 wawapi.top 式的洞（aff 名单进了广场，探针/导入闸却漏了它）。
+    #[test]
+    fn managed_site_hosts_spans_sponsors_aff_promo_and_directory() {
+        let config = RemoteConfig {
+            relay_directory: RelayDirectoryPolicy {
+                blocked_hosts: vec!["blocked.example".into()],
+                sites: BTreeMap::from([(
+                    "bestapi.store".into(),
+                    crate::relay::remote_config::RelayDirectorySite::default(),
+                )]),
+            },
+            sponsors: vec![crate::relay::remote_config::Sponsor {
+                site_origin: "https://www.WawAPII.com".into(),
+                display_name: "WawAPI".into(),
+                tagline: String::new(),
+            }],
+            aff_codes: BTreeMap::from([("wawapi.top".to_string(), "AFF".into())]),
+            promo_codes: BTreeMap::from([("promo.example".to_string(), "PROMO".into())]),
+            ..RemoteConfig::default()
+        };
+
+        let hosts = managed_site_hosts(&config);
+        for expected in [
+            "bestapi.store",
+            "wawapii.com",
+            "wawapi.top",
+            "promo.example",
+        ] {
+            assert!(
+                hosts.contains(&expected.to_string()),
+                "受管全集缺 {expected}：{hosts:?}"
+            );
+        }
+        assert!(!hosts.contains(&"blocked.example".to_string()));
     }
 }


### PR DESCRIPTION
## 洞（wawapi.top 实测）

三份清单各自为政：

| 清单 | 判据 | wawapi.top（在 aff_codes） |
|---|---|---|
| 广场曝光 | sponsors ∪ aff ∪ promo ∪ directory（`managed_veridrop_hosts`） | ✅ 进列表 |
| #157 探针名单 | 仅 `relay_directory.sites` 12 家 | ❌ 从未探过（没探过=不摘） |
| 导入闸 `directory_entry_source` | 仅 `relay_directory.sites` entry | ❌ 点「接入」被 NotInDirectory 拒 |

探针名单 ⊂ 曝光名单 ⇒ aff 站永远堵不住；导入闸再窄一截 ⇒ 广场显示但点不进。这正是「探针失败的站还能出现在推荐列表、点注册/登录又报错」的根因。

## 修法：唯源收敛

`managed_site_hosts` 扩成**受管真实 origin 全集**（sponsors ∪ aff_codes ∪ promo_codes ∪ relay_directory，统一 `lookup_host` 归一、去 blocked），三个消费方全部从它派生：

- **广场曝光**：`managed_veridrop_hosts` 不变（它就是这份在 veridrop 空间的别名视图）；
- **探针名单**：`refresh_site_probes_for_directory` 自动变宽——aff/sponsor 站从此进入 6h 探针与摘除闸；
- **导入闸**：`directory_entry_source` 加第二段回落——受管全集按 **Manual 保守规则放行裸 origin**（带 path 的输入不匹配，任意业务路径仍不能升级成受信入口）；`directory.sites` 条目的 `SignedDirectory` 专属入口语义不变。wawapi.top 这类站点「接入」从此直接走手动导入链路（原生探针 + 浏览器兜底）。

## 测试

- `directory_entry_source_falls_back_to_the_full_managed_set`：aff-only 站裸 origin 放行（Manual）、sponsor www/大小写归一命中、带 path 拒、blocked 拒、名单外拒；
- `managed_site_hosts_spans_sponsors_aff_promo_and_directory`：四类来源全覆盖 + 归一 + 去 blocked，任何一类从并集拿掉会红。

`cargo test --lib` 3401 全过、clippy 0 告警。纯后端。

> 注：发版前用户手上的 v3.28（13:50 tag）不含 #157/#159/#160 与本 PR——本地验证需从 main 构建。