### PR TITLE
feat(ui): 主页 tab 删自动折叠，hover × 就地隐藏应用；设置页补 codex 生图

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,12 @@ import {
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { Provider, VisibleApps } from "@/types";
 import type { EnvConflict } from "@/types/env";
-import { proxyKeys, useProvidersQuery, useSettingsQuery } from "@/lib/query";
+import {
+  proxyKeys,
+  useProvidersQuery,
+  useSaveSettingsMutation,
+  useSettingsQuery,
+} from "@/lib/query";
 import {
   providersApi,
   settingsApi,
@@ -127,6 +132,7 @@ import HermesMemoryPanel from "@/components/hermes/HermesMemoryPanel";
 import {
   APP_IDS,
   DEFAULT_VISIBLE_APPS,
+  getAppDisplayName,
   isProxyAppId,
 } from "@/config/appConfig";
 
@@ -227,6 +233,7 @@ function App() {
   }, [currentView]);
 
   const { data: settingsData } = useSettingsQuery();
+  const saveSettingsMutation = useSaveSettingsMutation();
   const useAppWindowControls =
     isLinux() && (settingsData?.useAppWindowControls ?? false);
   const dragBarHeight = useAppWindowControls ? 32 : DEFAULT_DRAG_BAR_HEIGHT;
@@ -248,6 +255,27 @@ function App() {
       setActiveApp(getFirstVisibleApp());
     }
   }, [visibleApps, activeApp]);
+
+  // tab 上的 ×：与设置页「主页面显示」同一开关，就地隐藏一个应用。
+  // 发送与 DEFAULT_VISIBLE_APPS 合并后的完整对象（后端 visible_apps 是整体替换）；
+  // settings 还没加载时不动 —— 那次保存会把其余字段全部清成默认值。
+  const hideAppFromMainPage = useCallback(
+    (app: AppId) => {
+      if (!settingsData) return;
+      saveSettingsMutation.mutate(
+        { ...settingsData, visibleApps: { ...visibleApps, [app]: false } },
+        {
+          onSuccess: () =>
+            toast.info(
+              t("appSwitcher.hiddenToast", {
+                name: getAppDisplayName(app, t),
+              }),
+            ),
+        },
+      );
+    },
+    [saveSettingsMutation, settingsData, visibleApps, t],
+  );
 
   useEffect(() => {
     if (activeApp !== "codex-image") return;
@@ -1436,14 +1464,15 @@ function App() {
                   <ProfileSwitcher activeApp={activeApp} />
                 </div>
               )}
-            {/* 弹性中段：空间不足时由 AppSwitcher 自行收纳溢出应用；
-                justify-end + overflow-hidden 只裁剪 resize 瞬间的过渡帧 */}
+            {/* 弹性中段：tab 不做自动折叠，放不下时由 overflow-hidden 裁剪左侧；
+                可见集由用户显式控制（tab 上的 × 或设置页「主页面显示」） */}
             <div className="flex flex-1 min-w-0 items-center justify-end overflow-hidden py-4">
               {currentView === "providers" && (
                 <AppSwitcher
                   activeApp={activeApp}
                   onSwitch={setActiveApp}
                   visibleApps={visibleApps}
+                  onHideApp={hideAppFromMainPage}
                 />
               )}
             </div>

--- a/src/components/AppSwitcher.tsx
+++ b/src/components/AppSwitcher.tsx
@@ -1,21 +1,14 @@
-import { useLayoutEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { AppId } from "@/lib/api";
 import type { VisibleApps } from "@/types";
 import { ProviderIcon } from "@/components/ProviderIcon";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
+import { Image as ImageIcon, Monitor, Terminal, X } from "lucide-react";
 import {
-  Image as ImageIcon,
-  Monitor,
-  MoreHorizontal,
-  Terminal,
-} from "lucide-react";
-import { APP_IDS } from "@/config/appConfig";
+  APP_DISPLAY_NAME,
+  APP_IDS,
+  getAppDisplayName,
+} from "@/config/appConfig";
 import { LAST_APP_STORAGE_KEY } from "@/config/constants";
 
 const APP_BADGE_ICON: Partial<
@@ -33,6 +26,8 @@ interface AppSwitcherProps {
   activeApp: AppId;
   onSwitch: (app: AppId) => void;
   visibleApps?: VisibleApps;
+  /** tab 上的 ×：就地隐藏一个应用，与设置页「主页面显示」是同一开关 */
+  onHideApp?: (app: AppId) => void;
 }
 
 const APP_ICON_NAME: Record<AppId, string> = {
@@ -46,20 +41,6 @@ const APP_ICON_NAME: Record<AppId, string> = {
   openclaw: "openclaw",
   hermes: "hermes",
   pi: "pi",
-};
-
-const APP_DISPLAY_NAME: Record<AppId, string> = {
-  claude: "Claude Code",
-  "claude-desktop": "Claude Desktop",
-  codex: "Codex",
-  // 静态占位；用户可见文案走 component 内的 displayName()（i18n）。
-  "codex-image": "Codex Image",
-  gemini: "Gemini",
-  grokbuild: "Grok Build",
-  opencode: "OpenCode",
-  openclaw: "OpenClaw",
-  hermes: "Hermes",
-  pi: "Pi",
 };
 
 /** 应用图标 + 角标（Claude Code / Desktop 用角标区分终端与桌面） */
@@ -102,14 +83,9 @@ export function AppSwitcher({
   activeApp,
   onSwitch,
   visibleApps,
+  onHideApp,
 }: AppSwitcherProps) {
   const { t } = useTranslation();
-  const rootRef = useRef<HTMLDivElement>(null);
-  const [moreOpen, setMoreOpen] = useState(false);
-  // LoongPort seam：「生图」是功能描述，四语各有说法（apps.codex-image）；
-  // 其余都是产品名，直接用上游的静态表。
-  const displayName = (app: AppId): string =>
-    app === "codex-image" ? t("apps.codex-image") : APP_DISPLAY_NAME[app];
 
   const handleSwitch = (app: AppId) => {
     if (app === activeApp) return;
@@ -122,120 +98,58 @@ export function AppSwitcher({
     if (!visibleApps) return true;
     return visibleApps[app];
   });
-  const appCount = appsToShow.length;
-
-  const [visibleCount, setVisibleCount] = useState(appCount);
-
-  // 宽度必须取父弹性槽而非自身：自身宽度随可见数量变化，
-  // 用它做输入会形成收起→变窄→再收起的反馈循环
-  useLayoutEffect(() => {
-    const root = rootRef.current;
-    const slot = root?.parentElement;
-    if (!root || !slot) return;
-
-    const compute = () => {
-      const sample = root.querySelector("button");
-      if (!sample) return;
-      const itemWidth = sample.offsetWidth;
-      // jsdom 或未完成布局时 offsetWidth 为 0，保持全部可见
-      if (itemWidth <= 0) return;
-      const rootStyle = window.getComputedStyle(root);
-      const gap = parseFloat(rootStyle.columnGap) || 0;
-      const padding =
-        (parseFloat(rootStyle.paddingLeft) || 0) +
-        (parseFloat(rootStyle.paddingRight) || 0);
-      const available = slot.clientWidth;
-      const widthAll = padding + appCount * itemWidth + (appCount - 1) * gap;
-      if (widthAll <= available) {
-        setVisibleCount(appCount);
-        return;
-      }
-      // 「更多」按钮与应用按钮同宽（同 padding + 同尺寸图标）
-      const fit = Math.floor(
-        (available - padding - itemWidth) / (itemWidth + gap),
-      );
-      setVisibleCount(Math.max(1, Math.min(appCount - 1, fit)));
-    };
-
-    compute();
-    const observer = new ResizeObserver(compute);
-    observer.observe(slot);
-    return () => observer.disconnect();
-  }, [appCount]);
-
-  const visibleList = appsToShow.slice(0, Math.max(1, visibleCount));
-  // 激活应用被收进溢出区时，顶替最后一个可见位，保证始终可点亮
-  if (appsToShow.includes(activeApp) && !visibleList.includes(activeApp)) {
-    visibleList[visibleList.length - 1] = activeApp;
-  }
-  const overflowList = appsToShow.filter((app) => !visibleList.includes(app));
+  // 与设置页同一护栏：只剩一个可见应用时不可再隐藏，否则没有任何 tab 可点
+  const canHide = appsToShow.length > 1 && onHideApp !== undefined;
 
   return (
     <div
-      ref={rootRef}
       className="inline-flex bg-muted rounded-xl p-1 gap-1"
       style={{ WebkitAppRegion: "no-drag" } as any}
     >
-      {visibleList.map((app) => {
+      {appsToShow.map((app) => {
         const isActive = activeApp === app;
+        const name = getAppDisplayName(app, t);
         return (
-          <button
-            key={app}
-            type="button"
-            onClick={() => handleSwitch(app)}
-            title={displayName(app)}
-            aria-label={displayName(app)}
-            className={cn(
-              "group inline-flex items-center px-3 h-8 rounded-md text-sm font-medium transition-all duration-200",
-              isActive
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground hover:bg-background/50",
-            )}
-          >
-            <AppGlyph app={app} isActive={isActive} />
-          </button>
-        );
-      })}
-      {overflowList.length > 0 && (
-        <Popover open={moreOpen} onOpenChange={setMoreOpen}>
-          <PopoverTrigger asChild>
+          <div key={app} className="group relative">
             <button
               type="button"
-              title={t("appSwitcher.more")}
-              aria-label={t("appSwitcher.more")}
+              onClick={() => handleSwitch(app)}
+              title={name}
+              aria-label={name}
               className={cn(
-                "inline-flex items-center px-3 h-8 rounded-md transition-all duration-200",
-                moreOpen
+                "inline-flex items-center px-3 h-8 rounded-md text-sm font-medium transition-all duration-200",
+                isActive
                   ? "bg-background text-foreground shadow-sm"
                   : "text-muted-foreground hover:text-foreground hover:bg-background/50",
               )}
             >
-              <MoreHorizontal size={20} className="shrink-0" />
+              <AppGlyph app={app} isActive={isActive} />
             </button>
-          </PopoverTrigger>
-          <PopoverContent
-            side="bottom"
-            align="end"
-            sideOffset={6}
-            className="z-[100] w-56 p-1"
-          >
-            {overflowList.map((app) => (
+            {canHide && (
               <button
-                key={app}
                 type="button"
-                onClick={() => {
-                  setMoreOpen(false);
-                  handleSwitch(app);
+                title={t("appSwitcher.hide")}
+                aria-label={`${t("appSwitcher.hide")}: ${name}`}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onHideApp?.(app);
                 }}
-                className="group flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                className={cn(
+                  "absolute -top-1.5 -right-1 z-10 flex h-3.5 w-3.5 items-center justify-center",
+                  "rounded-full border border-border bg-background text-muted-foreground shadow-sm",
+                  "opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 hover:text-foreground",
+                )}
               >
-                <AppGlyph app={app} isActive={false} />
-                <span className="truncate">{displayName(app)}</span>
+                <X
+                  aria-hidden="true"
+                  className="h-[9px] w-[9px]"
+                  strokeWidth={2.5}
+                />
               </button>
-            ))}
-          </PopoverContent>
-        </Popover>
-      )}
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/settings/AppVisibilitySettings.tsx
+++ b/src/components/settings/AppVisibilitySettings.tsx
@@ -24,6 +24,7 @@ const APP_CONFIG: Array<{
     nameKey: "apps.claudeDesktop",
   },
   { id: "codex", icon: "openai", nameKey: "apps.codex" },
+  { id: "codex-image", icon: "openai", nameKey: "apps.codex-image" },
   { id: "gemini", icon: "gemini", nameKey: "apps.gemini" },
   { id: "grokbuild", icon: "grok", nameKey: "apps.grokbuild" },
   { id: "opencode", icon: "opencode", nameKey: "apps.opencode" },

--- a/src/config/appConfig.tsx
+++ b/src/config/appConfig.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import type { TFunction } from "i18next";
 import type { AppId } from "@/lib/api/types";
 import type { VisibleApps } from "@/types";
 import {
@@ -21,8 +22,6 @@ export const APP_IDS: AppId[] = [
   "claude-desktop",
   "codex",
   "codex-image",
-  // Pi / Grok 排在生图后面：tab 栏宽度不够时按此顺序收进「更多」，
-  // 靠前才不会被折叠隐藏
   "pi",
   "grokbuild",
   "gemini",
@@ -30,6 +29,26 @@ export const APP_IDS: AppId[] = [
   "openclaw",
   "hermes",
 ];
+
+/** tab 栏 / 提示语里展示的应用名（静态表，产品名不翻译）。 */
+export const APP_DISPLAY_NAME: Record<AppId, string> = {
+  claude: "Claude Code",
+  "claude-desktop": "Claude Desktop",
+  codex: "Codex",
+  "codex-image": "Codex Image",
+  gemini: "Gemini",
+  grokbuild: "Grok Build",
+  opencode: "OpenCode",
+  openclaw: "OpenClaw",
+  hermes: "Hermes",
+  pi: "Pi",
+};
+
+/** 应用展示名的唯一来源：「生图」是功能描述，四语各有说法（apps.codex-image）；
+ *  其余都是产品名，直接用静态表。 */
+export function getAppDisplayName(app: AppId, t: TFunction): string {
+  return app === "codex-image" ? t("apps.codex-image") : APP_DISPLAY_NAME[app];
+}
 
 export const DEFAULT_VISIBLE_APPS: VisibleApps = {
   claude: true,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -924,7 +924,6 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "more": "More",
     "pi": "Pi"
   },
   "grokBuild": {
@@ -3597,6 +3596,7 @@
     }
   },
   "appSwitcher": {
-    "more": "More apps"
+    "hide": "Hide from homepage",
+    "hiddenToast": "Hidden \"{{name}}\". Restore it under Settings → Homepage Display."
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -924,7 +924,6 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "more": "その他",
     "pi": "Pi"
   },
   "grokBuild": {
@@ -3597,6 +3596,7 @@
     }
   },
   "appSwitcher": {
-    "more": "その他のアプリ"
+    "hide": "ホームページから隠す",
+    "hiddenToast": "「{{name}}」を非表示にしました。設定 → ホームページ表示 から戻せます。"
   }
 }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -925,7 +925,6 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "more": "更多",
     "pi": "Pi"
   },
   "grokBuild": {
@@ -3598,6 +3597,7 @@
     }
   },
   "appSwitcher": {
-    "more": "更多應用程式"
+    "hide": "從主頁面隱藏",
+    "hiddenToast": "已隱藏「{{name}}」，可在 設定 → 主頁面顯示 中恢復"
   }
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -924,7 +924,6 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "more": "更多",
     "pi": "Pi"
   },
   "grokBuild": {
@@ -3597,6 +3596,7 @@
     }
   },
   "appSwitcher": {
-    "more": "更多应用"
+    "hide": "从主页面隐藏",
+    "hiddenToast": "已隐藏「{{name}}」，可在 设置 → 主页面显示 中恢复"
   }
 }

--- a/tests/components/AppSwitcher.test.tsx
+++ b/tests/components/AppSwitcher.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AppSwitcher } from "@/components/AppSwitcher";
+import { DEFAULT_VISIBLE_APPS } from "@/config/appConfig";
+import type { VisibleApps } from "@/types";
+
+const allVisible = DEFAULT_VISIBLE_APPS;
+
+/** 测试环境 i18n 资源为空，t() 回落成键名本身；× 的 title 即 "appSwitcher.hide" */
+const hideButtonSelector = "button[title='appSwitcher.hide']";
+
+describe("AppSwitcher", () => {
+  it("所有可见应用直接平铺，不再有「更多」折叠入口", () => {
+    render(
+      <AppSwitcher
+        activeApp="claude"
+        onSwitch={vi.fn()}
+        visibleApps={allVisible}
+      />,
+    );
+    // 顺序上的第一个与最后一个可见应用都在
+    expect(
+      screen.getByRole("button", { name: "Claude Code" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Pi" })).toBeInTheDocument();
+    expect(screen.queryByTitle("appSwitcher.more")).not.toBeInTheDocument();
+  });
+
+  it("点 × 隐藏对应应用，不触发切换", () => {
+    const onSwitch = vi.fn();
+    const onHideApp = vi.fn();
+    render(
+      <AppSwitcher
+        activeApp="claude"
+        onSwitch={onSwitch}
+        visibleApps={allVisible}
+        onHideApp={onHideApp}
+      />,
+    );
+    const piTab = screen.getByRole("button", { name: "Pi" });
+    const hidePi = piTab.parentElement!.querySelector(hideButtonSelector);
+    expect(hidePi, "Pi 的 tab 上应有 ×").not.toBeNull();
+    fireEvent.click(hidePi!);
+    expect(onHideApp).toHaveBeenCalledTimes(1);
+    expect(onHideApp).toHaveBeenCalledWith("pi");
+    expect(onSwitch).not.toHaveBeenCalled();
+  });
+
+  it("只剩一个可见应用时不再出 ×（与设置页同一护栏）", () => {
+    const onlyClaude: VisibleApps = {
+      claude: true,
+      "claude-desktop": false,
+      codex: false,
+      "codex-image": false,
+      gemini: false,
+      grokbuild: false,
+      opencode: false,
+      openclaw: false,
+      hermes: false,
+      pi: false,
+    };
+    const { container } = render(
+      <AppSwitcher
+        activeApp="claude"
+        onSwitch={vi.fn()}
+        visibleApps={onlyClaude}
+        onHideApp={vi.fn()}
+      />,
+    );
+    expect(container.querySelector(hideButtonSelector)).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Claude Code" }),
+    ).toBeInTheDocument();
+  });
+
+  it("未传 onHideApp 时不渲染 ×", () => {
+    const { container } = render(
+      <AppSwitcher
+        activeApp="claude"
+        onSwitch={vi.fn()}
+        visibleApps={allVisible}
+      />,
+    );
+    expect(container.querySelector(hideButtonSelector)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary / 概述

主页平台 tab 的「宽度不够自动折叠进『更多』」下掉，改为显式控制可见集：

- **删折叠**：AppSwitcher 移除 visibleCount / ResizeObserver / 「更多」弹窗，可见 app 全部平铺。设置页「主页面显示」成为控制可见集的唯一机制。
- **hover × 就地隐藏**：鼠标移到任一 tab 上，右上角出现小 ×；点击即从主页面隐藏该应用（写的是同一份 `visibleApps`），隐藏后 toast 提示恢复入口（设置 → 主页面显示）。只剩一个可见应用时不出 ×，与设置页同一护栏；隐藏当前应用时自动切到首个可见应用（App.tsx 原有效应）。
- **设置页补 codex 生图**：「主页面显示」的应用清单此前漏了 codex-image——tab 能显示却没法在设置里隐藏/找回，现补在 Codex 旁边。
- 应用展示名（含 codex-image 四语特例）收拢到 `appConfig.getAppDisplayName` 单一来源，tab 与 toast 共用；顺手清掉遗留无引用的 `apps.more` / `appSwitcher.more` i18n 键。

纯前端改动，无 Rust 变更。

## Related Issue / 关联 Issue

Fixes #

## Screenshots / 截图

无（交互微调，可装 debug 包人工过一遍：hover 出 ×、点击隐藏、设置页恢复、单 app 时无 ×）。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
