### PR TITLE
chore: release v6.0.0（版本序列切换，跳过 4/5）

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-switch",
-  "version": "3.30.0",
+  "version": "6.0.0",
   "description": "All-in-One Assistant for Claude Code, Codex & Gemini CLI",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "cc-switch"
-version = "3.30.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # （裁决见 CLAUDE.md「三点五」）。面向用户的二进制名走 tauri.conf.json 的
 # `mainBinaryName`（已是 `LoongPort`）。
 name = "cc-switch"
-version = "3.30.0"
+version = "6.0.0"
 description = "同样的 Codex，成本省 95% 以上 —— 填一个域名、登录一次，其余自动配好"
 authors = ["SailingLoong", "Jason Young"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LoongPort",
   "mainBinaryName": "LoongPort",
-  "version": "3.30.0",
+  "version": "6.0.0",
   "identifier": "dev.loongport.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## 版本序列切换：v3.30.0 → v6.0.0

自本版起 LoongPort 启用独立版本序列，不再沿用 cc-switch 的 3.x 编号。

- **为什么跳过 4/5**：与上游编号空间彻底分开。上游现 v3.19.2（major 为年尺度节奏），若只切 4.0，一两年内上游进 4.x 又会同号；跳到 6.0 把撞号推到多年以后。跳过不是漏发，本产品没有遗漏的版本
- **fork 基线**：cc-switch v3.19.2。此后版本号不再携带与上游版本的对应关系，以发布说明声明为准（design 仓草稿已补切轨声明条目）
- **更新器不受影响**：6.0.0 > 3.30.0 单调递增；不回 1.0.0（更新器按 semver 判降级会断更新链）
- **版本号 4 处**：`package.json` / `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json` / `src-tauri/Cargo.lock`（`cc-switch` 条目）

## 验证

- 本地后端三件套全绿（冷编译）：`cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` / `cargo test`
- diff 恰好 4 文件各 1 行，无残留 `3.30.0`

> 打 tag 时发布说明正文从 design 仓草稿润出（含切轨声明三要素：序列独立、跳号缘由、fork 基线）。
