### PR TITLE
chore: dev 依赖不生成调试信息（防 target/debug 膨胀）

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -125,6 +125,10 @@ rquickjs = { version = "0.12", features = ["bindgen"] }
 objc2 = "0.6"
 objc2-app-kit = { version = "0.3", features = ["NSColor"] }
 
+# 依赖不生成调试信息（本 crate 仍保留），避免 target/debug 膨胀到几十 G
+[profile.dev.package."*"]
+debug = false
+
 # Optimize release binary size to help reduce AppImage footprint
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
## 背景

主仓 `src-tauri/target/debug` 累积到 80G（deps 27G + incremental 48G）。根因：dev 档位默认给**所有依赖**生成完整调试信息，且 cargo 从不回收 target 产物。

## 改动

```toml
[profile.dev.package."*"]
debug = false
```

依赖不再生成 DWARF；本 crate 调试信息保留，断点调试不受影响。release 档位不变。

## 验证

- `cargo fmt --check` 通过（无 .rs 改动，lint 面与 main 一致）
- 清空 target 后全量重编 + `cargo test` 全绿（新 profile 端到端构建验证）
- 实测：全量重编 + 完整测试后 `target/debug` 仅 5.4G（deps 3.7G + incremental 1.2G）