### PR TITLE
fix(onboarding): 首启引导不再赌远端配置缓存时序，错过可重试

### DIFF
--- a/src-tauri/src/commands/onboarding.rs
+++ b/src-tauri/src/commands/onboarding.rs
@@ -34,9 +34,13 @@ fn register_prompt_eligible(state: &AppState) -> Result<bool, crate::error::AppE
         && user_has_no_accounts(state)?)
 }
 
-/// 标志只置位一次：置位后无论弹窗结局如何（领了 / 取消 / 压根没弹成），
-/// 后续启动都不再主动弹。这是有意的不重试 —— 引导过的用户回落到广场页 +
-/// 顶栏红点（未领取时红点常亮，那是他们的「稍后再说」入口）。
+/// 标志只置位一次，且**只在确认拿到 offer、正要发事件时置位**：置位后无论
+/// 弹出去之后的结局如何（领了 / 取消 / 事件发不出去），后续启动都不再主动弹。
+/// 这是有意的不重试 —— 引导过的用户回落到广场页 + 顶栏红点（未领取时红点
+/// 常亮，那是他们的「稍后再说」入口）。
+///
+/// 反面是「压根没拿到 offer」（没网 / 活动下线 / 基线取不到，见命令体）：
+/// 那不算「引导过」，不置位，下次启动还能再试。
 fn mark_register_prompted() {
     let mut settings = crate::settings::get_settings();
     if settings.onboarding_register_prompted.is_none() {
@@ -53,7 +57,8 @@ fn mark_register_prompted() {
 /// → 基线星数取得到（star 邀约的基本盘 —— 取不到连比对都做不了，别让用户
 /// 看到一个随时兑现不了的 offer）。全过才发 [`ONBOARDING_STAR_REWARD_OFFER`]
 /// （payload 含基线），前端拿到即弹；任何一道不过都静默返回，新人引导宁可
-/// 少弹一次。
+/// 少弹一次 —— 但「没弹成」不置位一次性标志，下次启动还能再试（见
+/// [`mark_register_prompted`]）。
 ///
 /// 返回 `()`：弹不弹的判定完全在 Rust，前端不需要返回值分支（广场页总是要
 /// 落的，见 `RelaySection.reloadStatus`）。
@@ -66,11 +71,20 @@ pub async fn onboarding_prompt_star_reward(
     if !eligible {
         return Ok(());
     }
-    mark_register_prompted();
+
+    // 新装机的远端配置缓存要启动 5 秒后才由后台目录任务落盘，而这条命令
+    // 恰恰在最开始的渲染路径上被调 —— 不补这一拉，全新安装的首次引导必然
+    // 赶在空缓存上判「无活动」。幂等：与后台任务写的是同一份缓存。
+    if star_reward::effective_star_reward().is_none() {
+        crate::relay::remote_config::refresh_and_cache().await;
+    }
 
     let Some(offer) = star_reward::build_offer().await else {
+        // 拉完仍没有 offer：这次压根没弹成，不置位（否则一次网络抖动就把
+        // 引导永久吃掉），下次启动重试。
         return Ok(());
     };
+    mark_register_prompted();
     if let Err(error) = app_handle.emit(ONBOARDING_STAR_REWARD_OFFER, offer) {
         // 发不出去只是这次不弹（标志已置位，下次启动不再问）—— 命令本身
         // 不该因此失败，那会让前端把一次正常的引导当成后端故障。

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -583,12 +583,18 @@ function App() {
     null,
   );
   const [starRewardBusy, setStarRewardBusy] = useState(false);
+  // 已领取是 durable 事实（settings 持久化），事件守卫只认它 —— 不能认
+  // `starRewardActive`：后者在首启时由挂载检查按「当时缓存有没有活动」定值，
+  // 新装机缓存 5 秒后才落盘，挂载时几乎必然是 false，若拿它当守卫会把几秒
+  // 后到来的合法引导事件整个吞掉。
+  const starRewardClaimedRef = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
     Promise.all([settingsApi.get(), starRewardApi.configured()])
       .then(([settings, configured]) => {
         if (cancelled) return;
+        starRewardClaimedRef.current = settings.starRewardClaimed === true;
         setStarRewardActive(configured && settings.starRewardClaimed !== true);
       })
       .catch(() => {
@@ -600,9 +606,11 @@ function App() {
   }, []);
 
   // 新人引导的邀请事件（后端已过三道闸：资格 + 配置 + 基线）：拿到即弹。
-  // 已领取的极端情形（红点先领了、引导事件才到）直接忽略。
+  // 已领取的极端情形（红点先领了、引导事件才到）直接忽略。事件本身证明活动
+  // 在线，顺手点亮红点 —— 它到达时挂载检查可能刚在空缓存上判过 false。
   useTauriEvent<StarRewardOffer>(ONBOARDING_STAR_REWARD_OFFER, (payload) => {
-    if (starRewardActive === false) return;
+    if (starRewardClaimedRef.current) return;
+    setStarRewardActive(true);
     setStarRewardOffer(payload);
   });
 
@@ -631,6 +639,7 @@ function App() {
 
   /** 弹窗发码时刻：熄红点（持久化由弹窗自己负责）。 */
   const handleStarRewardClaimed = useCallback(() => {
+    starRewardClaimedRef.current = true;
     setStarRewardActive(false);
   }, []);
 


### PR DESCRIPTION
## 问题

真实新用户（全新安装）首次启动会遇到「双静默」：既不弹「点 Star 领注册礼」，顶栏红点也不亮。手动复现（`CC_SWITCH_TEST_HOME` 隔离环境）确认。

## 根因（两处时序错位）

**后端**：`onboarding_prompt_star_reward` 恰在首屏渲染路径被调，而远端配置缓存要启动 5 秒后才由后台目录任务（`maintenance` veridrop，`VERIDROP_STARTUP_DELAY=5s`）落盘——全新安装的首次判定必然赶在空缓存上读 `star_reward` 得 None。更糟的是 `mark_register_prompted()` 在判 offer **之前**执行，把一次时序错过变成永久错过：标志已置位，此后永不主动弹。

**前端**：`App.tsx` 的事件守卫 `if (starRewardActive === false) return`，而 `starRewardActive` 是挂载时按「当时缓存有没有活动」定的——首启挂载时缓存必空 ⇒ false。即使后端几秒后把合法事件发过来，也被这个守卫吞掉。

⇒ 净效果：新用户第一次启动什么都看不到；第二次启动起只剩红点（若已错过弹窗）。

## 修法

- **后端 `commands/onboarding.rs`**：
  - 缓存缺 `star_reward` 时按需 `refresh_and_cache().await`（幂等：与后台任务写同一份缓存），判据不再赌后台任务的时序；
  - `mark_register_prompted()` 后移到**确认拿到 offer 之后**——「压根没弹成」（没网 / 活动下线 / 基线取不到）不算「引导过」，不置位，下次启动可重试。「弹出去之后的结局不重试」的原语义保留。
- **前端 `App.tsx`**：
  - 守卫只认 durable 的 `starRewardClaimed`（ref），不再拿挂载时点的 `starRewardActive` 当守卫；
  - 引导事件到达即 `setStarRewardActive(true)`——事件本身证明活动在线，首启会话内红点当场点亮。

首启形状不变：新人照旧自动落到中转站广场（`onOpenAddHub("directory")`），`StarRewardDialog` 为 Radix portal 顶层弹窗，天然盖在广场之上。

## 验证

- 六道闸全绿：`cargo fmt --check` / `clippy --all-targets -D warnings` / `cargo test`（3405+ 全过）/ `tsc --noEmit` / `pnpm format:check` / `vitest run`（175 文件全过）。
- 未新增测试的理由：命令层被网络 + ed25519 签名边界包住（测试无私钥造不出含 `star_reward` 的合法缓存），`commands/onboarding.rs` 本就是无测试薄层；行为回归靠下面的手动配方兜底。
- 手动复现配方（合并后用新测试包验）：
  1. 退出运行中的 LoongPort（single-instance 共享 `/tmp/dev.loongport.desktop.sock`）；
  2. `rm -rf /tmp/loongport-fresh && mkdir -p /tmp/loongport-fresh`；
  3. `CC_SWITCH_TEST_HOME=/tmp/loongport-fresh <LoongPort.app>/Contents/MacOS/LoongPort`；
  4. 预期：自动落中转站广场，数秒内 StarRewardDialog 顶层弹出、红点点亮——**单次启动即完整引导**，不再需要旧配方里的「首启暖缓存 + 删 settings.json 重启」两步。