### PR TITLE
fix(onboarding): star 基线取数超时按国内实测校准 4s→10s

### DIFF
--- a/src-tauri/src/commands/onboarding.rs
+++ b/src-tauri/src/commands/onboarding.rs
@@ -82,6 +82,7 @@ pub async fn onboarding_prompt_star_reward(
     let Some(offer) = star_reward::build_offer().await else {
         // 拉完仍没有 offer：这次压根没弹成，不置位（否则一次网络抖动就把
         // 引导永久吃掉），下次启动重试。
+        log::info!("新人引导邀请未发出（无 offer：没网 / 活动下线 / 基线取不到），下次启动重试");
         return Ok(());
     };
     mark_register_prompted();

--- a/src-tauri/src/commands/star_reward.rs
+++ b/src-tauri/src/commands/star_reward.rs
@@ -44,15 +44,16 @@ pub(crate) fn effective_star_reward() -> Option<crate::relay::remote_config::Sta
         .filter(|reward| !reward.promo_code.trim().is_empty())
 }
 
-/// 取当前 star 数。4s 超时、失败重试一次 —— 弹窗闸门与「我已点赞」校验共用：
-/// 两次机会足够区分「抖了一下」和「这个网络到不了 GitHub」，再多重试只是
-/// 让用户干等。
+/// 取当前 star 数。10s 超时、失败重试一次 —— 弹窗闸门与「我已点赞」校验共用。
+/// 10s 是被实测校准的：国内直连 api.github.com 常态就要 5s+（2026-08-16 本机
+/// 实测 5.2s，4s 超时把「慢但通」误判成「到不了」，新人引导弹窗整条被掐）。
+/// 真到不了的网络两次也在 20s 内收敛，闸门跑在后台，不拖任何人干等。
 async fn fetch_star_count() -> Result<u64, String> {
     let url = format!("https://api.github.com/repos/{}", repo_api_slug());
     let mut last_error = String::new();
     for _ in 0..2 {
         let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(4))
+            .timeout(std::time::Duration::from_secs(10))
             .build()
             .map_err(|error| error.to_string())?;
         match client


### PR DESCRIPTION
## 背景

#173 修完首启时序竞态后，真机复测（`CC_SWITCH_TEST_HOME` 全新环境）弹窗仍不出现。逐闸排查：

- 标志未置位（`onboardingRegisterPrompted: None`）⇒ #173 的重试语义在正常工作，是 `build_offer` 返回 None；
- 远端配置缓存已落盘（config 闸过了，`FETCH_TIMEOUT_SECS=8`）；
- 本机 curl 实测：`api.github.com` **200 但要 5.2s**，而 `fetch_star_count` 超时 **4s** ×2 次 ⇒ 必超时。

## 修法

- `fetch_star_count` 超时 4s→10s，按目标用户（国内直连）网络画像校准；真不通的网络两次也在 20s 内收敛，闸门在后台跑，不挡新人落广场。
- onboarding 邀请未发出时补一行 `log::info`（今晚这个静默失败没有任何日志线索，全靠网络侧复测反推）。

## 验证

- 后端三件套绿：fmt / clippy `-D warnings` / cargo test 全过。
- 真机：重打包后全新环境单次启动，`onboardingRegisterPrompted` 置位 = offer 发出（详见后续评论）。

后续可选项（另议，本 PR 不做）：GitHub 完全不可达的网络里弹窗仍出不来——把 `baseline_stars` 改 `Option`（比对退化到「网络波动照发」路径）可以让引导不依赖 GitHub 连通性，但那是 #136 定的三道闸设计变更，留给维护者拍板。