### PR TITLE
fix(settings): 后端专有字段不接受前端全量保存覆盖（丢失更新收口）

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -48,6 +48,25 @@ fn merge_settings_for_save(
     // 开关）后、前端 query 缓存刷新前的一次全量保存会把旧 marker 重放回来，
     // 重新开启时被"复活"的标记挡住而漏迁。
     incoming.local_migrations = existing.local_migrations.clone();
+
+    // 后端专有字段（2026-08-16 收口，与 local_migrations 同一个丢失更新理由）：
+    // 切换链路在后端写 current_provider_*（`settings::set_current_provider`），
+    // 新人引导写 `onboarding_register_prompted`，Star 领取走窄命令
+    // `star_reward_mark_claimed` 写 `star_reward_claimed`。前端全量保存的快照
+    // 取自某个过去时刻，透传它们 = 把并发写入整体抹掉（当晚实测 mark 与
+    // claimed 先后被旧快照抹除；"当前在用"指针被抹会让整片供应商失去选中态）。
+    incoming.onboarding_register_prompted = existing.onboarding_register_prompted;
+    incoming.star_reward_claimed = existing.star_reward_claimed;
+    incoming.current_provider_claude = existing.current_provider_claude.clone();
+    incoming.current_provider_claude_desktop = existing.current_provider_claude_desktop.clone();
+    incoming.current_provider_codex = existing.current_provider_codex.clone();
+    incoming.current_provider_codex_image = existing.current_provider_codex_image.clone();
+    incoming.current_provider_gemini = existing.current_provider_gemini.clone();
+    incoming.current_provider_grokbuild = existing.current_provider_grokbuild.clone();
+    incoming.current_provider_opencode = existing.current_provider_opencode.clone();
+    incoming.current_provider_openclaw = existing.current_provider_openclaw.clone();
+    incoming.current_provider_hermes = existing.current_provider_hermes.clone();
+
     incoming
 }
 
@@ -530,6 +549,38 @@ mod tests {
                 .map(|v| v.secret_access_key.as_str()),
             Some("secret")
         );
+    }
+
+    /// 契约闸（2026-08-16）：后端专有字段不允许被前端全量保存覆盖 —— 哪怕
+    /// incoming 里带着旧值/空值。旧快照回写抹掉并发写入是实测过的事故
+    /// （新人引导一次性标志、Star 领取标记同晚被抹两次）。
+    #[test]
+    fn save_settings_must_not_overwrite_backend_owned_fields() {
+        let existing = AppSettings {
+            onboarding_register_prompted: Some(true),
+            star_reward_claimed: Some(true),
+            current_provider_codex: Some("provider-1".to_string()),
+            current_provider_claude: Some("provider-2".to_string()),
+            ..AppSettings::default()
+        };
+
+        // 旧快照：后端专有字段全是 None（后端写入前的状态），但 UI 偏好是新值。
+        let incoming = AppSettings {
+            show_in_tray: false,
+            ..AppSettings::default()
+        };
+
+        let merged = merge_settings_for_save(incoming, &existing);
+
+        assert_eq!(merged.onboarding_register_prompted, Some(true));
+        assert_eq!(merged.star_reward_claimed, Some(true));
+        assert_eq!(merged.current_provider_codex.as_deref(), Some("provider-1"));
+        assert_eq!(
+            merged.current_provider_claude.as_deref(),
+            Some("provider-2")
+        );
+        // 前端自有字段照常透传 —— 保留闸只拦后端专有键。
+        assert!(!merged.show_in_tray);
     }
 
     #[test]

--- a/src-tauri/src/commands/star_reward.rs
+++ b/src-tauri/src/commands/star_reward.rs
@@ -100,6 +100,18 @@ pub async fn star_reward_offer() -> Result<Option<StarRewardOffer>, String> {
     Ok(build_offer().await)
 }
 
+/// Star 领取落点（2026-08-16 起）：后端 RMW 写 `star_reward_claimed`，幂等。
+/// 不走前端全量 save —— 这条路在 `merge_settings_for_save` 对后端专有字段
+/// 无条件取现有值（旧快照回写曾把它抹掉，红点复活、码可重领），这个字段的
+/// 事实 owner 本来就在后端。
+#[tauri::command]
+pub fn star_reward_mark_claimed() -> Result<(), String> {
+    crate::settings::mutate_settings(|settings| {
+        settings.star_reward_claimed = Some(true);
+    })
+    .map_err(|e| e.to_string())
+}
+
 /// star_reward 活动还在吗（只读缓存配置，不碰网络）。红点显隐用它 ——
 /// 每次启动都为了一颗红点去拉一次基线太浪费。
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1608,6 +1608,7 @@ pub fn run() {
             commands::onboarding_open_register_window,
             commands::star_reward_offer,
             commands::star_reward_configured,
+            commands::star_reward_mark_claimed,
             commands::github_star_count,
             commands::github_star_via_gh,
             commands::relay_check_session,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -883,7 +883,9 @@ pub fn update_settings(mut new_settings: AppSettings) -> Result<(), AppError> {
     Ok(())
 }
 
-fn mutate_settings<F>(mutator: F) -> Result<(), AppError>
+// pub(crate)：LoongPort 的窄命令（如 `star_reward_mark_claimed`）用它做后端
+// RMW 写专有字段，与上面的迁移标记写入者同一形状。
+pub(crate) fn mutate_settings<F>(mutator: F) -> Result<(), AppError>
 where
     F: FnOnce(&mut AppSettings),
 {

--- a/src/components/StarRewardDialog.tsx
+++ b/src/components/StarRewardDialog.tsx
@@ -71,10 +71,9 @@ export function StarRewardDialog({
     setPhase({ kind: "granted", via });
     void (async () => {
       try {
-        const settings = await settingsApi.get();
-        // `webdavSync` 是只读的聚合字段，save 时要摘掉（与仓里其它调用点一致）。
-        const { webdavSync: _webdavSync, ...rest } = settings;
-        await settingsApi.save({ ...rest, starRewardClaimed: true });
+        // claimed 是后端专有事实：窄命令 RMW 落库。不走全量 save —— 那条路
+        // 对后端专有字段取现有值（2026-08-16 起，旧快照回写曾把它抹掉）。
+        await starRewardApi.markClaimed();
       } catch {
         // 持久化失败可接受：码已展示给用户，最坏下次启动红点再现（荣誉制）。
       }

--- a/src/components/__tests__/StarRewardDialog.test.tsx
+++ b/src/components/__tests__/StarRewardDialog.test.tsx
@@ -5,19 +5,18 @@ import { describe, expect, it, vi } from "vitest";
 import type { StarRewardOffer } from "@/lib/api";
 import { StarRewardDialog } from "@/components/StarRewardDialog";
 
-const { starViaGh, starCount, openRegisterWindow, openExternal, get, save } =
+const { starViaGh, starCount, openRegisterWindow, openExternal, markClaimed } =
   vi.hoisted(() => ({
     starViaGh: vi.fn(),
     starCount: vi.fn(),
     openRegisterWindow: vi.fn(),
     openExternal: vi.fn(),
-    get: vi.fn(),
-    save: vi.fn(),
+    markClaimed: vi.fn(),
   }));
 
 vi.mock("@/lib/api", () => ({
-  settingsApi: { get, save, openExternal },
-  starRewardApi: { starViaGh, starCount, openRegisterWindow },
+  settingsApi: { openExternal },
+  starRewardApi: { starViaGh, starCount, openRegisterWindow, markClaimed },
 }));
 vi.mock("@/lib/clipboard", () => ({
   copyText: vi.fn().mockResolvedValue(undefined),
@@ -42,8 +41,7 @@ function renderDialog(onClaimed = vi.fn(), onClose = vi.fn()) {
 describe("StarRewardDialog", () => {
   it("确认 → gh 直点成功 → 展示优惠码、落 claimed、开注册窗", async () => {
     starViaGh.mockResolvedValue(true);
-    get.mockResolvedValue({});
-    save.mockResolvedValue(undefined);
+    markClaimed.mockResolvedValue(undefined);
     openRegisterWindow.mockResolvedValue(undefined);
     const { onClaimed } = renderDialog();
 
@@ -54,9 +52,7 @@ describe("StarRewardDialog", () => {
     });
     expect(starCount).not.toHaveBeenCalled();
     expect(openExternal).not.toHaveBeenCalled();
-    expect(save).toHaveBeenCalledWith(
-      expect.objectContaining({ starRewardClaimed: true }),
-    );
+    expect(markClaimed).toHaveBeenCalled();
     expect(openRegisterWindow).toHaveBeenCalledWith("LOONGPORT5");
     await waitFor(() => expect(onClaimed).toHaveBeenCalled());
   });
@@ -65,8 +61,7 @@ describe("StarRewardDialog", () => {
     starViaGh.mockResolvedValue(false);
     openExternal.mockResolvedValue(undefined);
     starCount.mockResolvedValue(101); // 基线 100 → +1
-    get.mockResolvedValue({});
-    save.mockResolvedValue(undefined);
+    markClaimed.mockResolvedValue(undefined);
     openRegisterWindow.mockResolvedValue(undefined);
     renderDialog();
 
@@ -89,8 +84,7 @@ describe("StarRewardDialog", () => {
     starViaGh.mockResolvedValue(false);
     openExternal.mockResolvedValue(undefined);
     starCount.mockResolvedValue(100); // 与基线相同
-    get.mockResolvedValue({});
-    save.mockResolvedValue(undefined);
+    markClaimed.mockResolvedValue(undefined);
     openRegisterWindow.mockResolvedValue(undefined);
     renderDialog();
 
@@ -110,6 +104,6 @@ describe("StarRewardDialog", () => {
     expect(onClose).toHaveBeenCalled();
     expect(starViaGh).not.toHaveBeenCalled();
     expect(openRegisterWindow).not.toHaveBeenCalled();
-    expect(save).not.toHaveBeenCalled();
+    expect(markClaimed).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/api/starReward.ts
+++ b/src/lib/api/starReward.ts
@@ -38,6 +38,11 @@ export const starRewardApi = {
     return await invoke("github_star_via_gh");
   },
 
+  /** 标记已领取（发码时刻调用）。后端专有事实走窄命令 RMW，不走全量 save。 */
+  async markClaimed(): Promise<void> {
+    await invoke("star_reward_mark_claimed");
+  },
+
   /** 打开官方站注册窗并预填奖励码（star 走通之后的终点）。 */
   async openRegisterWindow(promoCode: string): Promise<void> {
     await invoke("onboarding_open_register_window", { promoCode });


### PR DESCRIPTION
## 问题（2026-08-16 晚实测）

`settings.json` 全量保存存在**丢失更新**：前端多处 `save({...旧快照, 改一个键})`，快照取自挂载时刻，任何并发写入会被整体抹掉。当晚新人引导验证中，`onboarding_register_prompted`（后端 22:42 写入）与 `star_reward_claimed`（弹窗发码 23:02 写入）先后被 23:03 的一次前端保存用旧快照抹掉——文件 mtime 取证确认。

高危同款：`current_provider_*` 由切换链路后端写入，一次旧快照回写即可让整片供应商失去「当前在用」指针。

## 修法

沿上游 `merge_settings_for_save`（它已为 webdav/s3 密钥与 `local_migrations` 做同款保留——同一丢失更新类的既有接缝）：

- **保存闸**：后端专有字段无条件取进程内 store 现值，忽略前端传入——`onboarding_register_prompted`、`star_reward_claimed`、`current_provider_*`（claude/claude_desktop/codex/codex_image/gemini/grokbuild/opencode/openclaw/hermes 9 槽位）。
- **窄命令** `star_reward_mark_claimed`：后端 RMW（`mutate_settings` 提为 `pub(crate)`，上游文件仅一词接缝）；`StarRewardDialog` 发码改走它。
- **契约测试** `save_settings_must_not_overwrite_backend_owned_fields`：旧快照全 None 也抹不掉 existing 现值，前端自有字段（show_in_tray）照常透传。

**有意不进保留清单**：`stats_install_id`（前端生成，lib.rs 注释明确）、`enable_claude_plugin_integration` / `unify_codex_migrate_existing`（前后端共写，保留闸会挡掉合法的前端写入——这类共享字段的彻底解是 PATCH 语义，属后续演进，非本 PR 范围）。

## 验证

- 后端三件套绿（新契约测试过）、前端三件套绿（StarRewardDialog 测试改为断言 markClaimed，1152 过）。
- 上游接缝面：`merge_settings_for_save` 内一个保留块、`mutate_settings` 可见性一词——满足升级协议 §三「最小、可说明理由的差异」。