### PR TITLE
fix(prompt): 全量 Prompt 同步把生图栏误报成「导入后同步失败」

### DIFF
--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -468,6 +468,15 @@ impl AppType {
         )
     }
 
+    /// 该 app 是否有可托管的提示词文件（CLAUDE.md / AGENTS.md / …）。
+    ///
+    /// ClaudeDesktop 与 CodexImage 不是能读提示词文件的 CLI —— 见
+    /// [`AppType::CodexImage`] 的说明。「支不支持 Prompts」以这里为唯一判据，
+    /// 别在调用方再手写排除名单。
+    pub fn supports_prompts(&self) -> bool {
+        !matches!(self, AppType::ClaudeDesktop | AppType::CodexImage)
+    }
+
     /// Return an iterator over all app types
     pub fn all() -> impl Iterator<Item = AppType> {
         [
@@ -1353,5 +1362,28 @@ mod app_type_all_tests {
     #[test]
     fn the_codex_image_const_matches_as_str() {
         assert_eq!(AppType::CODEX_IMAGE_STR, AppType::CodexImage.as_str());
+    }
+
+    /// 「支不支持 Prompts」的唯一判据是 [`AppType::supports_prompts`]。
+    ///
+    /// 名单漏更的后果不是编译红，而是**误报**：全量 Prompt 同步
+    /// （一键导入 / 云同步恢复后置）会把生图栏报成「导入后同步失败」，
+    /// 而导入本身明明成功了。加新 app 类型时这条闸会逼着把能力判定
+    /// 补进谓词，而不是指望散落各处的手写名单记得改。
+    #[test]
+    fn supports_prompts_flags_non_cli_slots() {
+        assert!(!AppType::ClaudeDesktop.supports_prompts());
+        assert!(!AppType::CodexImage.supports_prompts());
+        // 其余（含 Pi——`sync_to_live` 对它的跳过是投影语义不同，不是能力
+        // 缺失）都是能读 CLAUDE.md / AGENTS.md / SOUL.md 的 CLI。
+        for app in AppType::all() {
+            let is_non_cli = matches!(app, AppType::ClaudeDesktop | AppType::CodexImage);
+            assert_ne!(
+                app.supports_prompts(),
+                is_non_cli,
+                "{} 的 Prompts 能力判定与名单不一致",
+                app.as_str()
+            );
+        }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1124,16 +1124,8 @@ pub fn run() {
             if app_state.db.is_prompts_table_empty().unwrap_or(false) {
                 log::info!("Prompts table empty, importing from live configurations...");
 
-                for app in [
-                    crate::app_config::AppType::Claude,
-                    crate::app_config::AppType::Codex,
-                    crate::app_config::AppType::Gemini,
-                    crate::app_config::AppType::GrokBuild,
-                    crate::app_config::AppType::OpenCode,
-                    crate::app_config::AppType::OpenClaw,
-                    crate::app_config::AppType::Hermes,
-                    crate::app_config::AppType::Pi,
-                ] {
+                for app in crate::app_config::AppType::all().filter(|app| app.supports_prompts())
+                {
                     match crate::services::prompt::PromptService::import_from_file_on_first_launch(
                         &app_state,
                         app.clone(),

--- a/src-tauri/src/prompt_files.rs
+++ b/src-tauri/src/prompt_files.rs
@@ -10,8 +10,7 @@ use crate::opencode_config::get_opencode_dir;
 
 /// 返回指定应用所使用的提示词文件路径。
 pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
-    // 生图栏与 Claude Desktop 同类：它不是一个能读 AGENTS.md 的 CLI。
-    if matches!(app, AppType::ClaudeDesktop | AppType::CodexImage) {
+    if !app.supports_prompts() {
         return Err(AppError::localized(
             "app.prompts_unsupported",
             "当前应用暂不支持 Prompts",

--- a/src-tauri/src/services/prompt.rs
+++ b/src-tauri/src/services/prompt.rs
@@ -241,9 +241,13 @@ impl PromptService {
     /// This deliberately does not call `enable_prompt`: restore paths must not
     /// read stale live content and write it back into the freshly imported DB.
     pub fn sync_to_live(state: &AppState, app: AppType) -> Result<(), AppError> {
+        // 没有提示词文件的栏位（ClaudeDesktop / 生图栏）是「不适用」而不是失败。
+        if !app.supports_prompts() {
+            return Ok(());
+        }
         // Pi derives activation from its native AGENTS.md; its persisted prompt
         // rows are intentionally disabled and must not drive generic projection.
-        if matches!(app, AppType::ClaudeDesktop | AppType::Pi) {
+        if matches!(app, AppType::Pi) {
             return Ok(());
         }
 
@@ -259,9 +263,6 @@ impl PromptService {
     pub fn sync_all_to_live(state: &AppState) -> Result<(), AppError> {
         let mut failures = Vec::new();
         for app in AppType::all() {
-            if matches!(app, AppType::ClaudeDesktop) {
-                continue;
-            }
             if let Err(error) = Self::sync_to_live(state, app.clone()) {
                 log::warn!("同步 Prompt 到 {app:?} 失败: {error}");
                 failures.push(format!("{}: {error}", app.as_str()));
@@ -520,6 +521,23 @@ mod tests {
             std::fs::read_to_string(path).expect("read prompt"),
             "restored"
         );
+    }
+
+    /// ⭐ **导入 / 云同步恢复不该把生图栏报成 Prompt 同步失败。**
+    ///
+    /// `run_post_import_sync` 走 `sync_all_to_live` 扫全部 app；生图栏没有
+    /// 提示词文件，对它是「不适用」（Ok）而不是失败 —— 否则一键导入明明成功，
+    /// 却整体误报「导入后同步失败: … codex-image: 当前应用暂不支持 Prompts」。
+    #[test]
+    fn syncing_prompts_skips_apps_without_prompt_files() {
+        let state = crate::store::AppState::new(std::sync::Arc::new(
+            crate::database::Database::memory().expect("create in-memory database"),
+        ));
+
+        super::PromptService::sync_to_live(&state, crate::app_config::AppType::CodexImage)
+            .expect("生图栏没有提示词文件，该是 Ok 而不是失败");
+        super::PromptService::sync_to_live(&state, crate::app_config::AppType::ClaudeDesktop)
+            .expect("Claude Desktop 该被跳过");
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

一键导入 cc-switch（以及文件导入 / S3 / WebDAV 恢复）明明成功，却整体误报：

> 导入后同步失败: 部分导入后同步失败: prompts: 部分应用 Prompt 同步失败: codex-image: 当前应用暂不支持 Prompts

根因是「哪些 app 不支持 Prompts」这个事实散在多处手写名单里，加 `CodexImage`
这个 app 类型时只更新了 `prompt_file_path` 的拒绝名单，没更新
`PromptService::sync_all_to_live` / `sync_to_live` 的跳过名单 —— 全量同步扫到
生图栏，把「不适用」当成了「失败」（`git log -S CodexImage` 证实 `prompt.rs`
从未同步过该名单）。

修根而不是打补丁：能力判定收成唯一谓词 `AppType::supports_prompts()`
（与既有 `is_additive_mode` / `supports_local_proxy` 同一惯例），四处名单全部
收口读它：

- `prompt_files.rs` 的拒绝分支
- `sync_to_live` 的跳过（Pi 的跳过保留原处——那是投影语义不同，不是能力缺失）
- `sync_all_to_live` 的 ClaudeDesktop `continue`（删冗余副本）
- `lib.rs` 首启自动导入的手写 app 数组（改成 `all().filter(supports_prompts)`）

两道回归闸：谓词一致性测试 + `sync_to_live` 用户路径级别测试（生图栏必须是
`Ok` 而不是失败），防下次加 app 类型再漏。

## Related Issue / 关联 Issue

Fixes #

## Screenshots / 截图

纯后端行为修复，无 UI 变化。

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查（未动前端，N/A）
- [ ] `pnpm format:check` passes / 通过代码格式检查（未动前端，N/A）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本（无文案变化，N/A）
