### PR TITLE
feat(easy-mode): 省心模式扣上默认关闭的 Beta 开关，本版不随发布暴露

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -467,6 +467,11 @@ pub struct AppSettings {
     /// 的场景，`Default` impl 负责新装机，两处必须保持一致。
     #[serde(default = "default_true")]
     pub unify_codex_session_history: bool,
+    /// 「省心模式」Beta 开关：**默认关 = 发布形态不暴露**（设置页不出 tab），
+    /// 维护者在 settings.json 手动置 true 用于自测；成熟后翻默认或删开关。
+    /// 注意默认值两处一致（serde default 与 `Default` impl），见上方说明。
+    #[serde(default)]
+    pub easy_mode_beta: bool,
     /// User opted in (via the enable dialog checkbox) to migrate existing
     /// official sessions ("openai" bucket) into the shared bucket. Persisted so
     /// a failed migration retries at startup; cleared when the toggle turns off.
@@ -628,6 +633,7 @@ impl Default for AppSettings {
             // 见字段上的说明：这条保的是 ChatGPT 桌面版的登录凭据，LoongPort 必须默认开。
             preserve_codex_official_auth_on_switch: true,
             unify_codex_session_history: true,
+            easy_mode_beta: false,
             unify_codex_migrate_existing: None,
             failover_confirmed: None,
             first_run_notice_confirmed: None,

--- a/src/components/settings/AutoModeTabContent.tsx
+++ b/src/components/settings/AutoModeTabContent.tsx
@@ -17,7 +17,7 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
-import { Sparkles, Loader2, ShieldAlert, Zap } from "lucide-react";
+import { Sparkles, Loader2 } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
@@ -37,13 +37,13 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
-import { ToggleRow } from "@/components/ui/toggle-row";
 import { FailoverQueueManager } from "@/components/proxy/FailoverQueueManager";
 import { AutoFailoverConfigPanel } from "@/components/proxy/AutoFailoverConfigPanel";
 import {
   hasConfirmedAutoMode,
   markAutoModeConfirmed,
 } from "@/components/proxy/autoModeConfirm";
+import { FailoverControls } from "@/components/settings/FailoverControls";
 import {
   useAutoModeStatus,
   useDisableAutoMode,
@@ -52,9 +52,7 @@ import {
   useSetEasyModeMaster,
   useSetAutoModeModel,
   useSetAutoModeStrategy,
-  useSetFailoverAll,
 } from "@/lib/query/autoMode";
-import { useAutoFailoverEnabled } from "@/lib/query/failover";
 import { useProxyStatus } from "@/hooks/useProxyStatus";
 import type { SettingsFormState } from "@/hooks/useSettings";
 import {
@@ -79,8 +77,6 @@ export function AutoModeTabContent({
   const { t } = useTranslation();
   const setStrategy = useSetAutoModeStrategy();
   const masterFlow = useSetEasyModeMaster();
-  const setFailoverAll = useSetFailoverAll();
-  const [showFailoverConfirm, setShowFailoverConfirm] = useState(false);
   const [showMasterConfirm, setShowMasterConfirm] = useState(false);
 
   // strategy 是全局的，任一 app 的状态里都带同一份 —— 借第一个 app 当读取锚点。
@@ -91,12 +87,6 @@ export function AutoModeTabContent({
   // 显示值就是路由服务的运行态；只有它开着，各 app 卡片才可配置（开=起路由，
   // 关=全部 app 关省心 + 恢复配置停服务，见 useSetEasyModeMaster）。
   const { isRunning } = useProxyStatus();
-
-  // 统一故障转移开关的状态：全部 app 都开 = 开。
-  const failoverStates = PROXY_APP_IDS.map(
-    (appType) => useAutoFailoverEnabled(appType).data ?? false,
-  );
-  const failoverChecked = failoverStates.every(Boolean);
 
   const handleMasterChange = (checked: boolean) => {
     if (!checked) {
@@ -115,19 +105,6 @@ export function AutoModeTabContent({
     markAutoModeConfirmed();
     setShowMasterConfirm(false);
     masterFlow.mutate({ enable: true });
-  };
-
-  const handleDisplayToggleChange = (checked: boolean) => {
-    if (checked && !settings?.failoverConfirmed) {
-      setShowFailoverConfirm(true);
-    } else {
-      void onAutoSave({ enableFailoverToggle: checked });
-    }
-  };
-
-  const handleFailoverConfirm = async () => {
-    setShowFailoverConfirm(false);
-    await onAutoSave({ failoverConfirmed: true, enableFailoverToggle: true });
   };
 
   return (
@@ -226,59 +203,9 @@ export function AutoModeTabContent({
         <AutoModeAppCard key={appType} appType={appType} />
       ))}
 
-      {/* 统一的自动故障转移开关：作用于全部 app（队列管理仍在各卡片「高级」里）。 */}
-      <div className="rounded-xl glass-card p-6">
-        <div className="flex items-center justify-between gap-4">
-          <div className="space-y-0.5">
-            <div className="flex items-center gap-2">
-              <Zap className="h-4 w-4 text-orange-500" />
-              <span className="text-sm font-medium">
-                {t("proxy.failover.autoSwitch", "自动故障转移")}
-              </span>
-            </div>
-            <p className="text-xs text-muted-foreground">
-              {t(
-                "proxy.failover.autoSwitchDescription",
-                "开启后各应用立即切换到各自队列的 P1，请求失败时自动切换队列中的下一个供应商；对所有应用统一生效",
-              )}
-            </p>
-          </div>
-          <Switch
-            checked={failoverChecked}
-            onCheckedChange={(checked) =>
-              setFailoverAll.mutate({
-                apps: [...PROXY_APP_IDS],
-                enabled: checked,
-              })
-            }
-            disabled={setFailoverAll.isPending}
-            aria-label={t("proxy.failover.autoSwitch", "自动故障转移")}
-          />
-        </div>
-      </div>
-
-      {/* 主页面故障转移开关：控制顶栏 FailoverToggle 是否显示。 */}
-      <div className="rounded-xl glass-card p-6">
-        <ToggleRow
-          icon={<ShieldAlert className="h-4 w-4 text-orange-500" />}
-          title={t("settings.advanced.proxy.enableFailoverToggle")}
-          description={t(
-            "settings.advanced.proxy.enableFailoverToggleDescription",
-          )}
-          checked={settings?.enableFailoverToggle ?? false}
-          onCheckedChange={handleDisplayToggleChange}
-        />
-      </div>
-
-      <ConfirmDialog
-        isOpen={showFailoverConfirm}
-        variant="info"
-        title={t("confirm.failover.title")}
-        message={t("confirm.failover.message")}
-        confirmText={t("confirm.failover.confirm")}
-        onConfirm={() => void handleFailoverConfirm()}
-        onCancel={() => setShowFailoverConfirm(false)}
-      />
+      {/* 故障转移控制（统一开关 + 主页面显示开关）：与「高级」tab 的发布形态
+          共用一份组件，见 FailoverControls 的文档。 */}
+      <FailoverControls settings={settings} onAutoSave={onAutoSave} />
 
       <ConfirmDialog
         isOpen={showMasterConfirm}

--- a/src/components/settings/FailoverControls.tsx
+++ b/src/components/settings/FailoverControls.tsx
@@ -1,0 +1,187 @@
+/**
+ * 故障转移控制块：统一开关（全部 app 一次生效）+ 主页面显示开关 + 首开确认。
+ *
+ * 两个宿主共用一份：
+ * - 「省心模式」tab（Beta 开关开着时）—— 省心模式下队列是兜底，控制放一起；
+ * - 「高级」tab 的「自动故障转移」折叠项（省心模式 Beta 关闭的发布形态）——
+ *   故障转移是早已发布的既有功能，省心 tab 藏起来时它必须有家，不能跟着消失。
+ * 队列管理本身：省心形态在各卡「高级」折叠里；发布形态在 FailoverAccordionItem
+ * 的 app 子标签里（见下）。
+ */
+
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Activity, Zap, ShieldAlert } from "lucide-react";
+
+import { Switch } from "@/components/ui/switch";
+import { ToggleRow } from "@/components/ui/toggle-row";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { FailoverQueueManager } from "@/components/proxy/FailoverQueueManager";
+import { AutoFailoverConfigPanel } from "@/components/proxy/AutoFailoverConfigPanel";
+import { useSetFailoverAll } from "@/lib/query/autoMode";
+import { useAutoFailoverEnabled } from "@/lib/query/failover";
+import { useProxyStatus } from "@/hooks/useProxyStatus";
+import type { SettingsFormState } from "@/hooks/useSettings";
+import { getAppLabel, PROXY_APP_IDS } from "@/config/appConfig";
+
+interface FailoverControlsProps {
+  settings: SettingsFormState;
+  onAutoSave: (updates: Partial<SettingsFormState>) => Promise<boolean | void>;
+}
+
+export function FailoverControls({
+  settings,
+  onAutoSave,
+}: FailoverControlsProps) {
+  const { t } = useTranslation();
+  const setFailoverAll = useSetFailoverAll();
+  const [showFailoverConfirm, setShowFailoverConfirm] = useState(false);
+
+  // 统一故障转移开关的状态：全部 app 都开 = 开。
+  const failoverStates = PROXY_APP_IDS.map(
+    (appType) => useAutoFailoverEnabled(appType).data ?? false,
+  );
+  const failoverChecked = failoverStates.every(Boolean);
+
+  const handleDisplayToggleChange = (checked: boolean) => {
+    if (checked && !settings?.failoverConfirmed) {
+      setShowFailoverConfirm(true);
+    } else {
+      void onAutoSave({ enableFailoverToggle: checked });
+    }
+  };
+
+  const handleFailoverConfirm = async () => {
+    setShowFailoverConfirm(false);
+    await onAutoSave({ failoverConfirmed: true, enableFailoverToggle: true });
+  };
+
+  return (
+    <>
+      {/* 统一的自动故障转移开关：作用于全部 app。 */}
+      <div className="rounded-xl glass-card p-6">
+        <div className="flex items-center justify-between gap-4">
+          <div className="space-y-0.5">
+            <div className="flex items-center gap-2">
+              <Zap className="h-4 w-4 text-orange-500" />
+              <span className="text-sm font-medium">
+                {t("proxy.failover.autoSwitch", "自动故障转移")}
+              </span>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {t(
+                "proxy.failover.autoSwitchDescription",
+                "开启后各应用立即切换到各自队列的 P1，请求失败时自动切换队列中的下一个供应商；对所有应用统一生效",
+              )}
+            </p>
+          </div>
+          <Switch
+            checked={failoverChecked}
+            onCheckedChange={(checked) =>
+              setFailoverAll.mutate({
+                apps: [...PROXY_APP_IDS],
+                enabled: checked,
+              })
+            }
+            disabled={setFailoverAll.isPending}
+            aria-label={t("proxy.failover.autoSwitch", "自动故障转移")}
+          />
+        </div>
+      </div>
+
+      {/* 主页面故障转移开关：控制顶栏 FailoverToggle 是否显示。 */}
+      <div className="rounded-xl glass-card p-6">
+        <ToggleRow
+          icon={<ShieldAlert className="h-4 w-4 text-orange-500" />}
+          title={t("settings.advanced.proxy.enableFailoverToggle")}
+          description={t(
+            "settings.advanced.proxy.enableFailoverToggleDescription",
+          )}
+          checked={settings?.enableFailoverToggle ?? false}
+          onCheckedChange={handleDisplayToggleChange}
+        />
+      </div>
+
+      <ConfirmDialog
+        isOpen={showFailoverConfirm}
+        variant="info"
+        title={t("confirm.failover.title")}
+        message={t("confirm.failover.message")}
+        confirmText={t("confirm.failover.confirm")}
+        onConfirm={() => void handleFailoverConfirm()}
+        onCancel={() => setShowFailoverConfirm(false)}
+      />
+    </>
+  );
+}
+
+/**
+ * 「高级」tab 的故障转移折叠项（发布形态）：统一开关 + 各 app 的队列/熔断管理。
+ * 省心模式 Beta 开着时不渲染 —— 那些管理收在省心模式页的卡片「高级」折叠里，
+ * 两处同时出现只会让人困惑。
+ */
+export function FailoverAccordionItem({
+  settings,
+  onAutoSave,
+}: FailoverControlsProps) {
+  const { t } = useTranslation();
+  const { isRunning, takeoverStatus } = useProxyStatus();
+
+  return (
+    <AccordionItem
+      value="failover"
+      className="rounded-xl glass-card overflow-hidden"
+    >
+      <AccordionTrigger className="px-6 py-4 hover:no-underline hover:bg-muted/50 data-[state=open]:bg-muted/50">
+        <div className="flex items-center gap-3">
+          <Activity className="h-5 w-5 text-orange-500" />
+          <div className="text-left">
+            <h3 className="text-base font-semibold">
+              {t("settings.advanced.failover.title")}
+            </h3>
+            <p className="text-sm text-muted-foreground font-normal">
+              {t("settings.advanced.failover.description")}
+            </p>
+          </div>
+        </div>
+      </AccordionTrigger>
+      <AccordionContent className="space-y-4 px-6 pb-6 pt-4 border-t border-border/50">
+        <FailoverControls settings={settings} onAutoSave={onAutoSave} />
+        <Tabs defaultValue="claude" className="w-full">
+          <TabsList className="grid w-full grid-cols-4">
+            {PROXY_APP_IDS.map((id) => (
+              <TabsTrigger key={id} value={id}>
+                {getAppLabel(id)}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+          {PROXY_APP_IDS.map((appType) => {
+            const disabled =
+              !isRunning || !(takeoverStatus?.[appType] ?? false);
+            return (
+              <TabsContent
+                key={appType}
+                value={appType}
+                className="mt-4 space-y-6"
+              >
+                <FailoverQueueManager appType={appType} disabled={disabled} />
+                <div className="border-t border-border/50 pt-6">
+                  <AutoFailoverConfigPanel
+                    appType={appType}
+                    disabled={disabled}
+                  />
+                </div>
+              </TabsContent>
+            );
+          })}
+        </Tabs>
+      </AccordionContent>
+    </AccordionItem>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -52,6 +52,7 @@ import { WebdavSyncSection } from "@/components/settings/WebdavSyncSection";
 import { AboutSection } from "@/components/settings/AboutSection";
 import { AutoModeTabContent } from "@/components/settings/AutoModeTabContent";
 import { LocalRoutingServicePanel } from "@/components/settings/LocalRoutingServicePanel";
+import { FailoverAccordionItem } from "@/components/settings/FailoverControls";
 import { RectifierConfigPanel } from "@/components/settings/RectifierConfigPanel";
 import { GlobalProxySettings } from "@/components/settings/GlobalProxySettings";
 import { Badge } from "@/components/ui/badge";
@@ -64,6 +65,7 @@ import { useInstalledSkills } from "@/hooks/useSkills";
 import { useSettings } from "@/hooks/useSettings";
 import { useImportExport } from "@/hooks/useImportExport";
 import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/utils";
 import type { SettingsFormState } from "@/hooks/useSettings";
 
 interface SettingsDialogProps {
@@ -119,12 +121,23 @@ export function SettingsPage({
   const [showRestartPrompt, setShowRestartPrompt] = useState(false);
   const tabScrollContainerRef = useRef<HTMLDivElement>(null);
 
+  // 省心模式 Beta 开关（默认关）：关 = 发布形态，设置页不出现该 tab，
+  // 故障转移管理回退到「高级」tab（既有功能不能跟着消失）。
+  const easyModeBeta = settings?.easyModeBeta ?? false;
+
   useEffect(() => {
     if (open) {
       setActiveTab(defaultTab);
       resetStatus();
     }
   }, [open, resetStatus, defaultTab]);
+
+  // Beta 关着却停在省心 tab（例如开关刚被改回）：落回通用页，别留空白 tab。
+  useEffect(() => {
+    if (!easyModeBeta && activeTab === "proxy") {
+      setActiveTab("general");
+    }
+  }, [easyModeBeta, activeTab]);
 
   useEffect(() => {
     if (requiresRestart) {
@@ -232,18 +245,27 @@ export function SettingsPage({
           onValueChange={setActiveTab}
           className="flex flex-col h-full"
         >
-          <TabsList className="grid w-full grid-cols-6 mb-6 glass rounded-lg">
+          {/* 省心模式 Beta：默认关（发布形态不暴露设置 tab，维护者在
+              settings.json 置 easyModeBeta 自测）；tab 数变化时列数跟着变。 */}
+          <TabsList
+            className={cn(
+              "grid w-full mb-6 glass rounded-lg",
+              easyModeBeta ? "grid-cols-6" : "grid-cols-5",
+            )}
+          >
             <TabsTrigger value="general">
               {t("settings.tabGeneral")}
             </TabsTrigger>
-            <TabsTrigger value="proxy">
-              <span className="inline-flex items-center gap-1.5">
-                {t("settings.tabAutoMode", "自动模式")}
-                <Badge variant="secondary" className="h-4 px-1 text-[10px]">
-                  {t("autoMode.beta", "Beta")}
-                </Badge>
-              </span>
-            </TabsTrigger>
+            {easyModeBeta && (
+              <TabsTrigger value="proxy">
+                <span className="inline-flex items-center gap-1.5">
+                  {t("settings.tabAutoMode", "省心模式")}
+                  <Badge variant="secondary" className="h-4 px-1 text-[10px]">
+                    {t("autoMode.beta", "Beta")}
+                  </Badge>
+                </span>
+              </TabsTrigger>
+            )}
             <TabsTrigger value="auth">
               {t("settings.tabAuth", { defaultValue: "认证" })}
             </TabsTrigger>
@@ -307,14 +329,16 @@ export function SettingsPage({
                 ) : null}
               </TabsContent>
 
-              <TabsContent value="proxy" className="space-y-6 mt-0 pb-4">
-                {settings ? (
-                  <AutoModeTabContent
-                    settings={settings}
-                    onAutoSave={handleAutoSave}
-                  />
-                ) : null}
-              </TabsContent>
+              {easyModeBeta && (
+                <TabsContent value="proxy" className="space-y-6 mt-0 pb-4">
+                  {settings ? (
+                    <AutoModeTabContent
+                      settings={settings}
+                      onAutoSave={handleAutoSave}
+                    />
+                  ) : null}
+                </TabsContent>
+              )}
 
               <TabsContent value="auth" className="space-y-6 mt-0 pb-4">
                 <motion.div
@@ -548,6 +572,15 @@ export function SettingsPage({
                           （#165 过渡 tab 的最终归宿），产品语义是底层配置。 */}
                       {settings ? (
                         <LocalRoutingServicePanel
+                          settings={settings}
+                          onAutoSave={handleAutoSave}
+                        />
+                      ) : null}
+
+                      {/* 故障转移管理（发布形态的家）：省心模式 Beta 关着时
+                          它在这里；Beta 开着时收进省心模式页，两处不同现。 */}
+                      {!easyModeBeta && settings ? (
+                        <FailoverAccordionItem
                           settings={settings}
                           onAutoSave={handleAutoSave}
                         />

--- a/src/types.ts
+++ b/src/types.ts
@@ -428,6 +428,9 @@ export interface Settings {
   // Run official Codex under the shared "custom" provider id so future
   // sessions share one resume-history bucket with third-party providers
   unifyCodexSessionHistory?: boolean;
+  // Easy Mode (省心模式) Beta flag: default off — the shipped build hides the
+  // settings tab; maintainers flip it in settings.json to self-test.
+  easyModeBeta?: boolean;
   // User opted in (enable dialog checkbox) to migrate existing official sessions
   unifyCodexMigrateExisting?: boolean;
   // User has confirmed the failover toggle first-run notice


### PR DESCRIPTION
## Summary / 概述

用户决定：省心模式不够成熟，**这一版先不上**。修法是默认关闭的功能开关而不是回滚——main 上的开发继续，发布形态不暴露：

- settings 新增 `easyModeBeta`（**默认 false**，serde default 与 Default impl 两处一致）：false = 设置页不出现「省心模式」tab（TabsList 列数自适应 6→5；若正停在该 tab 自动落回通用页）。维护者在 `~/.loongport/settings.json` 手动置 `true` 自测；成熟后翻默认或删开关
- **故障转移管理是早已发布的既有功能，不能跟着 tab 消失**：提取 `FailoverControls`（统一开关 + 主页面显示开关 + 首开确认）两处共用——Beta 开着时在省心模式页（现状不变）；关着时「高级」tab 挂 `FailoverAccordionItem`（统一开关 + 各 app 队列/熔断管理，回到发布过的形态），**两处不同现**
- 对已开启省心模式的存量用户（如 v6.0.0 自动模式用户）：顶栏开关（生效时可见、可关）与「高级」页的本地路由服务面板仍可停用/停止，不会失去控制

## Related Issue / 关联 Issue

Fixes #

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（六道闸本地全绿：cargo test 15 套件 0 失败、clippy、fmt、tsc、prettier、vitest 174 文件 1155 测试）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（无新增文案，复用既有 key）
