### PR TITLE
fix(easy-mode): Beta 关闭时顶栏也不露出省心模式开关

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1492,7 +1492,10 @@ function App() {
                       {settingsData?.enableFailoverToggle && (
                         <FailoverToggle activeApp={proxyAppId} />
                       )}
-                      <AutoModeToggle activeApp={proxyAppId} />
+                      {/* 省心模式 Beta（默认关）：发布形态顶栏也不露出。 */}
+                      {settingsData?.easyModeBeta && (
+                        <AutoModeToggle activeApp={proxyAppId} />
+                      )}
                     </>
                   ) : null}
                 </div>


### PR DESCRIPTION
## Summary / 概述

#188 扣掉了设置页 tab，但 #172 之后顶栏 `AutoModeToggle` 是**常驻双态**——发布形态（`easyModeBeta=false`）它仍会出现在顶栏，功能照样漏出。本 PR 补上同一道闸：`settingsData.easyModeBeta` 为 true 才渲染。

存量已开启用户更新到发布版后：顶栏入口消失，但路由/接管不受影响；需要停用走「高级 → 本地路由服务」。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（纯前端一行门控；vitest 174 文件 1155 测试全绿）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（无文案变化）
