### PR TITLE
test(easy-mode): 端到端 HTTP 测试——闲置选最便宜/活跃不切换/故障转移与回切

### DIFF
--- a/src-tauri/src/proxy/auto_mode_e2e_tests.rs
+++ b/src-tauri/src/proxy/auto_mode_e2e_tests.rs
@@ -1,0 +1,373 @@
+//! 省心模式端到端（HTTP 线路）测试。
+//!
+//! `auto_strategy` / `provider_router` 的单元测试各自钉住排序与选路判定；
+//! 这里把整条链拉直了打真实流量：本地 axum mock 上游 + 真实 `ProxyServer`
+//! + reqwest 客户端，验证三条产品语义在线路上的落点：
+//!
+//! 1. 活跃会话外（无亲和）流量落最便宜档位；
+//! 2. 活跃会话内不切换 —— 当前档位 30 分钟内有流量时，更便宜的档位不抢
+//!    （中途换供应商丢提示词缓存，未命中按全价计费，是硬约束）；
+//! 3. 当前档位故障时请求仍成功（请求内故障转移 + 熔断），恢复后回到在用档位。
+//!
+//! headless 边界：`FailoverSwitchManager::do_switch` 的热切换只在有
+//! `AppHandle` 时执行（托盘/事件/写 live 都依赖它），本测试无 GUI，
+//! DB「当前档位」不会因故障转移而变 —— 所以断言落点是「哪家 mock 收到了
+//! 流量」与客户端最终拿到谁的响应，不断言热切换副作用。
+
+use super::auto_strategy;
+use super::server::ProxyServer;
+use super::types::ProxyConfig;
+use crate::app_config::AppType;
+use crate::database::Database;
+use crate::provider::Provider;
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::Json;
+use serde_json::{json, Value};
+use serial_test::serial;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use tempfile::TempDir;
+use tokio::sync::RwLock;
+
+/// 可编程 mock 上游：默认 200，可翻成 500 模拟故障；记录命中数与鉴权头。
+#[derive(Clone)]
+struct MockUpstreamState {
+    hits: Arc<AtomicUsize>,
+    status: Arc<RwLock<u16>>,
+    auth_header: Arc<RwLock<Option<String>>>,
+    marker: &'static str,
+}
+
+struct MockUpstream {
+    state: MockUpstreamState,
+    port: u16,
+}
+
+impl MockUpstream {
+    async fn spawn(marker: &'static str) -> Self {
+        let state = MockUpstreamState {
+            hits: Arc::new(AtomicUsize::new(0)),
+            status: Arc::new(RwLock::new(200)),
+            auth_header: Arc::new(RwLock::new(None)),
+            marker,
+        };
+        let app = axum::Router::new()
+            .fallback(handle_mock)
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock upstream");
+        let port = listener.local_addr().expect("mock local addr").port();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        Self { state, port }
+    }
+
+    fn base_url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+
+    fn hits(&self) -> usize {
+        self.state.hits.load(Ordering::SeqCst)
+    }
+
+    async fn set_status(&self, status: u16) {
+        *self.state.status.write().await = status;
+    }
+
+    async fn auth_header(&self) -> Option<String> {
+        self.state.auth_header.read().await.clone()
+    }
+}
+
+async fn handle_mock(
+    State(state): State<MockUpstreamState>,
+    headers: HeaderMap,
+    _body: axum::body::Bytes,
+) -> (StatusCode, Json<Value>) {
+    state.hits.fetch_add(1, Ordering::SeqCst);
+    *state.auth_header.write().await = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+    let status = *state.status.read().await;
+    if status == 200 {
+        (
+            StatusCode::OK,
+            Json(json!({
+                "id": "msg_mock",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-e2e",
+                "content": [{ "type": "text", "text": state.marker }],
+                "stop_reason": "end_turn",
+                "usage": { "input_tokens": 1, "output_tokens": 1 },
+            })),
+        )
+    } else {
+        (
+            StatusCode::from_u16(status).expect("valid status"),
+            Json(json!({
+                "type": "error",
+                "error": { "type": "api_error", "message": "mock upstream failure" },
+            })),
+        )
+    }
+}
+
+struct TempHome {
+    #[allow(dead_code)]
+    dir: TempDir,
+    original_home: Option<String>,
+    original_userprofile: Option<String>,
+    original_test_home: Option<String>,
+}
+
+impl TempHome {
+    fn new() -> Self {
+        let dir = TempDir::new().expect("failed to create temp home");
+        let original_home = std::env::var("HOME").ok();
+        let original_userprofile = std::env::var("USERPROFILE").ok();
+        let original_test_home = std::env::var("CC_SWITCH_TEST_HOME").ok();
+
+        std::env::set_var("HOME", dir.path());
+        std::env::set_var("USERPROFILE", dir.path());
+        std::env::set_var("CC_SWITCH_TEST_HOME", dir.path());
+        crate::settings::reload_settings().expect("reload settings");
+
+        Self {
+            dir,
+            original_home,
+            original_userprofile,
+            original_test_home,
+        }
+    }
+}
+
+impl Drop for TempHome {
+    fn drop(&mut self) {
+        match &self.original_home {
+            Some(value) => std::env::set_var("HOME", value),
+            None => std::env::remove_var("HOME"),
+        }
+        match &self.original_userprofile {
+            Some(value) => std::env::set_var("USERPROFILE", value),
+            None => std::env::remove_var("USERPROFILE"),
+        }
+        match &self.original_test_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+    }
+}
+
+struct E2eFixture {
+    _home: TempHome,
+    db: Arc<Database>,
+    server: ProxyServer,
+    port: u16,
+    cheap: MockUpstream,
+    expensive: MockUpstream,
+    cheap_id: String,
+    expensive_id: String,
+}
+
+impl E2eFixture {
+    /// 两个托管档位（便宜 0.5 / 贵 2.0，均无单价 → 组内按倍率比），
+    /// 故障转移开、熔断 1 次失败即开且冷却 0（每条请求都能立即探测恢复）。
+    async fn new() -> Self {
+        let _home = TempHome::new();
+        let db = Arc::new(Database::memory().expect("init db"));
+
+        let cheap = MockUpstream::spawn("served-by-cheap").await;
+        let expensive = MockUpstream::spawn("served-by-expensive").await;
+
+        let cheap_id =
+            crate::relay::provision::provider_id_for("https://cheap.example", Some(1), 11);
+        let expensive_id =
+            crate::relay::provision::provider_id_for("https://expensive.example", Some(1), 22);
+
+        let tier_provider = |id: &str, name: &str, mock: &MockUpstream, token: &str| {
+            Provider::with_id(
+                id.to_string(),
+                name.to_string(),
+                json!({
+                    "env": {
+                        "ANTHROPIC_BASE_URL": mock.base_url(),
+                        "ANTHROPIC_AUTH_TOKEN": token,
+                    }
+                }),
+                None,
+            )
+        };
+        db.save_provider(
+            "claude",
+            &tier_provider(&cheap_id, "Cheap Tier", &cheap, "tok-cheap"),
+        )
+        .expect("save cheap tier");
+        db.save_provider(
+            "claude",
+            &tier_provider(&expensive_id, "Expensive Tier", &expensive, "tok-expensive"),
+        )
+        .expect("save expensive tier");
+        db.set_tier_rate_multiplier("claude", &cheap_id, Some(0.5))
+            .expect("set cheap multiplier");
+        db.set_tier_rate_multiplier("claude", &expensive_id, Some(2.0))
+            .expect("set expensive multiplier");
+
+        let mut config = db.get_proxy_config_for_app("claude").await.unwrap();
+        config.enabled = true;
+        config.auto_failover_enabled = true;
+        config.max_retries = 3;
+        config.circuit_failure_threshold = 1;
+        config.circuit_timeout_seconds = 0;
+        db.update_proxy_config_for_app(config).await.unwrap();
+
+        auto_strategy::set_enabled(&db, "claude", true).expect("enable auto mode");
+
+        let server = ProxyServer::new(
+            ProxyConfig {
+                listen_port: 0,
+                ..Default::default()
+            },
+            db.clone(),
+            None,
+        );
+        let info = server.start().await.expect("start proxy server");
+
+        Self {
+            _home,
+            db,
+            server,
+            port: info.port,
+            cheap,
+            expensive,
+            cheap_id,
+            expensive_id,
+        }
+    }
+
+    fn set_current(&self, id: &str) {
+        self.db.set_current_provider("claude", id).unwrap();
+        crate::settings::set_current_provider(&AppType::Claude, Some(id)).unwrap();
+    }
+
+    /// 预置某档位最近有流量（亲和窗口判据读 proxy_request_logs）。
+    fn seed_recent_activity(&self, provider_id: &str) {
+        let conn = self.db.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO proxy_request_logs (
+                request_id, provider_id, app_type, model,
+                input_tokens, output_tokens, total_cost_usd,
+                latency_ms, first_token_ms, status_code, created_at
+            ) VALUES (?1, ?2, 'claude', 'm', 1, 1, '0', 10, 10, 200, ?3)",
+            rusqlite::params![
+                format!("e2e-activity-{provider_id}"),
+                provider_id,
+                chrono::Utc::now().timestamp()
+            ],
+        )
+        .unwrap();
+    }
+}
+
+/// 走真实代理端口的 Claude 请求；`session` 模拟同一会话的连续请求。
+async fn send_message(port: u16, session: &str) -> reqwest::Response {
+    reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("build client")
+        .post(format!("http://127.0.0.1:{port}/v1/messages"))
+        .header("x-api-key", "client-key-should-be-overridden")
+        .header("anthropic-version", "2023-06-01")
+        .header("x-claude-code-session-id", session)
+        .json(&json!({
+            "model": "claude-e2e",
+            "max_tokens": 16,
+            "stream": false,
+            "messages": [{ "role": "user", "content": "hi" }],
+        }))
+        .send()
+        .await
+        .expect("send request")
+}
+
+async fn response_text(resp: reqwest::Response) -> String {
+    let status = resp.status();
+    let body: Value = resp.json().await.expect("parse response body");
+    assert_eq!(status, reqwest::StatusCode::OK, "body: {body}");
+    body["content"][0]["text"]
+        .as_str()
+        .expect("marker text")
+        .to_string()
+}
+
+/// 闲置（无当前档位活跃会话）时，省心模式把流量交给最便宜档位。
+#[tokio::test]
+#[serial]
+async fn idle_traffic_goes_to_cheapest_tier() {
+    let fx = E2eFixture::new().await;
+
+    let marker = response_text(send_message(fx.port, "sess-e2e-idle-000001").await).await;
+    assert_eq!(marker, "served-by-cheap");
+    let marker = response_text(send_message(fx.port, "sess-e2e-idle-000002").await).await;
+    assert_eq!(marker, "served-by-cheap");
+
+    assert_eq!(fx.cheap.hits(), 2);
+    assert_eq!(fx.expensive.hits(), 0, "更贵的档位不应被触碰");
+    fx.server.stop().await.expect("stop server");
+}
+
+/// 活跃会话不切换：当前档位（贵）30 分钟内有流量时，更便宜的档位不抢，
+/// 同一 session 连续请求全部落在当前档位；鉴权头注入的是该档位自己的 token。
+#[tokio::test]
+#[serial]
+async fn active_session_sticks_to_current_tier_over_cheaper_one() {
+    let fx = E2eFixture::new().await;
+    fx.set_current(&fx.expensive_id);
+    fx.seed_recent_activity(&fx.expensive_id);
+
+    for i in 0..3 {
+        let marker = response_text(send_message(fx.port, "sess-e2e-sticky-000001").await).await;
+        assert_eq!(marker, "served-by-expensive", "第 {} 条请求被抢走了", i + 1);
+    }
+
+    assert_eq!(fx.expensive.hits(), 3);
+    assert_eq!(fx.cheap.hits(), 0, "便宜档位不得抢活跃会话");
+    assert_eq!(
+        fx.expensive.auth_header().await.as_deref(),
+        Some("Bearer tok-expensive"),
+        "转发必须注入档位自己的 token，而不是客户端的"
+    );
+    fx.server.stop().await.expect("stop server");
+}
+
+/// 在用档位（便宜）故障：请求内故障转移到下一家、客户端始终拿到 200；
+/// 恢复后回到在用档位。熔断 1 次失败即开 + 冷却 0 ⇒ 每条请求允许探测一次。
+#[tokio::test]
+#[serial]
+async fn failing_tier_fails_over_and_returns_when_recovered() {
+    let fx = E2eFixture::new().await;
+    fx.set_current(&fx.cheap_id);
+    fx.seed_recent_activity(&fx.cheap_id);
+
+    fx.cheap.set_status(500).await;
+
+    // 两条请求：每条先探测在用档位（500 → 熔断计失败），请求内落到贵档位
+    let marker = response_text(send_message(fx.port, "sess-e2e-failover-0001").await).await;
+    assert_eq!(marker, "served-by-expensive");
+    let marker = response_text(send_message(fx.port, "sess-e2e-failover-0001").await).await;
+    assert_eq!(marker, "served-by-expensive");
+    assert_eq!(fx.cheap.hits(), 2, "每条请求只应探测故障档位一次");
+    assert_eq!(fx.expensive.hits(), 2);
+
+    // 在用档位恢复 → 探测成功，回到在用档位（省心模式不因一次故障就弃用它）
+    fx.cheap.set_status(200).await;
+    let marker = response_text(send_message(fx.port, "sess-e2e-failover-0001").await).await;
+    assert_eq!(marker, "served-by-cheap");
+    assert_eq!(fx.cheap.hits(), 3);
+    assert_eq!(fx.expensive.hits(), 2, "恢复后不应继续占用备胎档位");
+    fx.server.stop().await.expect("stop server");
+}

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -36,6 +36,9 @@ pub(crate) mod tool_media;
 pub(crate) mod types;
 pub mod usage;
 
+#[cfg(test)]
+mod auto_mode_e2e_tests;
+
 // 公开导出给外部使用（commands, services等模块需要）
 #[allow(unused_imports)]
 pub use circuit_breaker::{


### PR DESCRIPTION
## Summary / 概述

补上省心模式缺的端到端 HTTP 测试：`proxy/auto_mode_e2e_tests.rs` 用 mock 上游 + 真实 `ProxyServer` + reqwest 打真流量，钉三条产品语义：

1. **闲置选最便宜**：无活跃会话时流量落最便宜档位（排序在线路上的落点，不是只有单测里的排序函数）；
2. **活跃不切换**：当前档位 30 分钟内有流量时，更便宜的档位不抢会话（用户核心需求「相同 session 尽量不切换」）；同时钉住转发注入的是档位自己的 token；
3. **失败才切换 + 恢复回切**：在用档位 5xx 时请求内故障转移到下一家（客户端始终 200），熔断每次只探测一次；恢复后回到在用档位。

headless 边界写进了文件头注释：`do_switch` 热切换依赖 `AppHandle`，无 GUI 下 DB 当前档位不变，因此断言落点是「哪家 mock 收到了流量」。

## Related Issue / 关联 Issue

无（补测试覆盖，对应省心模式 #165–#172/#187/#188 的行为定稿）

## Screenshots / 截图

纯测试，无 UI 变化。

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查（未动前端，跳过）
- [ ] `pnpm format:check` passes / 通过代码格式检查（未动前端，跳过）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（无用户可见文本）
