### PR TITLE
feat(vendor): 官网直连档位补模型目录与倍率 1.0

### DIFF
--- a/src-tauri/src/commands/vendor.rs
+++ b/src-tauri/src/commands/vendor.rs
@@ -915,7 +915,7 @@ async fn provision_impl(
                 .ok()
                 .flatten();
 
-            let settings_config = match existing {
+            let mut settings_config = match existing {
                 Some(old) => {
                     let mut kept = old.settings_config;
                     // patch 失败（形状被改坏 / 该放 sk 的 section 没了）⇒ 回落默认配置。
@@ -932,6 +932,13 @@ async fn provision_impl(
                 }
                 None => defaults.clone(),
             };
+            // 存量行补模型目录（只增不覆盖）：目录版本之前的行没有 modelCatalog，
+            // 而省心模式的偏好过滤会把无目录档位静默排除 —— 刷新密钥时顺手补齐。
+            if settings_config.get("modelCatalog").is_none() {
+                if let Some(catalog) = defaults.get("modelCatalog") {
+                    settings_config["modelCatalog"] = catalog.clone();
+                }
+            }
 
             let provider = Provider {
                 id: provider_id.clone(),
@@ -961,6 +968,11 @@ async fn provision_impl(
                 .map_err(|e| {
                     AppError::Database(format!("保存 {} 配置失败: {e}", app_type.as_str()))
                 })?;
+            // 官网直连按官方价目计费，倍率恒为 1（中转站才有站点折扣）。
+            // 不落倍率会被省心模式当「未知=最贵」垫底（2026-08-17 真实 smoke 实测）。
+            state
+                .db
+                .set_tier_rate_multiplier(app_type.as_str(), &provider_id, Some(1.0))?;
 
             let merged = provider_fingerprint::remove_unmanaged_duplicates(
                 state.db.as_ref(),

--- a/src-tauri/src/database/loongport_schema.rs
+++ b/src-tauri/src/database/loongport_schema.rs
@@ -48,7 +48,7 @@ use crate::error::AppError;
 /// LoongPort 自己的 schema 版本。加迁移时 +1。
 ///
 /// **与 `SCHEMA_VERSION`（上游那个）无关**，两者各自独立计数。
-pub(crate) const LOONGPORT_SCHEMA_VERSION: i32 = 15;
+pub(crate) const LOONGPORT_SCHEMA_VERSION: i32 = 16;
 
 /// 存版本号的表。**只有一行**（`id = 1`）。
 ///
@@ -247,6 +247,14 @@ pub(crate) fn apply(conn: &Connection) -> Result<(), AppError> {
                 log::info!("LoongPort 数据迁移 v14 → v15（余额快照去重：删余额未变的相邻行）");
                 dedupe_balance_snapshots(conn)?;
                 set_version(conn, 15)?;
+            }
+            // v15 → v16：存量官网直连档位补倍率 1.0。provision 侧从本版起写入，
+            // 这一步服务已停在 v15 的库 —— 倍率 NULL 会被省心模式当「未知=最贵」
+            // 系统性垫底（官网直连按官方价目计费，倍率恒为 1）。纯 DML，不动表形状。
+            15 => {
+                log::info!("LoongPort 数据迁移 v15 → v16（官网直连档位倍率补 1.0）");
+                backfill_vendor_tier_multipliers(conn)?;
+                set_version(conn, 16)?;
             }
             other => {
                 return Err(AppError::Database(format!(
@@ -578,6 +586,39 @@ fn add_user_edited_column(conn: &Connection) -> Result<(), AppError> {
 ///
 /// ⚠️ 与 [`add_user_edited_column`] 同一条纪律：**列不放进上游
 /// `create_tables_on_conn` 的 providers CREATE**，全新库靠迁移链补上。
+/// v15 → v16 的存量回填：官网直连档位（`loongport-vendor-%`）倍率 NULL → 1.0。
+/// 缺表/缺列不报错，理由同 [`add_tier_rate_multiplier_column]`（老库可能还没有
+/// providers 表或还没有这一列 —— 没有行可补就是成功）。
+fn backfill_vendor_tier_multipliers(conn: &Connection) -> Result<(), AppError> {
+    let has_table: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='providers'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+    if has_table == 0 {
+        return Ok(());
+    }
+    let has_column: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM pragma_table_info('providers') WHERE name='tier_rate_multiplier'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+    if has_column == 0 {
+        return Ok(());
+    }
+    conn.execute(
+        "UPDATE providers SET tier_rate_multiplier = 1.0
+         WHERE tier_rate_multiplier IS NULL
+           AND id LIKE 'loongport-vendor-%'",
+        [],
+    )?;
+    Ok(())
+}
+
 fn add_tier_rate_multiplier_column(conn: &Connection) -> Result<(), AppError> {
     // 缺表不报错，理由同 `add_user_edited_column`。
     let has_providers: i64 = conn
@@ -1548,6 +1589,44 @@ mod tests {
     fn a_fresh_database_reports_version_zero() {
         let conn = mem();
         assert_eq!(current_version(&conn).unwrap(), 0);
+    }
+
+    /// v15 → v16：官网直连档位倍率 NULL → 1.0（官方价目即倍率 1）；
+    /// 中转站/导入档位不碰 —— 它们的倍率归站点数据，NULL 的语义是「未知」。
+    #[test]
+    fn migrates_vendor_tier_multiplier_to_one() {
+        let conn = mem();
+        providers_table(&conn);
+        conn.execute(
+            "INSERT INTO providers (id, app_type, name, settings_config) VALUES
+             ('loongport-vendor-abc123def4567890', 'claude', 'DeepSeek', '{}'),
+             ('loongport-11112222333344445555', 'claude', 'Relay Tier', '{}')",
+            [],
+        )
+        .expect("造档位行");
+        ensure_version_table(&conn).expect("建版本表");
+        // 从 v11 起（倍率列由 v11→v12 加），让加列与回填都走真实迁移路径。
+        set_version(&conn, 11).expect("置 v11");
+
+        apply(&conn).expect("迁移到 v16");
+
+        let vendor: Option<f64> = conn
+            .query_row(
+                "SELECT tier_rate_multiplier FROM providers WHERE id LIKE 'loongport-vendor-%'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("查 vendor 倍率");
+        assert_eq!(vendor, Some(1.0));
+        let relay: Option<f64> = conn
+            .query_row(
+                "SELECT tier_rate_multiplier FROM providers
+                 WHERE id NOT LIKE 'loongport-vendor-%'",
+                [],
+                |r| r.get(0),
+            )
+            .expect("查 relay 倍率");
+        assert_eq!(relay, None, "中转站档位倍率仍归站点数据管");
     }
 
     #[test]

--- a/src-tauri/src/relay/provision.rs
+++ b/src-tauri/src/relay/provision.rs
@@ -819,30 +819,31 @@ pub fn settings_config_with_roles_and_models(
             if matches!(app_type, AppType::Claude) {
                 config["language"] = serde_json::json!("chinese");
             }
-            // Claude / Gemini：把分组模型目录落进配置（主界面模型芯片与自动模式
-            // app→模型 映射的数据源，形状与 codex 的 modelCatalog 相同）。
-            // 与 codex 的 `is_image_model` 过滤同理按家族收口：
-            // - claude 分组可能混 gpt-* / deepseek-*（瓜子跨家族对齐，角色挑选本来就
-            //   跨家族），目录收全部**文本**模型；
+            // 把分组模型目录落进配置（主界面模型芯片与自动模式 app→模型 映射的
+            // 数据源，形状与 codex 的 modelCatalog 相同）。**全部非 codex 平台**：
+            // 目录是档位级事实（「这把 key 能服务哪些模型」），省心模式的偏好过滤
+            // 对无目录档位是静默排除 —— 2026-08-17 真实 smoke 实测官网直连的
+            // hermes/openclaw/opencode 行中招。与 codex 的 `is_image_model` 过滤
+            // 同理按家族收口：
             // - gemini 走原生 URL 路由（`/v1beta/models/{model}:generateContent`），
-            //   只认 gemini-* 家族，目录只收 gemini-*。
-            if matches!(app_type, AppType::Claude | AppType::Gemini) {
-                if let Some(models) = models.filter(|models| !models.is_empty()) {
-                    let family: Vec<&String> = match app_type {
-                        AppType::Gemini => models
+            //   只认 gemini-* 家族，目录只收 gemini-*；
+            // - 其余平台目录收全部**文本**模型（claude 分组可能混 gpt-* / deepseek-*，
+            //   瓜子跨家族对齐，角色挑选本来就跨家族）。
+            if let Some(models) = models.filter(|models| !models.is_empty()) {
+                let family: Vec<&String> = match app_type {
+                    AppType::Gemini => models
+                        .iter()
+                        .filter(|m| m.to_ascii_lowercase().starts_with("gemini-"))
+                        .collect(),
+                    _ => models.iter().filter(|m| !is_image_model(m)).collect(),
+                };
+                if !family.is_empty() {
+                    config["modelCatalog"] = serde_json::json!({
+                        "models": family
                             .iter()
-                            .filter(|m| m.to_ascii_lowercase().starts_with("gemini-"))
-                            .collect(),
-                        _ => models.iter().filter(|m| !is_image_model(m)).collect(),
-                    };
-                    if !family.is_empty() {
-                        config["modelCatalog"] = serde_json::json!({
-                            "models": family
-                                .iter()
-                                .map(|model| serde_json::json!({ "model": model }))
-                                .collect::<Vec<_>>(),
-                        });
-                    }
+                            .map(|model| serde_json::json!({ "model": model }))
+                            .collect::<Vec<_>>(),
+                    });
                 }
             }
             config

--- a/src-tauri/src/vendor/mod.rs
+++ b/src-tauri/src/vendor/mod.rs
@@ -298,6 +298,39 @@ pub fn plan_style(vendor: Vendor, id_segment: &str) -> crate::relay::provision::
     }
 }
 
+/// 该厂商**某个 plan**能服务的模型清单（去重），供 provision 写进 `modelCatalog`
+/// —— 省心模式的模型偏好过滤与托盘 app→模型映射都以目录为准，没有目录的档位
+/// 在用户设了偏好时会被静默排除（2026-08-17 真实 smoke 实测 DeepSeek 直连中招）。
+///
+/// 派生而不是另列常量：取各平台 `config_for` 的主模型 + Claude 角色分档的取值，
+/// 与生成配置同源 —— 两边各写一份清单迟早分叉。`[1M]` 是上下文长度变体后缀，
+/// 目录收基础名（角色 env 才带后缀）。
+pub fn catalog_models(vendor: Vendor, id_segment: &str) -> Vec<String> {
+    let mut models: Vec<String> = Vec::new();
+    let push = |models: &mut Vec<String>, model: &str| {
+        let base = model.trim_end_matches("[1M]");
+        if !base.is_empty() && !models.iter().any(|m| m == base) {
+            models.push(base.to_string());
+        }
+    };
+    for app in crate::vendor::provision::VENDOR_APPS {
+        if let Some((_, model)) = config_for(vendor, id_segment, &app) {
+            push(&mut models, &model);
+        }
+    }
+    let roles = claude_role_models(vendor, id_segment);
+    for model in [
+        &roles.opus,
+        &roles.fable,
+        &roles.sonnet,
+        &roles.haiku,
+        &roles.subagent,
+    ] {
+        push(&mut models, model);
+    }
+    models
+}
+
 /// 「管理 API Key」网页（帮助跳转）。`None` = 该厂商没有公开的密钥管理页。
 pub fn api_keys_help_url(vendor: Vendor) -> Option<&'static str> {
     match vendor {

--- a/src-tauri/src/vendor/provision.rs
+++ b/src-tauri/src/vendor/provision.rs
@@ -130,27 +130,31 @@ pub struct PlanRows {
 pub fn plan_rows_for(vendor: Vendor, account_id: &str, api_key: &str) -> Vec<PlanRows> {
     crate::vendor::plans(vendor)
         .iter()
-        .map(|plan| PlanRows {
-            plan: *plan,
-            provider_id: provider_id_for(plan.id_segment, account_id),
-            rows: VENDOR_APPS
-                .iter()
-                .filter_map(|app| {
-                    let (base_url, model) =
-                        crate::vendor::config_for(vendor, plan.id_segment, app)?;
-                    let cfg = crate::relay::provision::settings_config_with_roles_and_models(
-                        app,
-                        api_key,
-                        plan.display_name,
-                        &base_url,
-                        &model,
-                        claude_roles_for(vendor, plan.id_segment, app),
-                        None,
-                        crate::vendor::plan_style(vendor, plan.id_segment),
-                    )?;
-                    Some((app.clone(), cfg))
-                })
-                .collect(),
+        .map(|plan| {
+            // 模型目录与配置同源派生：没有目录的档位会被省心模式的偏好过滤静默排除。
+            let catalog = crate::vendor::catalog_models(vendor, plan.id_segment);
+            PlanRows {
+                plan: *plan,
+                provider_id: provider_id_for(plan.id_segment, account_id),
+                rows: VENDOR_APPS
+                    .iter()
+                    .filter_map(|app| {
+                        let (base_url, model) =
+                            crate::vendor::config_for(vendor, plan.id_segment, app)?;
+                        let cfg = crate::relay::provision::settings_config_with_roles_and_models(
+                            app,
+                            api_key,
+                            plan.display_name,
+                            &base_url,
+                            &model,
+                            claude_roles_for(vendor, plan.id_segment, app),
+                            Some(catalog.as_slice()),
+                            crate::vendor::plan_style(vendor, plan.id_segment),
+                        )?;
+                        Some((app.clone(), cfg))
+                    })
+                    .collect(),
+            }
         })
         .collect()
 }
@@ -190,6 +194,35 @@ mod tests {
             "opencode",
         ] {
             assert!(apps.contains(&expect.to_string()), "缺平台 {expect}");
+        }
+    }
+
+    /// ⭐ 每条行都带模型目录：无目录档位会被省心模式的模型偏好过滤**静默排除**
+    /// （2026-08-17 真实 smoke 实测 DeepSeek 直连中招）。目录与配置同源派生、收基础名。
+    #[test]
+    fn rows_carry_model_catalog_for_easy_mode() {
+        let rows = deepseek_rows("sk-x");
+        for (app, cfg) in &rows {
+            let models: Vec<&str> = cfg["modelCatalog"]["models"]
+                .as_array()
+                .unwrap_or_else(|| panic!("{} 行缺模型目录", app.as_str()))
+                .iter()
+                .filter_map(|m| m.get("model").and_then(|v| v.as_str()))
+                .collect();
+            assert!(
+                models.contains(&"deepseek-v4-pro"),
+                "{} 目录缺 pro：{models:?}",
+                app.as_str()
+            );
+            assert!(
+                models.contains(&"deepseek-v4-flash"),
+                "{} 目录缺 flash：{models:?}",
+                app.as_str()
+            );
+            assert!(
+                models.iter().all(|m| !m.ends_with("[1M]")),
+                "目录收基础名（[1M] 是角色 env 的变体后缀）：{models:?}"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary / 概述

真实中转站 smoke（2026-08-17）发现官网直连档位（DeepSeek 等 vendor 档）在省心模式里被系统性错误对待，两处根因一起修：

1. **倍率 NULL → 当「未知=最贵」垫底**：官网直连按官方价目计费，倍率恒为 1。provision 落库时写入 `tier_rate_multiplier = 1.0`，另加 v15→v16 迁移回填存量 vendor 行（带缺表/缺列守卫，纯 DML 不动表形状）。
2. **无 modelCatalog → 设了模型偏好就被静默排除**（`filter_by_model_pref` 对无目录档位不保留）：新增 `vendor::catalog_models`（与生成配置同源派生：各平台主模型 + Claude 角色档，去重、剥 `[1M]` 变体后缀），provision 写入目录；目录写入从 Claude/Gemini 放开到全部非 codex 平台（目录是档位级事实）；存量行在「获取密钥」刷新时**只增不覆盖**补目录。

测试：目录断言（六平台行都带 DeepSeek 双模型）、迁移断言（vendor 行回填 1.0、中转站行不碰）、全量 cargo test 3431 绿。

## Related Issue / 关联 Issue

无（真实 smoke 发现；页面重构 spec 的 P0 项之一提前落地）

## Screenshots / 截图

纯后端，无 UI。

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查（未动前端，跳过）
- [ ] `pnpm format:check` passes / 通过代码格式检查（未动前端，跳过）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（无）
