### PR TITLE
feat(easy-mode): 档位看板聚合命令 + 手动/自动双选路模式（后端）

### DIFF
--- a/src-tauri/src/commands/auto_mode.rs
+++ b/src-tauri/src/commands/auto_mode.rs
@@ -300,13 +300,305 @@ pub(crate) async fn set_auto_mode_model_impl(
     Ok(())
 }
 
+/// 设置某应用的省心选路模式（auto / manual）。
+///
+/// 首次切到 manual 且还没有手动清单时，把当前选路序快照成初始清单 ——
+/// 用户从现状开始拖，不给空白列表。
+#[tauri::command]
+pub async fn set_easy_mode_mode(
+    state: tauri::State<'_, AppState>,
+    app_type: String,
+    mode: String,
+) -> Result<(), String> {
+    require_auto_mode_app(&app_type)?;
+    let parsed = auto_strategy::EasyModeMode::from_setting_value(&mode);
+    if parsed.as_str() != mode {
+        return Err(format!("未知的省心选路模式: {mode}"));
+    }
+    if parsed == auto_strategy::EasyModeMode::Manual
+        && auto_strategy::get_manual_order(&state.db, &app_type).is_empty()
+    {
+        let snapshot: Vec<String> =
+            auto_strategy::rank_managed_tier_candidates(&state.db, &app_type, false)
+                .map_err(|e| e.to_string())?
+                .unwrap_or_default()
+                .into_iter()
+                .map(|p| p.id)
+                .collect();
+        if !snapshot.is_empty() {
+            auto_strategy::set_manual_order(&state.db, &app_type, &snapshot)
+                .map_err(|e| e.to_string())?;
+        }
+    }
+    auto_strategy::set_mode(&state.db, &app_type, parsed).map_err(|e| e.to_string())
+}
+
+/// 写某应用的手动档位顺序（前端拖拽落定后整份提交）。
+#[tauri::command]
+pub async fn set_easy_mode_manual_order(
+    state: tauri::State<'_, AppState>,
+    app_type: String,
+    ordered_ids: Vec<String>,
+) -> Result<(), String> {
+    require_auto_mode_app(&app_type)?;
+    auto_strategy::set_manual_order(&state.db, &app_type, &ordered_ids).map_err(|e| e.to_string())
+}
+
+/// 省心模式档位看板的一行（首页省心视图的展示事实，全部后端算好）。
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TierBoardTier {
+    pub provider_id: String,
+    pub name: String,
+    /// 展示序即选路优先级序（含亲和置顶/手动序）。
+    pub position: usize,
+    pub is_current: bool,
+    pub rate_multiplier: Option<f64>,
+    /// 该档位有效模型的单价（每百万 token 输入+输出之和，美元）；
+    /// `None` = 价格未知 —— 排序保守垫底的同一个事实，前端原样展示「未知」。
+    pub unit_price_per_million: Option<f64>,
+    pub effective_model: Option<String>,
+    pub avg_first_token_ms: Option<u64>,
+    /// 站点钱包余额（美元）。sub2api 用档位 sk 直查 `GET /v1/usage`（同站各档
+    /// 共享一个账号钱包）；newapi 无此路 → `None`（前端显示 —，走登录态的余额链）。
+    pub balance_usd: Option<f64>,
+}
+
+/// 省心模式档位看板：首页省心视图一次拉全的聚合 DTO。
+///
+/// 业务事实（顺序/模式/策略/倍率/单价/耗时/命中/余额）的唯一源在后端，
+/// 前端只渲染 —— 别在前端用多个原始命令各拼一遍（分叉温床）。
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TierBoard {
+    /// "auto" | "manual"
+    pub mode: String,
+    /// "cheapest" | "fastest"（全局一份）
+    pub strategy: String,
+    pub model: Option<String>,
+    pub available_models: Vec<String>,
+    pub current_provider_id: Option<String>,
+    pub tiers: Vec<TierBoardTier>,
+}
+
+/// 省心模式档位看板（首页省心视图数据源）。
+#[tauri::command]
+pub async fn easy_mode_tier_board(
+    state: tauri::State<'_, AppState>,
+    app_type: String,
+) -> Result<TierBoard, String> {
+    tier_board_impl(&state, &app_type).await
+}
+
+/// 看板核心（真实 smoke 直接调它，不走 tauri State）。
+pub(crate) async fn tier_board_impl(state: &AppState, app_type: &str) -> Result<TierBoard, String> {
+    require_auto_mode_app(app_type)?;
+    let db = &state.db;
+    let providers = db.get_all_providers(app_type).map_err(|e| e.to_string())?;
+    let ranked = auto_strategy::rank_managed_tier_candidates(db, app_type, true)
+        .map_err(|e| e.to_string())?
+        .unwrap_or_default();
+    let multipliers = db.get_tier_rate_multipliers(app_type).unwrap_or_default();
+    let ttft = db
+        .get_provider_avg_first_token_ms(app_type, chrono::Utc::now().timestamp() - 7 * 86400)
+        .unwrap_or_default();
+    let model_pref = auto_strategy::get_model_pref(db, app_type);
+    let current_id = auto_strategy::effective_current_provider_id(db, app_type);
+
+    let balances = fetch_site_balances(app_type, &ranked).await;
+
+    let tiers = ranked
+        .into_iter()
+        .enumerate()
+        .map(|(position, p)| TierBoardTier {
+            is_current: current_id.as_deref() == Some(p.id.as_str()),
+            effective_model: model_pref
+                .clone()
+                .or_else(|| crate::relay::provision::extract_model(&p.settings_config)),
+            unit_price_per_million: auto_strategy::effective_unit_price(
+                db,
+                &p,
+                model_pref.as_deref(),
+            ),
+            rate_multiplier: multipliers.get(&p.id).copied(),
+            avg_first_token_ms: ttft.get(&p.id).copied(),
+            balance_usd: balances.get(&p.id).copied(),
+            provider_id: p.id.clone(),
+            name: p.name.clone(),
+            position,
+        })
+        .collect();
+
+    Ok(TierBoard {
+        mode: auto_strategy::get_mode(db, app_type).as_str().to_string(),
+        strategy: auto_strategy::get_strategy(db).as_str().to_string(),
+        model: model_pref,
+        available_models: auto_strategy::auto_mode_models(&providers),
+        current_provider_id: current_id,
+        tiers,
+    })
+}
+
+/// sub2api 站点钱包余额：按「站点 origin」去重，每个 origin 用第一把 sk 查一次
+/// `GET /v1/usage`（登录态过期也能查），回填到该站的全部档位上。newapi 站
+/// 403/404 → 该站各档 `None`。只对 https 端点发起（http/本地/无 sk 自然跳过，
+/// 单元测试零网络）。
+async fn fetch_site_balances(
+    app_type: &str,
+    tiers: &[crate::provider::Provider],
+) -> std::collections::HashMap<String, f64> {
+    use crate::app_config::AppType;
+    let app = match AppType::from_str(app_type) {
+        Ok(app) => app,
+        Err(_) => return std::collections::HashMap::new(),
+    };
+    let Some(adapter) = crate::proxy::providers::get_adapter(&app) else {
+        return std::collections::HashMap::new();
+    };
+
+    let mut tier_origin: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+    let mut origin_key: std::collections::HashMap<String, String> =
+        std::collections::HashMap::new();
+    for tier in tiers {
+        let (base, auth) = match (adapter.extract_base_url(tier), adapter.extract_auth(tier)) {
+            (Ok(base), Some(auth)) => (base, auth),
+            _ => continue,
+        };
+        let Some(origin) = origin_of(&base) else {
+            continue;
+        };
+        if !origin.starts_with("https://") {
+            continue;
+        }
+        tier_origin.insert(tier.id.clone(), origin.clone());
+        origin_key.entry(origin).or_insert(auth.api_key);
+    }
+
+    let mut balances = std::collections::HashMap::new();
+    let queries: Vec<_> = origin_key
+        .into_iter()
+        .map(|(origin, key)| async move {
+            let balance = crate::relay::api::usage_with_api_key(&origin, &key)
+                .await
+                .ok()
+                .and_then(|usage| {
+                    usage
+                        .data
+                        .and_then(|items| items.first().and_then(|item| item.remaining))
+                });
+            (origin, balance)
+        })
+        .collect();
+    for (origin, balance) in futures::future::join_all(queries).await {
+        if let Some(balance) = balance {
+            for (tier_id, tier_origin) in &tier_origin {
+                if tier_origin == &origin {
+                    balances.insert(tier_id.clone(), balance);
+                }
+            }
+        }
+    }
+    balances
+}
+
+/// 从 base_url 取 `scheme://authority`（`https://site/v1` → `https://site`）。
+fn origin_of(base_url: &str) -> Option<String> {
+    let (scheme, rest) = base_url.split_once("://")?;
+    let authority = rest.split('/').next()?;
+    if authority.is_empty() {
+        return None;
+    }
+    Some(format!("{scheme}://{authority}"))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::require_auto_mode_app;
+    use super::{require_auto_mode_app, tier_board_impl};
+    use crate::store::AppState;
+    use crate::Database;
+    use serde_json::json;
+    use serial_test::serial;
+    use std::sync::Arc;
 
     #[test]
     fn auto_mode_rejects_apps_without_a_proxy_data_plane() {
         assert!(require_auto_mode_app("claude").is_ok());
         assert!(require_auto_mode_app("pi").is_err());
+    }
+
+    /// 看板聚合：顺序=选路序、倍率/单价/耗时/命中齐全；手动模式反映手动序。
+    /// 余额链对 http 端点零网络（真实站点路径由 ignored 的真实 smoke 覆盖）。
+    #[tokio::test]
+    #[serial]
+    async fn tier_board_aggregates_display_facts() {
+        let _home = test_home();
+        let db = Arc::new(Database::memory().unwrap());
+        let state = AppState::new(db.clone());
+
+        let expensive = crate::relay::provision::provider_id_for("https://a.example", Some(1), 1);
+        let cheap = crate::relay::provision::provider_id_for("https://b.example", Some(1), 2);
+        // http 端点（fetch_site_balances 只对 https 发请求）
+        let tier = |id: &str, name: &str, config: serde_json::Value| {
+            crate::provider::Provider::with_id(id.to_string(), name.to_string(), config, None)
+        };
+        db.save_provider(
+            "claude",
+            &tier(&expensive, "贵档", json!({ "config": "model = \"m-x\"\n" })),
+        )
+        .unwrap();
+        db.save_provider(
+            "claude",
+            &tier(&cheap, "便宜档", json!({ "config": "model = \"m-x\"\n" })),
+        )
+        .unwrap();
+        db.set_tier_rate_multiplier("claude", &expensive, Some(2.0))
+            .unwrap();
+        db.set_tier_rate_multiplier("claude", &cheap, Some(0.5))
+            .unwrap();
+        db.set_current_provider("claude", &expensive).unwrap();
+
+        let board = tier_board_impl(&state, "claude").await.unwrap();
+        assert_eq!(board.mode, "auto");
+        assert_eq!(board.strategy, "cheapest");
+        assert_eq!(board.tiers.len(), 2);
+        assert_eq!(board.tiers[0].provider_id, cheap, "自动模式便宜在前");
+        assert_eq!(board.tiers[0].rate_multiplier, Some(0.5));
+        assert_eq!(
+            board.tiers[0].unit_price_per_million, None,
+            "价表没收录 → 未知"
+        );
+        assert!(
+            board
+                .tiers
+                .iter()
+                .any(|t| t.is_current && t.provider_id == expensive),
+            "当前档位有命中标记"
+        );
+
+        // 手动模式：手动序反映到看板
+        crate::proxy::auto_strategy::set_mode(
+            &db,
+            "claude",
+            crate::proxy::auto_strategy::EasyModeMode::Manual,
+        )
+        .unwrap();
+        crate::proxy::auto_strategy::set_manual_order(
+            &db,
+            "claude",
+            &[expensive.clone(), cheap.clone()],
+        )
+        .unwrap();
+        let board = tier_board_impl(&state, "claude").await.unwrap();
+        assert_eq!(board.mode, "manual");
+        assert_eq!(board.tiers[0].provider_id, expensive, "手动序优先");
+    }
+
+    fn test_home() -> tempfile::TempDir {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::env::set_var("HOME", dir.path());
+        std::env::set_var("CC_SWITCH_TEST_HOME", dir.path());
+        crate::settings::reload_settings().unwrap();
+        dir
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1858,6 +1858,9 @@ pub fn run() {
             commands::set_auto_mode_enabled,
             commands::set_auto_mode_strategy,
             commands::set_auto_mode_model,
+            commands::easy_mode_tier_board,
+            commands::set_easy_mode_mode,
+            commands::set_easy_mode_manual_order,
             // Usage statistics
             commands::get_usage_summary,
             commands::get_usage_summary_by_app,

--- a/src-tauri/src/proxy/auto_strategy.rs
+++ b/src-tauri/src/proxy/auto_strategy.rs
@@ -31,6 +31,79 @@ pub const SETTING_STRATEGY: &str = "auto_mode_strategy";
 /// settings 表里「某应用模型偏好」的 key 前缀（`auto_mode_model_<app>`）。
 /// `None` = 不限模型（全部托管档位都进候选）。
 pub const SETTING_MODEL_PREFIX: &str = "auto_mode_model_";
+/// settings 表里「某应用省心选路模式」的 key 前缀（`easy_mode_mode_<app>`，
+/// `auto` / `manual`）。
+pub const SETTING_MODE_PREFIX: &str = "easy_mode_mode_";
+/// settings 表里「某应用手动档位顺序」的 key 前缀（`easy_mode_manual_order_<app>`，
+/// JSON 数组，存 provider id）。清单外的档位（新档位/被删后残留的 id）由下面的
+/// 读取函数兜底：不认识的忽略、漏掉的按策略序追加 —— 手动序永远不能让档位丢失。
+pub const SETTING_MANUAL_ORDER_PREFIX: &str = "easy_mode_manual_order_";
+
+/// 省心模式的选路模式：自动按策略排序 / 用户手动定序。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EasyModeMode {
+    /// 系统按策略（cheapest/fastest）排序，会话亲和照常。
+    Auto,
+    /// 用户拖拽定的顺序即优先级；亲和、熔断、故障转移照常（定序 ≠ 关保险）。
+    Manual,
+}
+
+impl EasyModeMode {
+    /// 从 settings 值解析；不认识的值落回默认（auto）。
+    pub fn from_setting_value(value: &str) -> Self {
+        match value {
+            "manual" => Self::Manual,
+            _ => Self::Auto,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Manual => "manual",
+        }
+    }
+}
+
+/// 读某应用的选路模式（缺省 auto）。
+pub fn get_mode(db: &Database, app_type: &str) -> EasyModeMode {
+    db.get_setting(&format!("{SETTING_MODE_PREFIX}{app_type}"))
+        .ok()
+        .flatten()
+        .map(|value| EasyModeMode::from_setting_value(&value))
+        .unwrap_or(EasyModeMode::Auto)
+}
+
+/// 写某应用的选路模式。
+pub fn set_mode(
+    db: &Database,
+    app_type: &str,
+    mode: EasyModeMode,
+) -> Result<(), crate::error::AppError> {
+    db.set_setting(&format!("{SETTING_MODE_PREFIX}{app_type}"), mode.as_str())
+}
+
+/// 读某应用的手动档位顺序。脏数据 / 不存在 → 空清单（等同「全按策略追加」）。
+pub fn get_manual_order(db: &Database, app_type: &str) -> Vec<String> {
+    db.get_setting(&format!("{SETTING_MANUAL_ORDER_PREFIX}{app_type}"))
+        .ok()
+        .flatten()
+        .and_then(|value| serde_json::from_str(&value).ok())
+        .unwrap_or_default()
+}
+
+/// 写某应用的手动档位顺序（完整清单，前端拖拽落定后整份提交）。
+pub fn set_manual_order(
+    db: &Database,
+    app_type: &str,
+    ordered_ids: &[String],
+) -> Result<(), crate::error::AppError> {
+    db.set_setting(
+        &format!("{SETTING_MANUAL_ORDER_PREFIX}{app_type}"),
+        &serde_json::to_string(ordered_ids)
+            .map_err(|e| crate::error::AppError::Config(format!("序列化手动顺序失败: {e}")))?,
+    )
+}
 
 /// 会话亲和窗口：当前档位最近一次请求距今小于该值即视为「会话进行中」。
 /// 30 分钟 ≈ 一次长编码会话的自然间隔，期间不因策略重排切走。
@@ -220,14 +293,22 @@ pub fn rank_managed_tier_candidates(
         None
     };
     let now = chrono::Utc::now().timestamp();
-    let mut ranked = rank_tiers(
-        db,
-        app_type,
-        &tiers,
-        current_id.as_deref(),
-        get_strategy(db),
-        now,
-    );
+    // 手动模式：清单序优先（亲和交给下面的置顶块统一处理，rank_tiers 里不再预置顶，
+    // 否则策略预置顶会被清单重排冲掉）；自动模式：策略排序（含内部亲和置顶）。
+    let mut ranked = match get_mode(db, app_type) {
+        EasyModeMode::Auto => rank_tiers(
+            db,
+            app_type,
+            &tiers,
+            current_id.as_deref(),
+            get_strategy(db),
+            now,
+        ),
+        EasyModeMode::Manual => {
+            let by_strategy = rank_tiers(db, app_type, &tiers, None, get_strategy(db), now);
+            apply_manual_order(&get_manual_order(db, app_type), by_strategy)
+        }
+    };
 
     if let Some(current_id) = current_id.as_deref() {
         let already_first = ranked.first().is_some_and(|p| p.id == current_id);
@@ -327,6 +408,33 @@ pub fn rank_tiers(
     }
 
     ranked
+}
+
+/// 手动序套在策略序上：清单里的按清单序排前，漏掉的（清单写之后的**新档位**）
+/// 按策略序追加 —— 清单是用户的显式意志，但绝不能因为清单过期让新档位拿不到流量；
+/// 清单里已不存在的 id（档位被删）自然被忽略。
+fn apply_manual_order(order: &[String], mut by_strategy: Vec<Provider>) -> Vec<Provider> {
+    let mut ranked: Vec<Provider> = Vec::with_capacity(by_strategy.len());
+    for id in order {
+        if let Some(pos) = by_strategy.iter().position(|p| &p.id == id) {
+            ranked.push(by_strategy.remove(pos));
+        }
+    }
+    ranked.extend(by_strategy);
+    ranked
+}
+
+/// 看板命令展示用的单价入口：与排序同一份实现（唯源），别在看板侧再算一遍。
+pub(crate) fn effective_unit_price(
+    db: &Database,
+    tier: &Provider,
+    model_pref: Option<&str>,
+) -> Option<f64> {
+    let conn = db
+        .conn
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    tier_unit_price(&conn, tier, model_pref)
 }
 
 /// 档位「有效模型」的合并单价：每百万 token 输入+输出之和（美元）。
@@ -521,6 +629,82 @@ mod tests {
             t + AFFINITY_WINDOW_SECS + 1,
         );
         assert_eq!(ranked_idle[0].id, cheap);
+    }
+
+    /// 手动模式：清单序优先，清单外的新档位按策略序追加（绝不能丢流量），
+    /// 清单里已删档位的 id 被忽略；亲和照常置顶活跃当前档位（定序 ≠ 关掉会话保护）。
+    #[test]
+    fn manual_mode_orders_by_user_list_with_strategy_fallback() {
+        let db = Database::memory().unwrap();
+        let expensive = managed_id("https://a.example", 1, 1);
+        let cheap = managed_id("https://b.example", 1, 2);
+        let fresh = managed_id("https://c.example", 1, 3);
+        let tiers = vec![tier(&expensive, "E"), tier(&cheap, "C"), tier(&fresh, "F")];
+        for p in &tiers {
+            db.save_provider("claude", p).unwrap();
+        }
+        db.set_tier_rate_multiplier("claude", &expensive, Some(2.0))
+            .unwrap();
+        db.set_tier_rate_multiplier("claude", &cheap, Some(0.5))
+            .unwrap();
+        // fresh 不设倍率：策略序垫底，但不在清单里也必须被追加
+
+        // 自动模式基线：便宜在前
+        let ranked = rank_managed_tier_candidates(&db, "claude", false)
+            .unwrap()
+            .expect("候选非空");
+        assert_eq!(ranked[0].id, cheap);
+
+        // 手动序：贵档第一；清单里塞一个已删档位的 id（被忽略）
+        set_mode(&db, "claude", EasyModeMode::Manual).unwrap();
+        set_manual_order(
+            &db,
+            "claude",
+            &[
+                expensive.clone(),
+                "loongport-deadbeefdeadbeef".to_string(),
+                cheap.clone(),
+            ],
+        )
+        .unwrap();
+        let ranked = rank_managed_tier_candidates(&db, "claude", true)
+            .unwrap()
+            .expect("手动模式候选非空");
+        let ids: Vec<&str> = ranked.iter().map(|p| p.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec![expensive.as_str(), cheap.as_str(), fresh.as_str()],
+            "手动序优先，漏档按策略序追加"
+        );
+
+        // 亲和：当前档位（fresh）活跃 → 手动序之上仍被置顶
+        seed_activity(&db, "claude", &fresh, now() - 60, 500);
+        db.set_current_provider("claude", &fresh).unwrap();
+        let ranked = rank_managed_tier_candidates(&db, "claude", true)
+            .unwrap()
+            .expect("候选非空");
+        assert_eq!(ranked[0].id, fresh, "活跃会话在手动模式下同样不被打断");
+    }
+
+    #[test]
+    fn mode_and_manual_order_setting_roundtrip() {
+        let db = Database::memory().unwrap();
+        assert_eq!(get_mode(&db, "claude"), EasyModeMode::Auto);
+
+        set_mode(&db, "claude", EasyModeMode::Manual).unwrap();
+        assert_eq!(get_mode(&db, "claude"), EasyModeMode::Manual);
+        assert_eq!(get_mode(&db, "codex"), EasyModeMode::Auto, "按 app 隔离");
+        // 脏数据落回默认，别炸选路
+        db.set_setting(&format!("{SETTING_MODE_PREFIX}claude"), "nonsense")
+            .unwrap();
+        assert_eq!(get_mode(&db, "claude"), EasyModeMode::Auto);
+
+        // 手动序：脏数据 → 空清单（等同全按策略追加）
+        db.set_setting(&format!("{SETTING_MANUAL_ORDER_PREFIX}claude"), "not-json")
+            .unwrap();
+        assert!(get_manual_order(&db, "claude").is_empty());
+        set_manual_order(&db, "claude", &["x".to_string(), "y".to_string()]).unwrap();
+        assert_eq!(get_manual_order(&db, "claude"), vec!["x", "y"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

省心模式首页重构（spec `spec-省心模式页面重构与手动排序.md`）的后端半部：

1. **`easy_mode_tier_board` 聚合命令**：首页省心视图一次拉全展示事实——选路优先级序（含亲和/手动序）、倍率、有效模型单价（每 M 输入+输出之和）、7 天平均首字耗时、当前命中、站点钱包余额（sub2api `GET /v1/usage` 用档位 sk 直查、按站点 origin 去重、仅 https 端点发起）。业务事实后端唯源，前端只渲染。
2. **手动/自动双选路模式**：`easy_mode_mode_<app>`（auto/manual）+ `easy_mode_manual_order_<app>`（JSON id 清单）；手动分支收在 `rank_managed_tier_candidates` 唯源——清单序优先、清单外新档位按策略序追加（绝不能丢流量）、已删 id 忽略、会话亲和照常置顶（定序 ≠ 关掉会话保护）；首切手动把当前序快照为初始清单（不给空白列表）。
3. `set_easy_mode_mode` / `set_easy_mode_manual_order` 命令 + lib.rs 注册。

测试：模式/清单往返与脏数据兜底、手动序+漏档追加+亲和置顶、看板聚合断言（http 端点余额链零网络）。全量 cargo test 绿。

## Related Issue / 关联 Issue

页面重构 spec（design 仓）P0+P1 的后端部分

## Screenshots / 截图

纯后端，无 UI。

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查（未动前端，跳过）
- [ ] `pnpm format:check` passes / 通过代码格式检查（未动前端，跳过）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（无）
