### PR TITLE
fix(relay): 导入窗锚定探针最终落地 origin（裸域 301 到 www 的站点）

### DIFF
--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -1266,6 +1266,16 @@ pub(crate) async fn import_site(
         }
     };
 
+    let requested_origin = site_origin.clone();
+    let site_origin = import_anchor_origin(site_origin, initial_detected.as_ref());
+    if site_origin != requested_origin {
+        log::info!(
+            "站点 {} 探针重定向到 {}，导入窗按最终 origin 锚定",
+            requested_origin,
+            site_origin
+        );
+    }
+
     let result = browser_import(
         app_handle,
         input,
@@ -1344,6 +1354,22 @@ fn recoverable_native_discovery_error(
     } else {
         Ok(error)
     }
+}
+
+/// 导入窗的锚定 origin：探针跟随重定向落在**别的 origin**（典型：裸域全路径 301
+/// 到 `www.`）时，以最终落地 origin 为准。
+///
+/// `browser_import` 里所有同源约束都锚在这一个值上 —— 登录/注册入口、注入脚本的
+/// origin 守卫、落库的 `site_origin`。用户输入的 origin 被站点 301 走时，页面实际
+/// 停在最终 origin 上，锚若留在请求 origin，守卫（见 `login::login_script` 与
+/// `discovery::browser_probe_script` 的 origin 早退）会静默吞掉全部回传：探针没有
+/// 结果、凭据永远不来、导入干等到超时。探针没跑成（回退浏览器辅助发现）或没有
+/// 重定向时，保持用户输入的 origin。
+fn import_anchor_origin(requested: String, detected: Option<&discovery::DetectedSite>) -> String {
+    detected
+        .and_then(|site| site.final_origin.clone())
+        .filter(|final_origin| *final_origin != requested)
+        .unwrap_or(requested)
 }
 
 /// 生成浏览器首次打开的地址：站点 origin 与后端归一化规则一致，但保留用户给的
@@ -5649,6 +5675,7 @@ mod tests {
             backend_kind: discovery::BackendKind::Sub2Api,
             site_name: "Example".into(),
             api_base_url: String::new(),
+            final_origin: None,
         }
     }
 
@@ -5657,7 +5684,38 @@ mod tests {
             backend_kind: discovery::BackendKind::NewApi,
             site_name: "NewAPI".into(),
             api_base_url: String::new(),
+            final_origin: None,
         }
+    }
+
+    #[test]
+    fn import_anchor_origin_prefers_the_probe_final_origin() {
+        let redirected = discovery::DetectedSite {
+            final_origin: Some("https://panel.example".into()),
+            ..detected_sub2api()
+        };
+        assert_eq!(
+            import_anchor_origin("https://apex.example".into(), Some(&redirected)),
+            "https://panel.example"
+        );
+        // 浏览器路径的回传不带 final_origin（守卫保证同源），探针也没跑成时同理：
+        // 都保持用户输入的 origin。
+        assert_eq!(
+            import_anchor_origin("https://apex.example".into(), Some(&detected_sub2api())),
+            "https://apex.example"
+        );
+        assert_eq!(
+            import_anchor_origin("https://apex.example".into(), None),
+            "https://apex.example"
+        );
+        let same_origin = discovery::DetectedSite {
+            final_origin: Some("https://apex.example".into()),
+            ..detected_sub2api()
+        };
+        assert_eq!(
+            import_anchor_origin("https://apex.example".into(), Some(&same_origin)),
+            "https://apex.example"
+        );
     }
 
     #[test]

--- a/src-tauri/src/relay/api.rs
+++ b/src-tauri/src/relay/api.rs
@@ -74,6 +74,7 @@ fn detect_site(body: &str) -> Option<DetectedSite> {
         backend_kind: BackendKind::Sub2Api,
         site_name: settings.site_name,
         api_base_url: settings.api_base_url,
+        final_origin: None,
     })
 }
 

--- a/src-tauri/src/relay/backend.rs
+++ b/src-tauri/src/relay/backend.rs
@@ -20,6 +20,10 @@ pub struct DetectedSite {
     pub backend_kind: BackendKind,
     pub site_name: String,
     pub api_base_url: String,
+    /// 指纹实际被观察到的 origin。原生探针跟随重定向后可能落在与请求不同的
+    /// origin（典型：裸域 301 到 `www.`）；浏览器路径的回传总在锚点 origin 上，
+    /// 故为 `None`。导入窗据此把入口、脚本守卫与落库行锚到页面真正停留的 origin。
+    pub final_origin: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]

--- a/src-tauri/src/relay/discovery.rs
+++ b/src-tauri/src/relay/discovery.rs
@@ -83,6 +83,10 @@ pub struct ProbeResponse {
     pub json_like: bool,
     #[serde(default)]
     pub error_kind: Option<String>,
+    /// 原生请求跟随重定向后的最终落地 origin；浏览器回传不含该字段 —— 探针脚本
+    /// 受 origin 守卫约束，只在与锚点同源的页面上跑。
+    #[serde(default)]
+    pub final_origin: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize)]
@@ -446,6 +450,7 @@ pub(crate) async fn probe_candidates(
             }
         };
         response.status = Some(sent.status().as_u16());
+        response.final_origin = Some(sent.url().origin().ascii_serialization());
         response.content_type = sent
             .headers()
             .get(reqwest::header::CONTENT_TYPE)
@@ -530,9 +535,10 @@ pub fn converge_probe_responses(
 ) -> Result<DetectedSite, DiscoveryError> {
     let mut detected = Vec::new();
     for response in responses {
-        let Some(candidate) = detect_candidate(&response.candidate_id, &response.body) else {
+        let Some(mut candidate) = detect_candidate(&response.candidate_id, &response.body) else {
             continue;
         };
+        candidate.final_origin = response.final_origin.clone();
         if detected
             .iter()
             .any(|item: &DetectedSite| item.backend_kind == candidate.backend_kind)
@@ -742,6 +748,7 @@ mod tests {
                 detector_body_bytes: 0,
                 json_like: false,
                 error_kind: None,
+                final_origin: None,
             },
             ProbeResponse {
                 candidate_id: "newapi".into(),
@@ -943,5 +950,76 @@ mod tests {
             browser_probe_script("https://relay.example", PROBE_CANDIDATES),
             "the mandatory Vitest fixture must stay byte-for-byte current",
         );
+    }
+
+    #[test]
+    fn convergence_propagates_final_origin_from_the_matching_candidate() {
+        let response = ProbeResponse {
+            candidate_id: "sub2api".into(),
+            body: sub2api_body().into(),
+            final_origin: Some("https://panel.example".into()),
+            ..ProbeResponse::default()
+        };
+
+        let detected = converge_probe_responses(std::slice::from_ref(&response))
+            .expect("valid sub2api body must converge");
+
+        assert_eq!(
+            detected.final_origin.as_deref(),
+            Some("https://panel.example")
+        );
+    }
+
+    /// 裸域全路径 301 到 `www.` 的站点：原生探针跟随重定向认出协议，且必须带回
+    /// **最终落地 origin** —— 导入窗靠它把入口、脚本守卫与落库行锚到页面真正
+    /// 停留的 origin，否则守卫锚在请求 origin 上、回传永远不来。
+    #[tokio::test]
+    async fn native_probe_follows_redirect_and_reports_final_origin() {
+        let panel = Router::new().route(
+            "/api/v1/settings/public",
+            get(|| async {
+                Json(serde_json::from_str::<serde_json::Value>(sub2api_body()).unwrap())
+            }),
+        );
+        let panel_listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind panel server");
+        let panel_origin = format!(
+            "http://{}",
+            panel_listener.local_addr().expect("panel local address")
+        );
+        let panel_server = tokio::spawn(async move {
+            axum::serve(panel_listener, panel)
+                .await
+                .expect("serve panel");
+        });
+
+        let redirect_target = format!("{panel_origin}/api/v1/settings/public");
+        let apex = Router::new().route(
+            "/api/v1/settings/public",
+            get(move || async move { axum::response::Redirect::permanent(&redirect_target) }),
+        );
+        let apex_listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind apex server");
+        let apex_origin = format!(
+            "http://{}",
+            apex_listener.local_addr().expect("apex local address")
+        );
+        let apex_server = tokio::spawn(async move {
+            axum::serve(apex_listener, apex).await.expect("serve apex");
+        });
+
+        let detected = probe_site(&apex_origin)
+            .await
+            .expect("redirected sub2api probe must converge");
+
+        assert_eq!(detected.backend_kind, BackendKind::Sub2Api);
+        assert_eq!(
+            detected.final_origin.as_deref(),
+            Some(panel_origin.as_str())
+        );
+        apex_server.abort();
+        panel_server.abort();
     }
 }

--- a/src-tauri/src/relay/newapi.rs
+++ b/src-tauri/src/relay/newapi.rs
@@ -183,6 +183,7 @@ fn detect_site(body: &str) -> Option<DetectedSite> {
         backend_kind: BackendKind::NewApi,
         site_name: status.system_name,
         api_base_url: String::new(),
+        final_origin: None,
     })
 }
 

--- a/src-tauri/src/relay/site_probe.rs
+++ b/src-tauri/src/relay/site_probe.rs
@@ -302,6 +302,7 @@ mod tests {
             detector_body_bytes: body.len(),
             json_like: trimmed.starts_with('{') || trimmed.starts_with('['),
             error_kind: None,
+            final_origin: None,
         }
     }
 


### PR DESCRIPTION
## Summary / 概述

手动添加「裸域全路径 301 到 `www.`」的中转站站点时，导入流程会静默死锁：原生探针跟随重定向能认出协议，但导入窗入口、注入脚本 origin 守卫与落库行都锚在用户输入的裸域上；页面实际停在 `www.`，守卫（`login_script` / `browser_probe_script` 的 origin 早退）把探针回传和凭据回传全部吞掉，导入只能干等到 300 秒超时。

本 PR 修根：探针候选记录 reqwest 跟随重定向后的**最终落地 origin**（`ProbeResponse` / `DetectedSite` 新增 `final_origin`，浏览器路径受守卫约束天然同源、保持 `None`），`import_site` 据此把锚点换成最终 origin：

- 导入窗入口、脚本守卫、落库 `site_origin` 一致锚到页面真正停留的 origin；
- 落库后复检、探活、重登直连真实面板 origin，不再每次吃一遍重定向；
- aff/promo 查表按剥 `www.` 后的 host 匹配，不受重锚影响；
- 与 `normalize_site_origin`「不剥 www.」的立场同构：锚必须等于实际连接的那个 origin —— 那次防把 www 剥成裸域，这次防站点把裸域 301 走之后锚还留在裸域。

已知残留（有意不做）：历史已按裸域落库的旧行不会迁移，重新添加一次即按最终 origin 落库；浏览器辅助发现路径（探针没跑成时）本就锚用户输入 origin，由守卫保证同源，无需重锚。

## Related Issue / 关联 Issue

无（用户反馈的手动导入卡死问题）。

## Screenshots / 截图

纯后端行为修复，无 UI 变化。

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查（未动前端）
- [ ] `pnpm format:check` passes / 通过代码格式检查（未动前端）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（无用户可见文本变化）
