### PR TITLE
fix(usage): absorb upstream multi-year trend chart fix (#6337) to supersede local minimal fix

### DIFF
--- a/docs/upstream-merges.md
+++ b/docs/upstream-merges.md
@@ -26,6 +26,7 @@
 |---|---|---|---|---|---|---|
 | 2026-08-14 | #116 | 整并 upstream main | 67 | （未单列，主要在 Cargo.lock） | 有（依赖大版本栈） | merge-tree 干跑定冲突面；Cargo.lock `--theirs` + `cargo check` 收口；WSL2 job flake 重跑即绿 |
 | 2026-08-16 | #145 | 定点 cherry-pick | 2 | 2（database/mod.rs、schema.rs） | 1（sha2 `LowerHex`→`hex::encode`） | SCHEMA_VERSION 16→17 跟上游走，口径注释保留；首次建立本台账 |
+| 2026-08-19 | #200 | 定点 cherry-pick（预收冲突） | 1（3d126f45） | 1（UsageTrendChart.tsx，取上游版整体替换本地 3c43cfca） | 无 | 上游 #6337 与本地 #144 同根修复的会合：主动吸收上游版使文件回到与上游一致，下次整并该文件不再冲突；上游 PR #6488 已被取代关闭 |
 
 ## 关联
 

--- a/src/components/usage/UsageTrendChart.tsx
+++ b/src/components/usage/UsageTrendChart.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
   AreaChart,
@@ -29,6 +30,111 @@ interface UsageTrendChartProps {
   refreshIntervalMs: number;
 }
 
+export interface UsageTrendStatLike {
+  date: string;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCacheCreationTokens: number;
+  totalCacheReadTokens: number;
+  totalCost: string | number;
+}
+
+export interface UsageTrendChartPoint {
+  /** Unique category key for Recharts — must not collide across years. */
+  xKey: string;
+  rawDate: string;
+  /** Short tick label shown on the X axis. */
+  label: string;
+  /** Fuller label used by the tooltip. */
+  tooltipLabel: string;
+  hour: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  cost: number | null;
+}
+
+/** Build chart rows from backend trend stats. Exported for unit tests. */
+export function buildUsageTrendChartData(
+  trends: UsageTrendStatLike[] | undefined,
+  options: {
+    isHourly: boolean;
+    dateLocale: string;
+    /** Inclusive range endpoints (unix seconds). Used to decide year labels. */
+    startDate: number;
+    endDate: number;
+  },
+): UsageTrendChartPoint[] {
+  const { isHourly, dateLocale, startDate, endDate } = options;
+  const startYear = new Date(startDate * 1000).getFullYear();
+  const endYear = new Date(endDate * 1000).getFullYear();
+  const spansMultipleYears = startYear !== endYear;
+
+  return (
+    trends?.map((stat) => {
+      const pointDate = new Date(stat.date);
+      const cost = parseFiniteNumber(stat.totalCost);
+      // Prefer a stable unique key from the source timestamp / date string.
+      // Falling back to ISO keeps categories unique even if the backend
+      // returns sparse points that share the same local MM/DD across years.
+      const xKey = stat.date;
+      const tooltipLabel = isHourly
+        ? pointDate.toLocaleString(dateLocale, {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit",
+          })
+        : pointDate.toLocaleDateString(dateLocale, {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+          });
+      const label = isHourly
+        ? pointDate.toLocaleString(dateLocale, {
+            month: "2-digit",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit",
+          })
+        : spansMultipleYears
+          ? pointDate.toLocaleDateString(dateLocale, {
+              year: "2-digit",
+              month: "2-digit",
+              day: "2-digit",
+            })
+          : pointDate.toLocaleDateString(dateLocale, {
+              month: "2-digit",
+              day: "2-digit",
+            });
+
+      return {
+        xKey,
+        rawDate: stat.date,
+        label,
+        tooltipLabel,
+        hour: pointDate.getHours(),
+        inputTokens: stat.totalInputTokens,
+        outputTokens: stat.totalOutputTokens,
+        cacheCreationTokens: stat.totalCacheCreationTokens,
+        cacheReadTokens: stat.totalCacheReadTokens,
+        cost: cost ?? null,
+      };
+    }) || []
+  );
+}
+
+/** Resolve a tick label by the unique category key (not by filtered tick index). */
+export function formatUsageTrendTickLabel(
+  xKey: string,
+  chartData: UsageTrendChartPoint[],
+): string {
+  const point = chartData.find((row) => row.xKey === xKey);
+  return point?.label ?? xKey;
+}
+
 export function UsageTrendChart({
   range,
   rangeLabel,
@@ -47,6 +153,22 @@ export function UsageTrendChart({
     },
   );
 
+  const durationSeconds = Math.max(endDate - startDate, 0);
+  const isHourly = durationSeconds <= 24 * 60 * 60;
+  const language = i18n.resolvedLanguage || i18n.language || "en";
+  const dateLocale = getLocaleFromLanguage(language);
+
+  const chartData = useMemo(
+    () =>
+      buildUsageTrendChartData(trends, {
+        isHourly,
+        dateLocale,
+        startDate,
+        endDate,
+      }),
+    [trends, isHourly, dateLocale, startDate, endDate],
+  );
+
   if (isLoading) {
     return (
       <div className="flex h-[350px] items-center justify-center rounded-xl bg-card/40 border border-border/50">
@@ -55,49 +177,13 @@ export function UsageTrendChart({
     );
   }
 
-  const durationSeconds = Math.max(endDate - startDate, 0);
-  const isHourly = durationSeconds <= 24 * 60 * 60;
-  const language = i18n.resolvedLanguage || i18n.language || "en";
-  const dateLocale = getLocaleFromLanguage(language);
-
-  // X 轴必须用原始日期做 key：跨年区间里不同年份的相同 MM/DD 会生成重复
-  // label，recharts 按类别匹配时 tooltip 和高亮点会命中前一年的数据点。
-  // 显示用的 label 由 formatTrendLabel 统一格式化。
-  const formatTrendLabel = (rawDate: string) => {
-    const pointDate = new Date(rawDate);
-    return isHourly
-      ? pointDate.toLocaleString(dateLocale, {
-          month: "2-digit",
-          day: "2-digit",
-          hour: "2-digit",
-          minute: "2-digit",
-        })
-      : pointDate.toLocaleDateString(dateLocale, {
-          month: "2-digit",
-          day: "2-digit",
-        });
-  };
-
-  const chartData =
-    trends?.map((stat) => {
-      const cost = parseFiniteNumber(stat.totalCost);
-      return {
-        rawDate: stat.date,
-        inputTokens: stat.totalInputTokens,
-        outputTokens: stat.totalOutputTokens,
-        cacheCreationTokens: stat.totalCacheCreationTokens,
-        cacheReadTokens: stat.totalCacheReadTokens,
-        cost: cost ?? null,
-      };
-    }) || [];
-
-  const displayData = chartData;
-
-  const CustomTooltip = ({ active, payload, label }: any) => {
+  const CustomTooltip = ({ active, payload }: any) => {
     if (active && payload && payload.length) {
+      const point = payload[0]?.payload as UsageTrendChartPoint | undefined;
+      const heading = point?.tooltipLabel ?? point?.label ?? "";
       return (
         <div className="rounded-lg border bg-background/95 p-3 shadow-lg backdrop-blur-md">
-          <p className="mb-2 font-medium">{formatTrendLabel(String(label))}</p>
+          <p className="mb-2 font-medium">{heading}</p>
           {payload.map((entry: any, index: number) => (
             <div
               key={index}
@@ -134,7 +220,7 @@ export function UsageTrendChart({
       <div className="h-[350px] w-full">
         <ResponsiveContainer width="100%" height="100%">
           <AreaChart
-            data={displayData}
+            data={chartData}
             margin={{ top: 10, right: 10, left: 0, bottom: 0 }}
           >
             <defs>
@@ -168,12 +254,15 @@ export function UsageTrendChart({
               opacity={0.4}
             />
             <XAxis
-              dataKey="rawDate"
+              dataKey="xKey"
               axisLine={false}
               tickLine={false}
               tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 12 }}
-              tickFormatter={(value: string) => formatTrendLabel(value)}
               dy={10}
+              tickFormatter={(value) =>
+                formatUsageTrendTickLabel(String(value), chartData)
+              }
+              allowDuplicatedCategory={false}
             />
             <YAxis
               yAxisId="tokens"

--- a/tests/components/UsageTrendChart.test.ts
+++ b/tests/components/UsageTrendChart.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildUsageTrendChartData,
+  formatUsageTrendTickLabel,
+} from "@/components/usage/UsageTrendChart";
+
+const day = (isoDate: string) =>
+  ({
+    date: `${isoDate}T12:00:00.000Z`,
+    totalInputTokens: 100,
+    totalOutputTokens: 50,
+    totalCacheCreationTokens: 0,
+    totalCacheReadTokens: 0,
+    totalCost: "0.01",
+  }) as const;
+
+describe("buildUsageTrendChartData (#6302)", () => {
+  it("keeps unique x-axis keys when the same MM/DD appears in multiple years", () => {
+    // 2025-04-27 and 2026-04-27 share the same MM/DD tick text in single-year
+    // formatting. Using that text as the Recharts category key made activeDots
+    // jump to the earlier year's point while the tooltip followed the cursor.
+    const startDate = Math.floor(Date.parse("2025-01-01T00:00:00Z") / 1000);
+    const endDate = Math.floor(Date.parse("2026-08-10T00:00:00Z") / 1000);
+
+    const points = buildUsageTrendChartData(
+      [day("2025-04-27"), day("2026-04-27")],
+      {
+        isHourly: false,
+        dateLocale: "en-US",
+        startDate,
+        endDate,
+      },
+    );
+
+    expect(points).toHaveLength(2);
+    expect(points[0].xKey).not.toBe(points[1].xKey);
+    expect(points[0].xKey).toContain("2025-04-27");
+    expect(points[1].xKey).toContain("2026-04-27");
+    // Tooltip always carries a year so the user can tell which April it is.
+    expect(points[0].tooltipLabel).toMatch(/2025/);
+    expect(points[1].tooltipLabel).toMatch(/2026/);
+  });
+
+  it("includes a year in the axis tick when the selected range spans years", () => {
+    const startDate = Math.floor(Date.parse("2025-01-01T00:00:00Z") / 1000);
+    const endDate = Math.floor(Date.parse("2026-08-10T00:00:00Z") / 1000);
+
+    const points = buildUsageTrendChartData([day("2026-04-27")], {
+      isHourly: false,
+      dateLocale: "en-US",
+      startDate,
+      endDate,
+    });
+
+    expect(points[0].label).toMatch(/26|2026/);
+  });
+
+  it("keeps short MM/DD ticks for single-year ranges", () => {
+    const startDate = Math.floor(Date.parse("2026-01-01T00:00:00Z") / 1000);
+    const endDate = Math.floor(Date.parse("2026-08-10T00:00:00Z") / 1000);
+
+    const points = buildUsageTrendChartData([day("2026-04-27")], {
+      isHourly: false,
+      dateLocale: "en-US",
+      startDate,
+      endDate,
+    });
+
+    // en-US 2-digit month/day — should not need a year prefix inside one year.
+    expect(points[0].label).not.toMatch(/2026/);
+    expect(points[0].tooltipLabel).toMatch(/2026/);
+  });
+});
+
+describe("formatUsageTrendTickLabel", () => {
+  it("resolves labels by xKey even when the tick index is thinned", () => {
+    const startDate = Math.floor(Date.parse("2025-01-01T00:00:00Z") / 1000);
+    const endDate = Math.floor(Date.parse("2026-08-10T00:00:00Z") / 1000);
+    const points = buildUsageTrendChartData(
+      [
+        {
+          date: "2025-01-01T12:00:00.000Z",
+          totalInputTokens: 1,
+          totalOutputTokens: 1,
+          totalCacheCreationTokens: 0,
+          totalCacheReadTokens: 0,
+          totalCost: "0",
+        },
+        {
+          date: "2025-04-27T12:00:00.000Z",
+          totalInputTokens: 1,
+          totalOutputTokens: 1,
+          totalCacheCreationTokens: 0,
+          totalCacheReadTokens: 0,
+          totalCost: "0",
+        },
+        {
+          date: "2026-04-27T12:00:00.000Z",
+          totalInputTokens: 1,
+          totalOutputTokens: 1,
+          totalCacheCreationTokens: 0,
+          totalCacheReadTokens: 0,
+          totalCost: "0",
+        },
+      ],
+      { isHourly: false, dateLocale: "en-US", startDate, endDate },
+    );
+
+    // Simulate Recharts passing a later category as the only visible tick
+    // (filtered index 0 would wrongly map to the first chart row).
+    const last = points[2];
+    expect(formatUsageTrendTickLabel(last.xKey, points)).toBe(last.label);
+    expect(formatUsageTrendTickLabel(last.xKey, points)).not.toBe(
+      points[0].label,
+    );
+  });
+});


### PR DESCRIPTION
## Summary / 概述

Absorb upstream fix `3d126f45` (farion1231/cc-switch#6337) for the usage trend chart multi-year hover mismatch, **verbatim** — component + its unit tests, file content now byte-identical to upstream.

- Replaces our local minimal fix `3c43cfca` (PR #144; superseded upstream by farion1231/cc-switch#6488 closed): same root cause (Recharts category keyed on localized `MM/DD` label collapsing across years), upstream additionally shows the year on multi-year ranges (2-digit on axis ticks, 4-digit in the tooltip heading) and ships unit tests.
- Purpose: align this file with upstream so the next upstream sync merges clean — the known future conflict is resolved ahead of time.

## Related Issue / 关联 Issue

Upstream: farion1231/cc-switch#6337 (fixes their #6302). Our earlier backport PR #144 is superseded by this change.

## Screenshots / 截图

Not applicable — behavior-only fix; single-year ranges render exactly as before, multi-year ranges additionally show year markers.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）— no Rust changes
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 — no i18n strings changed (year digits come from `toLocaleDateString`)
