### PR TITLE
fix(relay): 补注册 relay_open_usage，修复「查看用量」点击报 Command not found

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1642,6 +1642,7 @@ pub fn run() {
             commands::relay_balance,
             commands::relay_reconciliation,
             commands::relay_purchase,
+            commands::relay_open_usage,
             commands::relay_restore_official_login,
             commands::list_verification_models,
             commands::start_model_verification,


### PR DESCRIPTION
## 问题

v6.5.0 起，中转站列表里点「查看用量」直接报错：`Command relay_open_usage not found`。

## 根因

「查看用量」开窗（#205）落地时命令**三处只齐了两处**：`relay.rs` 里带 `#[tauri::command]` 的定义有了、前端 `relay.ts` 的 invoke 有了，唯独漏了 `lib.rs` `generate_handler!` 的注册。Tauri 的 invoke 是运行时字符串，编译器与 CI 都无从发现；模块单测直接驱动 `open_usage_window` 内部函数，也绕过了注册层。

## 修法

在 `relay_purchase` 后补一行注册（同族命令放在一起）。一行修复。

## 验证

- `cargo check` / `cargo fmt --check` 通过；relay 模块 101 个单测全绿；全量 `cargo test` 3677 个单测 + 集成测试绿
- 全仓扫描同类漏注册：唯一另一个是 `switch_proxy_provider`（2025-12 上游死代码，无任何调用方），不在本次范围
