### PR TITLE
test: 清偿 clippy --all-targets 存量 + 命令注册完整性闸

### DIFF
--- a/src-tauri/src/proxy/auto_mode_e2e_tests.rs
+++ b/src-tauri/src/proxy/auto_mode_e2e_tests.rs
@@ -448,7 +448,7 @@ async fn passive_anomaly_lands_and_surfaces() {
         for _ in 0..250 {
             reports = crate::relay::model_verification::store::list_for_provider_ids(
                 &fx.db,
-                &[fx.cheap_id.clone()],
+                std::slice::from_ref(&fx.cheap_id),
             )
             .unwrap();
             if !reports.is_empty() {
@@ -498,7 +498,7 @@ async fn passive_anomaly_lands_and_surfaces() {
     assert!(
         crate::relay::model_verification::store::list_for_provider_ids(
             &fx.db,
-            &[fx.expensive_id.clone()],
+            std::slice::from_ref(&fx.expensive_id),
         )
         .unwrap()
         .is_empty()
@@ -510,7 +510,7 @@ async fn passive_anomaly_lands_and_surfaces() {
     tokio::time::sleep(std::time::Duration::from_millis(150)).await;
     let reports = crate::relay::model_verification::store::list_for_provider_ids(
         &fx.db,
-        &[fx.cheap_id.clone()],
+        std::slice::from_ref(&fx.cheap_id),
     )
     .unwrap();
     assert_eq!(reports.len(), 1, "干净流量不落库，异常报告不被干净流量稀释");

--- a/src-tauri/src/relay/model_verification/target.rs
+++ b/src-tauri/src/relay/model_verification/target.rs
@@ -117,101 +117,6 @@ fn fitness_for(
     }
 }
 
-#[cfg(test)]
-mod fitness_tests {
-    use super::*;
-    use crate::relay::transit::ModelProtocolCapabilities;
-    use std::collections::BTreeMap;
-
-    fn capabilities() -> ModelProtocolCapabilities {
-        // 两代协议值并存（实证快照的投影）：新版 openai_responses /
-        // anthropic_messages，旧版 responses。
-        crate::relay::transit::tests::capabilities_from_snapshot_json(
-            r#"{
-              "groups": [
-                {"name": "g-new", "models": [
-                  {"raw_model": "gpt-x", "standard_model": "gpt-x-std",
-                   "supported_protocols": ["openai_responses"]},
-                  {"raw_model": "claude-y", "standard_model": "claude-y-std",
-                   "supported_protocols": ["anthropic_messages"]}
-                ]},
-                {"name": "g-legacy", "models": [
-                  {"raw_model": "old-gpt", "supported_protocols": ["responses"]}
-                ]}
-              ]
-            }"#,
-        )
-    }
-
-    fn fitness(app: &str, group: Option<&str>, model: &str) -> ModelFitness {
-        let caps = capabilities();
-        fitness_for(&AppType::from_str(app).unwrap(), Some(&caps), group, model)
-    }
-
-    #[test]
-    fn supported_matches_both_protocol_generations() {
-        // 新版值。
-        assert_eq!(
-            fitness("codex", Some("g-new"), "gpt-x"),
-            ModelFitness::Supported
-        );
-        // 旧版值（老站只有 responses 键）。
-        assert_eq!(
-            fitness("codex", Some("g-legacy"), "old-gpt"),
-            ModelFitness::Supported
-        );
-        // claude 的 Messages。
-        assert_eq!(
-            fitness("claude", Some("g-new"), "claude-y"),
-            ModelFitness::Supported
-        );
-        // standard_model 名字也能命中（/v1/models 两种形态都可能是它）。
-        assert_eq!(
-            fitness("codex", Some("g-new"), "gpt-x-std"),
-            ModelFitness::Supported
-        );
-    }
-
-    #[test]
-    fn positive_coverage_excludes_cross_protocol_models() {
-        // 快照正向覆盖了（分组在、模型在），但声明的是另一族协议 —— 排除。
-        assert_eq!(
-            fitness("claude", Some("g-new"), "gpt-x"),
-            ModelFitness::UnsupportedProtocol
-        );
-        // claude 撞旧版 openai 分组：旧站没有 messages 形态的键，也不猜
-        // 没见过的值 —— 正向覆盖且不含 anthropic_messages ⇒ 排除。
-        assert_eq!(
-            fitness("claude", Some("g-legacy"), "old-gpt"),
-            ModelFitness::UnsupportedProtocol
-        );
-    }
-
-    #[test]
-    fn missing_coverage_is_unknown_never_excluded() {
-        // 分组不在快照（站点只发布部分分组是常态）。
-        assert_eq!(
-            fitness("codex", Some("g-unpublished"), "gpt-x"),
-            ModelFitness::Unknown
-        );
-        // 模型不在该分组清单。
-        assert_eq!(
-            fitness("codex", Some("g-new"), "unlisted-model"),
-            ModelFitness::Unknown
-        );
-        // 档位没记分组身份（旧数据）。
-        assert_eq!(fitness("codex", None, "gpt-x"), ModelFitness::Unknown);
-        // 站点没有公开数据。
-        let none = fitness_for(
-            &AppType::from_str("codex").unwrap(),
-            None,
-            Some("g-new"),
-            "gpt-x",
-        );
-        assert_eq!(none, ModelFitness::Unknown);
-    }
-}
-
 fn unavailable_models_error() -> AppError {
     AppError::Config(MODEL_LIST_UNAVAILABLE.into())
 }
@@ -314,5 +219,99 @@ fn resolve_relay(
         None => Err(AppError::Config(format!(
             "这个档位没有记录属于 {site_origin} 上的哪个账号，而那个站现在挂着多个账号。请用「获取密钥」重新生成它 —— 那会带上账号归属。"
         ))),
+    }
+}
+
+#[cfg(test)]
+mod fitness_tests {
+    use super::*;
+    use crate::relay::transit::ModelProtocolCapabilities;
+
+    fn capabilities() -> ModelProtocolCapabilities {
+        // 两代协议值并存（实证快照的投影）：新版 openai_responses /
+        // anthropic_messages，旧版 responses。
+        crate::relay::transit::tests::capabilities_from_snapshot_json(
+            r#"{
+              "groups": [
+                {"name": "g-new", "models": [
+                  {"raw_model": "gpt-x", "standard_model": "gpt-x-std",
+                   "supported_protocols": ["openai_responses"]},
+                  {"raw_model": "claude-y", "standard_model": "claude-y-std",
+                   "supported_protocols": ["anthropic_messages"]}
+                ]},
+                {"name": "g-legacy", "models": [
+                  {"raw_model": "old-gpt", "supported_protocols": ["responses"]}
+                ]}
+              ]
+            }"#,
+        )
+    }
+
+    fn fitness(app: &str, group: Option<&str>, model: &str) -> ModelFitness {
+        let caps = capabilities();
+        fitness_for(&AppType::from_str(app).unwrap(), Some(&caps), group, model)
+    }
+
+    #[test]
+    fn supported_matches_both_protocol_generations() {
+        // 新版值。
+        assert_eq!(
+            fitness("codex", Some("g-new"), "gpt-x"),
+            ModelFitness::Supported
+        );
+        // 旧版值（老站只有 responses 键）。
+        assert_eq!(
+            fitness("codex", Some("g-legacy"), "old-gpt"),
+            ModelFitness::Supported
+        );
+        // claude 的 Messages。
+        assert_eq!(
+            fitness("claude", Some("g-new"), "claude-y"),
+            ModelFitness::Supported
+        );
+        // standard_model 名字也能命中（/v1/models 两种形态都可能是它）。
+        assert_eq!(
+            fitness("codex", Some("g-new"), "gpt-x-std"),
+            ModelFitness::Supported
+        );
+    }
+
+    #[test]
+    fn positive_coverage_excludes_cross_protocol_models() {
+        // 快照正向覆盖了（分组在、模型在），但声明的是另一族协议 —— 排除。
+        assert_eq!(
+            fitness("claude", Some("g-new"), "gpt-x"),
+            ModelFitness::UnsupportedProtocol
+        );
+        // claude 撞旧版 openai 分组：旧站没有 messages 形态的键，也不猜
+        // 没见过的值 —— 正向覆盖且不含 anthropic_messages ⇒ 排除。
+        assert_eq!(
+            fitness("claude", Some("g-legacy"), "old-gpt"),
+            ModelFitness::UnsupportedProtocol
+        );
+    }
+
+    #[test]
+    fn missing_coverage_is_unknown_never_excluded() {
+        // 分组不在快照（站点只发布部分分组是常态）。
+        assert_eq!(
+            fitness("codex", Some("g-unpublished"), "gpt-x"),
+            ModelFitness::Unknown
+        );
+        // 模型不在该分组清单。
+        assert_eq!(
+            fitness("codex", Some("g-new"), "unlisted-model"),
+            ModelFitness::Unknown
+        );
+        // 档位没记分组身份（旧数据）。
+        assert_eq!(fitness("codex", None, "gpt-x"), ModelFitness::Unknown);
+        // 站点没有公开数据。
+        let none = fitness_for(
+            &AppType::from_str("codex").unwrap(),
+            None,
+            Some("g-new"),
+            "gpt-x",
+        );
+        assert_eq!(none, ModelFitness::Unknown);
     }
 }

--- a/src-tauri/src/relay/purchase.rs
+++ b/src-tauri/src/relay/purchase.rs
@@ -342,7 +342,6 @@ mod tests {
         }
     }
 
-    #[test]
     /// 充值窗与用量窗必须是**两个窗口**：label 不同（互不聚焦、互不顶掉），
     /// 标题带各自的页面语义；window-state 过滤要把两类都排除。
     #[test]
@@ -368,6 +367,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn window_labels_are_per_relay_and_collide_with_no_other_window() {
         // **按行分窗**是资损面的修法：全局单窗时「开新窗前销毁残留窗」会销毁一个
         // 可能正在付款的窗口（服务端订单不会因此取消，用户却失去确认页面）。

--- a/src-tauri/src/relay/remote_config.rs
+++ b/src-tauri/src/relay/remote_config.rs
@@ -993,7 +993,6 @@ mod tests {
             .is_none());
     }
 
-    #[test]
     /// usage_url 与 purchase_url 同一套校验（HTTPS + 同源 + 签名值），
     /// 理由不是付款，而是它开在**注入登录态的窗口**里——跨源等于带走站内会话。
     #[test]
@@ -1023,6 +1022,7 @@ mod tests {
         }
     }
 
+    #[test]
     fn purchase_url_rejects_http_and_cross_origin_entries() {
         for purchase_url in [
             "http://api-top.com/wallet",

--- a/src-tauri/tests/command_registration.rs
+++ b/src-tauri/tests/command_registration.rs
@@ -1,0 +1,144 @@
+//! 命令注册完整性闸：每个 `#[tauri::command]` 函数必须进 `generate_handler!`。
+//!
+//! 为什么要有这条：Tauri 的 `invoke` 是运行时字符串，命令漏注册时编译器、
+//! clippy、CI 全都无感（v6.5.0 的 `relay_open_usage` 漏注册带病发版，
+//! 用户点击「查看用量」即报 Command not found，v6.5.2 才修复）。本地
+//! 单测又直接驱动内部函数、绕过注册层，所以只能在源码层面收这道闸。
+//!
+//! 唯一豁免 [`KNOWN_UNREGISTERED`]：定义了但有意不注册的命令。豁免必须
+//! 双向核验（确实定义着、确实没注册），防止名单腐化成永久免死金牌。
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// 有定义、但有意不注册进 IPC 的命令（豁免名单，新增须写明原因）。
+const KNOWN_UNREGISTERED: &[&str] = &[
+    // 上游传下来的热切换命令，前后端都没有调用方；不删是为了少给上游
+    // 合并添冲突。见 src/commands/proxy.rs。
+    "switch_proxy_provider",
+];
+
+fn src_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+/// 从 lib.rs 的 `generate_handler![...]` 块里取已注册的命令名集合。
+fn registered_commands() -> BTreeMap<String, ()> {
+    let lib_rs = fs::read_to_string(src_dir().join("lib.rs")).expect("读 src/lib.rs");
+    let block = lib_rs
+        .split("generate_handler![")
+        .nth(1)
+        .expect("lib.rs 里应有 generate_handler! 注册块")
+        .split("];")
+        .next()
+        .expect("注册块应以 ]; 结束");
+
+    block
+        .lines()
+        .filter_map(|line| {
+            let entry = line.split("//").next()?.trim();
+            let entry = entry.strip_suffix(',')?;
+            let name = entry.rsplit("::").next()?.trim();
+            if name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') && !name.is_empty() {
+                Some((name.to_string(), ()))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// 扫全仓 `src/`，收集带 `#[tauri::command]` 属性的函数：名字 → 所在文件。
+fn defined_commands() -> BTreeMap<String, String> {
+    let mut defined = BTreeMap::new();
+    let mut files = vec![src_dir()];
+    while let Some(dir) = files.pop() {
+        for entry in fs::read_dir(&dir).expect("遍历 src/ 目录") {
+            let path = entry.expect("读目录项").path();
+            if path.is_dir() {
+                files.push(path);
+                continue;
+            }
+            if path.extension().is_none_or(|ext| ext != "rs") {
+                continue;
+            }
+            collect_from_file(&path, &mut defined);
+        }
+    }
+    defined
+}
+
+fn collect_from_file(path: &Path, defined: &mut BTreeMap<String, String>) {
+    let source = match fs::read_to_string(path) {
+        Ok(source) => source,
+        Err(_) => return,
+    };
+    let mut lines = source.lines().enumerate().peekable();
+    while let Some((_, line)) = lines.next() {
+        if !line.trim_start().starts_with("#[tauri::command") {
+            continue;
+        }
+        // 属性后面可能还隔着别的属性行 / 文档注释（含 #[tauri::command(...)]
+        // 带参形态自身的续行），一路向下找到函数签名行。
+        for (_, next) in lines.by_ref() {
+            // 文档/普通注释行里也可能出现 "fn " 字样，不算签名。
+            if next.trim_start().starts_with("//") {
+                continue;
+            }
+            let Some(fn_pos) = next.find("fn ") else {
+                continue;
+            };
+            let after_fn = next[fn_pos + 3..].trim_start();
+            let name: String = after_fn
+                .chars()
+                .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+                .collect();
+            if !name.is_empty() {
+                defined.insert(
+                    name,
+                    path.strip_prefix(src_dir())
+                        .unwrap_or(path)
+                        .display()
+                        .to_string(),
+                );
+            }
+            break;
+        }
+    }
+}
+
+#[test]
+fn every_defined_command_is_registered() {
+    let registered = registered_commands();
+    let defined = defined_commands();
+
+    let missing: Vec<&String> = defined
+        .keys()
+        .filter(|name| !registered.contains_key(*name))
+        .filter(|name| !KNOWN_UNREGISTERED.contains(&name.as_str()))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "以下 #[tauri::command] 未注册进 lib.rs 的 generate_handler!（前端 invoke 会报 \
+         Command not found）：{missing:?}\n若是有意不注册，请加入本测试的 \
+         KNOWN_UNREGISTERED 并写明原因。"
+    );
+}
+
+#[test]
+fn known_unregistered_allowlist_stays_honest() {
+    let registered = registered_commands();
+    let defined = defined_commands();
+
+    for name in KNOWN_UNREGISTERED {
+        assert!(
+            defined.contains_key(*name),
+            "豁免名单里的 {name} 已不存在于源码，请从 KNOWN_UNREGISTERED 删除"
+        );
+        assert!(
+            !registered.contains_key(*name),
+            "豁免名单里的 {name} 已经注册进 generate_handler! 了，请从 KNOWN_UNREGISTERED 删除"
+        );
+    }
+}


### PR DESCRIPTION
## 背景

v6.5.2 修复 `relay_open_usage` 漏注册时发现的测试基建债，两件事一个 PR（各一个 commit）。

## 一、清偿 clippy --all-targets 存量红（9 处，全在测试代码）

CI 的 clippy 不带 `--all-targets`（CLAUDE.md §四：本地才是超集），automerge 只看 CI——这批存量从未被线上拦下：

- **两处 `#[test]` 重复属性**（#205 引入，文档注释夹在两个属性中间）：去重后发现这两个测试此前**被注册两遍、每次跑两遍**，现恢复单次
- **两个漏写 `#[test]` 的测试**（#205 引入）：补属性复活，**均通过**——它们自合入起从未运行过
- target.rs（#206）：删未用 import、测试模块从文件中段挪到尾部（items-after-test-module）
- auto_mode_e2e_tests.rs（#191）：三处单元素切片 clone 改 `std::slice::from_ref`

## 二、命令注册完整性闸

新测试 `tests/command_registration.rs`：解析 `generate_handler!` 注册表，对照全仓 `#[tauri::command]` 函数全集，断言全部注册。**背景**：Tauri invoke 是运行时字符串，漏注册时编译器/clippy/CI 全无感（单测直接驱动内部函数也绕过注册层），`relay_open_usage` 就这样带病发版。豁免名单仅 `switch_proxy_provider`（2025-12 上游死代码、无调用方，不删是为了少给上游合并添冲突），且名单双向核验防腐化（名字消失/已被注册都会红）。

## 验证

- `cargo clippy --all-targets -- -D warnings` 全绿（修复前 9 红）
- 全量 `cargo test` 绿；复活的两测试单独跑过；闸测试 2 个断言过
- 无生产代码改动（target.rs 仅挪测试模块位置）
