### PR TITLE
ci: clippy 补 --all-targets，对齐本地闸与官方惯例

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
         run: cargo fmt --check --manifest-path src-tauri/Cargo.toml
 
       - name: Clippy
-        run: cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
+        run: cargo clippy --all-targets --manifest-path src-tauri/Cargo.toml -- -D warnings
 
       - name: Run tests
         run: cargo test --manifest-path src-tauri/Cargo.toml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,7 +280,8 @@ Tauri 的 npm↔crate 版本校验只在打包时触发（已踩过，见 `ca82a
 
 - 只动 `src/` / `tests/`：前端三件套（typecheck / format:check / test:unit）。
 - 只动 `src-tauri/`：后端三件套（fmt / clippy / test）。
-- 依据有两条：本地 clippy 带 `--all-targets`，是 CI 那条（不带）的**超集**；
+- 依据有两条：CI 的 clippy 与本地同一条命令（都带 `--all-targets`，2026-08-25
+  起对齐——此前 CI 不带它，测试代码的 lint 线上隐形，攒过 9 处存量才补齐）；
   CI 工具链走 `rust-toolchain.toml`（同本机版本，2026-08-16 #150 起 —— 别在
   workflow 里换回 `@stable`，那会覆盖钉版，重新制造「本地绿 CI 红」的漂移）。
 


### PR DESCRIPTION
## 改动

CI 的 Clippy 步补上 `--all-targets`（一行），并把 CLAUDE.md §四 里「本地是 CI 超集」的表述改为两边同一条命令。

## 为什么

- rust-clippy 官方 README 的 CI 示例就是 `cargo clippy --all-targets --all-features -- -D warnings`；不带 `--all-targets` 时 tests/benches/examples 完全不进 lint
- 本仓这条继承自上游、一直没带；automerge 只看 CI ⇒ 测试代码 lint 线上隐形，攒过 9 处存量（#212 清偿），根因就是执法点与文档标准之间这道缝
- 存量已清（#212 合入），本 PR 的 CI 会第一次以新口径跑 main + 本改动，应当绿

## 边界

- `--all-features`（官方示例的另一半）会点亮 `test-hooks` 门控代码、纳入从未 lint 过的部分，超出现有本地闸口径——留作单独决定，不在本 PR
- 代价：clippy 步多编译测试 target，每个后端 job 增几分钟

## 验证

本地 `cargo clippy --all-targets -- -D warnings` 在 main（含 #212）全绿；本 PR 的线上检查即新口径的首跑。
