### PR TITLE
fix(crowd): 共建告知改为启动时主动弹一次

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -113,6 +113,7 @@ import { DeepLinkImportDialog } from "@/components/DeepLinkImportDialog";
 import { CcSwitchImportEntry } from "@/components/settings/CcSwitchImportEntry";
 import { RelaySection } from "@/components/relay/RelaySection";
 import { StatsNoticeDialog } from "@/components/relay/StatsNoticeDialog";
+import { CrowdNoticeDialog } from "@/components/relay/CrowdNoticeDialog";
 import { useCodexSwitchGuard } from "@/components/relay/useCodexSwitchGuard";
 import { AgentsPanel } from "@/components/agents/AgentsPanel";
 import { UniversalProviderPanel } from "@/components/universal";
@@ -1957,6 +1958,10 @@ function App() {
           `statsNoticeConfirmed`，没表态就一个字节都不发）。
           它自带「读设置 → 判要不要弹」的全部状态，这里只挂一行。 */}
       <StatsNoticeDialog />
+
+      {/* 站点实测共建的告知弹窗：主动告知（升级后首启、未表态则弹一次）+
+          广场「加入共建」再入口共用这一个实例 —— 组件自带全部状态，这里只挂一行。 */}
+      <CrowdNoticeDialog />
 
       {/* 「点 Star 领注册礼」弹窗：新人引导事件与红点点击共用，状态机在组件内；
           这里只持开关（offer 在即弹）。 */}

--- a/src/components/relay/CrowdNoticeDialog.tsx
+++ b/src/components/relay/CrowdNoticeDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -15,48 +15,82 @@ import { crowdKeys } from "@/lib/query/crowd";
 import { settingsApi } from "@/lib/api";
 import type { Settings } from "@/types";
 
-interface CrowdNoticeDialogProps {
-  open: boolean;
-  /** 表态完成（无论参与与否）后回调 —— 调用方关弹窗、刷新展示。 */
-  onDone: () => void;
-}
+/** 广场实测区「加入共建」按钮唤起本弹窗用的窗口事件（拒绝过的用户再次加入的入口）。 */
+export const CROWD_NOTICE_OPEN_EVENT = "loongport:crowd-notice-open";
+
+/** 主动告知的延迟：避开首屏渲染与其它启动弹窗的拥挤（数值是体感值，无硬约束）。 */
+const AUTO_OPEN_DELAY_MS = 5_000;
 
 /**
  * 站点实测共建的告知弹窗（结构克隆 `StatsNoticeDialog`，文案换血）。
+ *
+ * ## 主动告知（维护者 2026-08-26 拍板，推翻早前「功能入口处弹」的方案）
+ *
+ * 早前方案把弹窗放在「首次点开实测区」—— 升级用户根本走不到那个入口，
+ * 功能对他们等于隐形；而数据共享的**同意必须先于功能可见**。所以现在
+ * 启动后若从未表态（`crowdMetricsNoticeConfirmed === undefined`）就主动弹一次。
+ *
+ * 每进程只主动弹一次；拒绝过/参与过都不再打扰，但广场锁定卡的「加入共建」
+ * 仍可通过 [`CROWD_NOTICE_OPEN_EVENT`] 再次唤起（改主意的入口）。
  *
  * 与匿名统计那条告知的三点不同，都是**条款本身**的差异：
  * 1. **默认关 + 对等条款**：不参与则不能查看其他用户的实测数据 —— 拒绝不是
  *    「少贡献」而是「少获得」，所以这一条必须出现在弹窗里，不能只写在文案里；
  * 2. **标识每日轮换**：没有持久安装 id 可披露，说的是「每日轮换的随机标识」；
  * 3. **数据是聚合指标**：小时桶里没有任何请求明细，边界讲「站点级聚合」即可。
- *
- * 受控组件（`open` 由调用方持有）：触发点是实测区的「加入共建」入口与设置开关，
- * 不是首启全局弹窗 —— 用户带着「我要看什么」的上下文来理解「我付出什么」。
  */
-export function CrowdNoticeDialog({ open, onDone }: CrowdNoticeDialogProps) {
+export function CrowdNoticeDialog() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
   const [settings, setSettings] = useState<Settings | null>(null);
   const [saving, setSaving] = useState(false);
+  const autoAskDone = useRef(false);
 
+  // 每次打开前取最新设置：save 要回写整份对象。取失败就这一轮关掉（下次再问）。
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
-    // 打开时才取设置：save 要回写整份对象，取失败就这一轮不弹（下次再问）。
     settingsApi
       .get()
       .then((s) => {
         if (!cancelled) setSettings(s);
       })
       .catch(() => {
-        if (!cancelled) onDone();
+        if (!cancelled) setOpen(false);
       });
     return () => {
       cancelled = true;
     };
-    // onDone 是父组件的稳定回调；settings 变化不该重取。
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
+
+  // 主动告知：启动后延迟弹一次，条件是「从未表态」。表过态（含拒绝）永不主动再弹。
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (autoAskDone.current) return;
+      autoAskDone.current = true;
+      settingsApi
+        .get()
+        .then((s) => {
+          if (s.crowdMetricsNoticeConfirmed === undefined) {
+            setSettings(s);
+            setOpen(true);
+          }
+        })
+        .catch(() => {
+          // 读不到设置就不弹 —— 门禁在后端，没表态什么都不会发生。
+        });
+    }, AUTO_OPEN_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, []);
+
+  // 广场「加入共建」的再入口（拒绝过的用户改主意）。
+  useEffect(() => {
+    const onOpenEvent = () => setOpen(true);
+    window.addEventListener(CROWD_NOTICE_OPEN_EVENT, onOpenEvent);
+    return () =>
+      window.removeEventListener(CROWD_NOTICE_OPEN_EVENT, onOpenEvent);
+  }, []);
 
   const respond = async (participate: boolean) => {
     if (!settings || saving) return;
@@ -71,10 +105,10 @@ export function CrowdNoticeDialog({ open, onDone }: CrowdNoticeDialogProps) {
       await queryClient.invalidateQueries({ queryKey: ["settings"] });
       // 参与的那一刻快照才有意义 —— 失效让它立即现拉（命令层门禁刚开）。
       await queryClient.invalidateQueries({ queryKey: crowdKeys.all });
-      onDone();
+      setOpen(false);
     } catch {
       // 存不进去：不置 confirmed（下次还能问），弹窗先收起别卡死用户。
-      onDone();
+      setOpen(false);
     } finally {
       setSaving(false);
     }
@@ -85,8 +119,8 @@ export function CrowdNoticeDialog({ open, onDone }: CrowdNoticeDialogProps) {
   return (
     <Dialog open onOpenChange={() => {}}>
       {/* 有意不给关闭途径（结构同 StatsNoticeDialog）：这一屏要一个明确表态，
-          两个按钮都能让它消失。zIndex 用 top：本弹窗从详情弹窗（也是 top）里
-          唤起，DOM 后挂载者在上层。 */}
+          两个按钮都能让它消失。zIndex 用 top：可能从详情弹窗（也是 top）里
+          经由事件唤起，DOM 后挂载者在上层。 */}
       <DialogContent className="max-w-[26rem] gap-0 p-6" zIndex="top">
         <DialogTitle className="text-base font-semibold">
           {t("loongport.crowd.notice.title")}

--- a/src/components/relay/__tests__/CrowdNoticeDialog.test.tsx
+++ b/src/components/relay/__tests__/CrowdNoticeDialog.test.tsx
@@ -1,0 +1,110 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createTestQueryClient } from "../../../../tests/utils/testQueryClient";
+import type { Settings } from "@/types";
+
+import {
+  CROWD_NOTICE_OPEN_EVENT,
+  CrowdNoticeDialog,
+} from "../CrowdNoticeDialog";
+
+const { get, save } = vi.hoisted(() => ({ get: vi.fn(), save: vi.fn() }));
+
+vi.mock("@/lib/api", () => ({
+  settingsApi: { get, save },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { resolvedLanguage: "zh" },
+  }),
+}));
+
+function makeSettings(overrides: Partial<Settings> = {}): Settings {
+  return {
+    minimizeToTrayOnClose: true,
+    ...overrides,
+  } as Settings;
+}
+
+function renderDialog() {
+  return render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <CrowdNoticeDialog />
+    </QueryClientProvider>,
+  );
+}
+
+/** 推进假时钟并冲刷其间结算的微任务（mock 的 get 是已 resolve 的 promise）。 */
+async function tick(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+describe("CrowdNoticeDialog 主动告知（维护者 2026-08-26 拍板：同意先于功能可见）", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    save.mockReset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("未表态：启动延迟后主动弹一次", async () => {
+    get.mockResolvedValue(makeSettings()); // crowdMetricsNoticeConfirmed === undefined
+    renderDialog();
+    expect(screen.queryByText("loongport.crowd.notice.title")).toBeNull();
+
+    await tick(5_100);
+    expect(screen.getByText("loongport.crowd.notice.title")).toBeTruthy();
+  });
+
+  it("表过态（含拒绝过）：启动后不主动弹", async () => {
+    get.mockResolvedValue(makeSettings({ crowdMetricsNoticeConfirmed: true }));
+    renderDialog();
+    await tick(6_000);
+    expect(screen.queryByText("loongport.crowd.notice.title")).toBeNull();
+  });
+
+  it("广场再入口事件可以唤起（拒绝过的用户改主意）", async () => {
+    get.mockResolvedValue(makeSettings({ crowdMetricsNoticeConfirmed: true }));
+    renderDialog();
+    await tick(6_000);
+    expect(screen.queryByText("loongport.crowd.notice.title")).toBeNull();
+
+    act(() => {
+      window.dispatchEvent(new Event(CROWD_NOTICE_OPEN_EVENT));
+    });
+    await tick(0);
+    expect(screen.getByText("loongport.crowd.notice.title")).toBeTruthy();
+  });
+
+  it("拒绝也写 confirmed（之后不再主动弹），且 enable=false", async () => {
+    // 对象持有者：闭包内赋值的 let 会被 TS 流分析窄化成 null，读不出来。
+    const captured: { saved?: Partial<Settings> } = {};
+    get.mockResolvedValue(makeSettings());
+    save.mockImplementation(async (s: Partial<Settings>) => {
+      captured.saved = s;
+    });
+    renderDialog();
+    await tick(5_100);
+
+    // fireEvent 而非 userEvent：假时钟下指针模拟的 setTimeout 链会死锁，
+    // 这里只要 onClick 触发 respond()。
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole("button", { name: "loongport.crowd.notice.decline" }),
+      );
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(save).toHaveBeenCalled();
+    expect(captured.saved?.crowdMetricsNoticeConfirmed).toBe(true);
+    expect(captured.saved?.crowdMetricsEnabled).toBe(false);
+    expect(screen.queryByText("loongport.crowd.notice.title")).toBeNull();
+  });
+});

--- a/src/components/relay/directory/RelayDirectoryPage.tsx
+++ b/src/components/relay/directory/RelayDirectoryPage.tsx
@@ -38,7 +38,7 @@ import {
   visibleDirectoryRange,
 } from "./directoryState";
 import { RelayDirectoryRow } from "./RelayDirectoryRow";
-import { CrowdNoticeDialog } from "../CrowdNoticeDialog";
+import { CROWD_NOTICE_OPEN_EVENT } from "../CrowdNoticeDialog";
 import { FirstVisitDomainDialog } from "./FirstVisitDomainDialog";
 import { TransitDetailDialog } from "./TransitDetailDialog";
 
@@ -88,9 +88,6 @@ export function RelayDirectoryPage({
   const [transitDetail, setTransitDetail] = useState<RelayDirectoryItem | null>(
     null,
   );
-  // 共建告知弹窗（从实测区的加入入口唤起）。
-  const [crowdNoticeOpen, setCrowdNoticeOpen] = useState(false);
-
   const { settings: appSettings } = useSettings();
   const crowdEnabled = appSettings?.crowdMetricsEnabled ?? false;
   const crowdSnapshotQuery = useQuery({
@@ -236,15 +233,12 @@ export function RelayDirectoryPage({
               : null
           }
           crowdEnabled={crowdEnabled}
-          onOpenCrowdNotice={() => setCrowdNoticeOpen(true)}
+          onOpenCrowdNotice={() =>
+            // 弹窗单实例挂在 App 层（主动告知 + 广场再入口共用），这里只广播。
+            window.dispatchEvent(new Event(CROWD_NOTICE_OPEN_EVENT))
+          }
         />
       )}
-      {/* 共建告知：从实测区的「加入共建」入口唤起，表态后设置与快照缓存
-          都会被弹窗自己失效 —— 这里只负责开关。 */}
-      <CrowdNoticeDialog
-        open={crowdNoticeOpen}
-        onDone={() => setCrowdNoticeOpen(false)}
-      />
       <div className="flex items-start justify-between gap-4 border-b border-border-default py-4">
         <div className="flex min-w-0 items-start gap-3">
           {!embedded && (


### PR DESCRIPTION
## 问题

v6.7.0 的共建告知放在「首次点开实测区」触发——升级用户走不到那个入口，功能对存量用户等于隐形。维护者拍板：**数据共享的同意必须先于功能可见**，改为启动时主动弹。

（事实核查附注：v6.7.0 的默认值是 false、上传门禁在后端设置层，本 PR 之前不存在未经同意上传的可能；本 PR 修的是「告知不可达」，不是隐私洞。）

## 改动

- `CrowdNoticeDialog` 自管理 open：启动 5s 后 `crowdMetricsNoticeConfirmed === undefined` 则主动弹一次（每进程一次，表过态永不主动再弹）
- 单实例上移 App.tsx（与 StatsNoticeDialog 同位）；广场「加入共建」按钮改派发 `CROWD_NOTICE_OPEN_EVENT` 窗口事件（拒绝过的用户改主意的再入口）
- 拒绝同样写 confirmed + enable=false（闸测试钉住）

## 验证

- typecheck / format:check / vitest 1289+4 例全绿
- 新增行为测试 4 例：主动弹、表过态不弹、事件再唤起、拒绝写 confirmed 且 enable=false