### PR TITLE
fix(updater): 更新检查双端点（官网代理优先、GitHub 兜底）

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -83,6 +83,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDREODJCRjlEMzJEMUYyMzcKUldRMzh0RXluYitDVFNQVXM5SFdSaGxrMUJlSWNnTDdicm14Y2YrV2NHOUdsdDN5SzNCS1V5UXgK",
       "endpoints": [
+        "https://loongport.dev/api/latest.json",
         "https://github.com/SailingLoong/LoongPort/releases/latest/download/latest.json"
       ]
     }


### PR DESCRIPTION
配套 website PR #12（/api/latest.json 缓存代理）。tauri.conf.json 的 endpoints 由单 GitHub 直链改为双端点：国内可达的 loongport.dev 代理优先、GitHub 直连兜底。旧版本更新到本版后即获得弹性端点。