### PR TITLE
fix(codex): 模型目录不再把 max_context_window 钉成表值，1M 开关恢复生效

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,29 @@
 3. **子模块指针一 bump 行号就集体失准**（纯注释 commit 也能让整片下移）。指针不自动 bump
    所以当前稳；bump 那天要么重新生成，要么降级成「只读结构、不引行号」。
 
+### 改 codex 模型目录 / 上下文窗口：三条外部事实（对着 codex-rs 源码核实过）
+
+1. **本地 catalog 是该 provider 的唯一权威**。config.toml 配了 `model_catalog_json` 后，
+   codex 给这个 provider 建 `StaticModelsManager`（model-provider/src/provider.rs），
+   官方 `models_cache.json` 的元数据**完全不参与** —— catalog 里写 262144，codex 就真跑
+   256k（比官方默认 272k 还低）。别拿官方缓存推断生成档位上的行为。
+2. **`model_context_window` 会被 `max_context_window` 钳制**。config.toml 顶层的
+   `model_context_window`（「1M 上下文窗口」开关写的值）在 codex 侧先
+   `min(该模型 entry 的 max_context_window)` 再生效（models-manager `with_config_overrides`，
+   官方测试名就叫 `model_context_window_override_clamps_to_max_context_window`）。
+   曾把映射表值同时钉进两个键，导致 1M 开关对任何填了窗口的行静默失效 —— PR #221 修根：
+   中性路径只写 `context_window`、不声明上限；厂商镜像路径保留厂商 max、用户值更高时抬升。
+3. **官方 catalog 的形状是两个不同的值**：`context_window`=默认窗口（官方模型当前全是
+   272k，2026-08 快照、会漂移），`max_context_window`=上限（gpt-5.4=1M、5.6 系=872k、
+   5.5/5.4-mini=272k）。`max_context_window` 是 serde 全可选字段，缺省=不钳制；
+   `auto_compact_token_limit` 缺省时按窗口 90% 推导。
+
+修后语义：映射表「上下文窗口」= 该模型默认窗口（逐模型可不同，与官方形状对齐）；
+1M 开关 = 全局覆盖（codex 官方对 `model_context_window` 的定义）；catalog 启动时加载，
+改完要重启 codex。生成逻辑全在 `codex_config.rs`：`codex_model_catalog_from_settings`
+入口（含 config 顶层 `model_context_window` 拾取）→ `codex_catalog_model_entry`
+（中性模板）/ `codex_vendor_catalog_model_entry`（厂商官方目录镜像）。
+
 ## 三、LoongPort 自己的代码在哪
 
 ```

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1331,8 +1331,13 @@ fn codex_catalog_model_entry(
     entry_obj.insert("description".to_string(), json!(display_name));
     if let Some(context_window) = context_window {
         entry_obj.insert("context_window".to_string(), json!(context_window));
-        entry_obj.insert("max_context_window".to_string(), json!(context_window));
     }
+    // Codex clamps a config.toml `model_context_window` override to each
+    // catalog entry's `max_context_window` (models-manager
+    // `with_config_overrides`), so pinning max to the table value silently
+    // defeated the 1M-context opt-in for every row with an explicit window.
+    // For relay models we don't know the real ceiling — don't claim one.
+    entry_obj.remove("max_context_window");
     entry_obj.insert("priority".to_string(), json!(1000 + priority));
     entry_obj.insert("additional_speed_tiers".to_string(), json!([]));
     entry_obj.insert("service_tiers".to_string(), json!([]));
@@ -1891,7 +1896,14 @@ fn codex_vendor_catalog_model_entry(
     }
     if let Some(context_window) = spec.context_window {
         entry_obj.insert("context_window".to_string(), json!(context_window));
-        entry_obj.insert("max_context_window".to_string(), json!(context_window));
+        // The vendor entry's max is real gateway data — keep it unless the
+        // user's window exceeds it. A ceiling below the declared window both
+        // contradicts the row and lets Codex clamp `model_context_window`
+        // overrides back down to the old max.
+        let vendor_max = entry_obj.get("max_context_window").and_then(Value::as_u64);
+        if vendor_max.is_none_or(|max| max < context_window) {
+            entry_obj.insert("max_context_window".to_string(), json!(context_window));
+        }
     }
     if let Some(parallel) = spec.supports_parallel_tool_calls {
         entry_obj.insert("supports_parallel_tool_calls".to_string(), json!(parallel));
@@ -4620,6 +4632,14 @@ base_url = "https://production.api/v1"
             Some(272_000),
             "unset model context must inherit the Codex template instead of shrinking to 128K"
         );
+        for entry in models {
+            assert!(
+                entry.get("max_context_window").is_none(),
+                "neutral entries must not declare a ceiling: Codex clamps \
+                 model_context_window overrides to max_context_window, which \
+                 would defeat the 1M opt-in for rows with an explicit window"
+            );
+        }
 
         let configured_catalog = codex_model_catalog_from_specs(
             &specs,
@@ -4640,6 +4660,12 @@ base_url = "https://production.api/v1"
                 .and_then(Value::as_u64),
             Some(500_000),
             "top-level configured context must override the Codex template"
+        );
+        assert!(
+            configured_catalog["models"][1]
+                .get("max_context_window")
+                .is_none(),
+            "the configured-context fallback must not pin max either"
         );
         assert!(
             models[0].get("model_messages").is_some(),
@@ -5084,6 +5110,11 @@ wire_api = "responses"
             flash.get("context_window").and_then(|v| v.as_u64()),
             Some(1_048_576)
         );
+        assert_eq!(
+            flash.get("max_context_window").and_then(|v| v.as_u64()),
+            Some(1_048_576),
+            "the vendor's own ceiling is real gateway data and survives mirroring"
+        );
         // Explicit user display name still wins over the official one.
         assert_eq!(
             flash.get("display_name").and_then(|v| v.as_str()),
@@ -5100,14 +5131,49 @@ wire_api = "responses"
             pro.get("context_window").and_then(|v| v.as_u64()),
             Some(500_000)
         );
+        // …but only lowers the window, not the ceiling: the official max
+        // stays so Codex-side `model_context_window` overrides are not
+        // clamped back down to the user's smaller value.
         assert_eq!(
             pro.get("max_context_window").and_then(|v| v.as_u64()),
-            Some(500_000)
+            Some(1_048_576)
         );
         // …while the untouched official display name is kept.
         assert_eq!(
             pro.get("display_name").and_then(|v| v.as_str()),
             Some("DeepSeek-V4-Pro")
+        );
+    }
+
+    #[test]
+    fn vendor_user_window_above_official_max_raises_ceiling() {
+        // A user window larger than the vendor's declared max must raise the
+        // ceiling with it: keeping the old max would leave a ceiling below the
+        // row's own window and let Codex clamp `model_context_window`
+        // overrides back down to the vendor value.
+        let settings = json!({
+            "modelCatalog": {
+                "models": [{ "model": "deepseek-v4-flash", "contextWindow": 2_000_000 }]
+            }
+        });
+
+        let catalog = codex_model_catalog_from_settings(
+            &settings,
+            DEEPSEEK_NATIVE_CONFIG,
+            CodexCatalogToolProfile::NativeResponses,
+        )
+        .expect("vendor catalog generation should not error")
+        .expect("non-empty modelCatalog must yield a catalog");
+
+        let flash = &catalog["models"][0];
+        assert_eq!(
+            flash.get("context_window").and_then(|v| v.as_u64()),
+            Some(2_000_000)
+        );
+        assert_eq!(
+            flash.get("max_context_window").and_then(|v| v.as_u64()),
+            Some(2_000_000),
+            "a user window above the vendor max must lift the ceiling, not keep it below the window"
         );
     }
 


### PR DESCRIPTION
## 问题

模型映射表每行的「上下文窗口」值被同时写进生成 catalog 的 `context_window` 和 `max_context_window`。而 Codex 对 config.toml 顶层 `model_context_window`（即「1M 上下文窗口」开关写入的值）的处理是**先钳到该模型 catalog entry 的 `max_context_window` 再生效**（codex-rs models-manager `with_config_overrides`，官方测试名即 `model_context_window_override_clamps_to_max_context_window`）。

结果：只要模型行里填了上下文窗口，1M 开关和「压缩阈值」对该模型静默失效（1050000 被 min(表值) 钳回）。这也顺带解释了为什么生成的档位里没有大窗口升级入口——官方 catalog 本来就是 context=272k / max=872k 两个不同值，钉成同值抹掉了这层语义。

## 修法（修根：一个值只承担一个职责）

- **中性模板路径**：表值只写 `context_window`；中转站模型没有已知真实上限，catalog 不再声明 `max_context_window`（serde 全可选，缺省时 Codex 对 config 覆盖不做钳制）
- **官方厂商目录路径**（如 DeepSeek 原生 /responses）：厂商的 max 是网关真实数据，保留；仅当用户窗口超过厂商 max 时抬升，避免出现「上限低于窗口」的自相矛盾

## 语义（修后）

- 模型行「上下文窗口」= 该模型的默认窗口（逐模型可不同，与官方 catalog 形状一致）
- 1M 开关 = 全局覆盖，对任何模型生效（Codex 官方语义：`model_context_window` 是显式覆盖）
- 生效方式不变：重新保存/切换该 provider 后 catalog 重生成，重启 Codex 加载

## 测试

- 中性路径：所有生成 entry 断言无 `max_context_window`（含模板继承值与 config 回填值两条来路）
- 厂商路径：用户值低于厂商 max 时保留厂商 max；高于时抬升（新增 `vendor_user_window_above_official_max_raises_ceiling`）
- `cargo test --lib codex_config` 98 过 / clippy --all-targets --all-features 0 警告 / fmt 干净