### PR TITLE
fix(update): 预下载 set_ready 加版本守卫，防被取代任务后到覆盖

### DIFF
--- a/src-tauri/src/services/app_update.rs
+++ b/src-tauri/src/services/app_update.rs
@@ -49,6 +49,12 @@ fn prestage_action(staged: Option<&str>, available: Option<&str>) -> PrestageAct
     }
 }
 
+/// `set_ready` 的发布守卫：只有当前 Downloading 槽位仍属于同版本时才允许发布。
+/// 后到的旧版本任务完成（已被更新版本取代）不得覆盖新状态。
+fn should_publish_ready(current: &StageInner, version: &str) -> bool {
+    matches!(current, StageInner::Downloading { version: v, .. } if v == version)
+}
+
 /// 已就绪的预下载产物：`Update` 对象 + 安装包落盘路径。
 struct ReadyUpdate {
     update: Update,
@@ -134,7 +140,15 @@ impl AppUpdateStage {
     }
 
     fn set_ready(&self, version: String, ready: Box<ReadyUpdate>) {
-        *self.lock() = StageInner::Ready { version, ready };
+        let mut inner = self.lock();
+        if should_publish_ready(&inner, &version) {
+            *inner = StageInner::Ready { version, ready };
+        } else {
+            // 一个已被更新版本取代的预下载任务后到完成：不发布（否则会把
+            // 更新的 Downloading/Ready 顶掉，点升级时装到被取代的旧版），
+            // 并清掉刚写盘的过期产物。
+            let _ = std::fs::remove_file(&ready.installer);
+        }
     }
 
     /// 预下载失败：只在仍处于同版本 Downloading 时退回 Idle（不覆盖新版本就绪态）。
@@ -431,7 +445,10 @@ pub async fn check(app: &tauri::AppHandle) -> Result<AppUpdateCheckResult, AppEr
 
 #[cfg(test)]
 mod tests {
-    use super::{app_update_check_timeout, prestage_action, AppUpdateCheckResult, PrestageAction};
+    use super::{
+        app_update_check_timeout, prestage_action, should_publish_ready, AppUpdateCheckResult,
+        PrestageAction, StageInner,
+    };
     use std::time::Duration;
 
     #[test]
@@ -447,6 +464,21 @@ mod tests {
         assert_eq!(prestage_action(Some("6.8.3"), Some("6.8.3")), Keep);
         // 应用跨版本运行，来了更新的版本：换目标重新预下载。
         assert_eq!(prestage_action(Some("6.8.3"), Some("6.8.4")), Start);
+    }
+
+    #[test]
+    fn stale_prestage_completion_never_supersedes_newer_state() {
+        use tokio::sync::oneshot;
+
+        let downloading = |version: &str| StageInner::Downloading {
+            version: version.to_string(),
+            done: Some(oneshot::channel().1),
+        };
+        // 只有仍处于同版本 Downloading 时才发布就绪。
+        assert!(should_publish_ready(&downloading("6.9.0"), "6.9.0"));
+        // 后到的旧版本完成不得覆盖更新版本的下载，也不得在 Idle（更新消失）时发布。
+        assert!(!should_publish_ready(&downloading("6.9.1"), "6.9.0"));
+        assert!(!should_publish_ready(&StageInner::Idle, "6.9.0"));
     }
 
     #[test]


### PR DESCRIPTION
## 问题

上游 PR #6907 移植版的 codex review（P2）指出同源竞态，LoongPort v6.9.0 的 PR #223 同样存在：新版本检查替换在途下载后，旧任务后到完成时 `set_ready` 无条件覆盖新的 Downloading/Ready 状态——点升级可能装到被取代的旧版，且新产物文件成孤儿。

## 修法

- `set_ready` 加与 `set_failed` 对称的版本守卫：仅当 Downloading 槽位仍属同版本才发布；否则删除刚写盘的过期产物
- 守卫提取为纯函数 `should_publish_ready`，配套单测（同版本发布/跨版本拒绝/Idle 拒绝）

## 测试

`cargo test --lib app_update` 7 过（+1 新测试）；clippy 0 警告；fmt 干净