### PR TITLE
fix(proxy): 保留对话中段 system 消息以保住前缀缓存（上游 #6941）

### DIFF
--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -158,14 +158,19 @@ pub fn anthropic_to_openai_with_reasoning_content(
                 messages.push(json!({"role": "system", "content": text}));
             }
         } else if let Some(arr) = system.as_array() {
+            // 顶层 system 数组合并为一条 system 消息（跨轮字节稳定，不影响前缀缓存）
+            let mut parts = Vec::new();
             for msg in arr {
                 if let Some(text) = msg.get("text").and_then(|t| t.as_str()) {
                     let text = strip_leading_anthropic_billing_header(text);
                     if text.is_empty() {
                         continue;
                     }
-                    messages.push(json!({"role": "system", "content": text}));
+                    parts.push(text.to_string());
                 }
+            }
+            if !parts.is_empty() {
+                messages.push(json!({"role": "system", "content": parts.join("\n")}));
             }
         }
     }
@@ -180,7 +185,6 @@ pub fn anthropic_to_openai_with_reasoning_content(
         }
     }
 
-    normalize_openai_system_messages(&mut messages);
     result["messages"] = json!(messages);
 
     // 转换参数 — o-series 模型需要 max_completion_tokens
@@ -302,57 +306,6 @@ fn map_tool_choice_to_chat(tool_choice: &Value) -> Value {
             _ => tool_choice.clone(),
         },
         _ => tool_choice.clone(),
-    }
-}
-
-fn normalize_openai_system_messages(messages: &mut Vec<Value>) {
-    let system_count = messages
-        .iter()
-        .filter(|message| message.get("role").and_then(|value| value.as_str()) == Some("system"))
-        .count();
-
-    if system_count == 0 {
-        return;
-    }
-
-    if system_count == 1 {
-        if let Some(index) = messages.iter().position(|message| {
-            message.get("role").and_then(|value| value.as_str()) == Some("system")
-        }) {
-            if index > 0 {
-                let message = messages.remove(index);
-                messages.insert(0, message);
-            }
-        }
-        return;
-    }
-
-    let mut parts = Vec::new();
-    messages.retain(|message| {
-        if message.get("role").and_then(|value| value.as_str()) != Some("system") {
-            return true;
-        }
-
-        match message.get("content") {
-            Some(Value::String(text)) if !text.is_empty() => parts.push(text.clone()),
-            Some(Value::Array(content_parts)) => {
-                let text = content_parts
-                    .iter()
-                    .filter_map(|part| part.get("text").and_then(|value| value.as_str()))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                if !text.is_empty() {
-                    parts.push(text);
-                }
-            }
-            _ => {}
-        }
-
-        false
-    });
-
-    if !parts.is_empty() {
-        messages.insert(0, json!({"role": "system", "content": parts.join("\n")}));
     }
 }
 
@@ -986,6 +939,40 @@ mod tests {
             "You are Claude Code.\nBe concise."
         );
         assert!(result["messages"][0].get("cache_control").is_none());
+    }
+
+    #[test]
+    fn test_anthropic_to_openai_preserves_mid_conversation_system_in_place() {
+        // Claude Code 会在对话中间注入 system 消息（如 <total_tokens>），
+        // 必须保持原位，不合并不上提，否则破坏前缀缓存。
+        let input = json!({
+            "model": "claude-3-sonnet",
+            "max_tokens": 1024,
+            "system": "You are Claude Code.",
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there!"},
+                {"role": "system", "content": "<total_tokens>14963538 tokens left</total_tokens>"},
+                {"role": "user", "content": "Continue"}
+            ]
+        });
+
+        let result = anthropic_to_openai(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        // 顶层 system 在最前面
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[0]["content"], "You are Claude Code.");
+
+        // 中途 system 保持原位（第 3 条，index=3），不被合并或上提
+        assert_eq!(messages[3]["role"], "system");
+        assert_eq!(
+            messages[3]["content"],
+            "<total_tokens>14963538 tokens left</total_tokens>"
+        );
+
+        // 总共 5 条消息，没有合并
+        assert_eq!(messages.len(), 5);
     }
 
     #[test]


### PR DESCRIPTION
## 背景

整并上游 v3.20.1 关键修复第一弹。

上游 farion1231/cc-switch #6941（d8065cc6）：`normalize_openai_system_messages` 会把对话中段的 system 消息全部搬到头部，Claude Code 每轮注入 `<total_tokens>` 元数据型 system 消息时，头部字节每轮都变，上游 radix prefix cache 每轮全灭——表现为中转站上游成本直接上升。

## 修法（与上游逐字对齐）

- 顶层 `system` 数组仍合并为一条 system 消息（跨轮字节稳定，不影响前缀缓存）
- `messages` 数组里的中段 system 消息保位、不合并、不重排
- 删除 `normalize_openai_system_messages`
- 带上游回归测试 `test_anthropic_to_openai_preserves_mid_conversation_system_in_place`

本文件与修前上游逐字一致，cherry-pick 干净落地（claude.rs:437 是活调用路径）。

## 有意不动：`collapse_system_messages_to_head`

评估过 `transform_codex_chat.rs` 的同型合并（responses→chat 桥接），结论是与上游判断对齐、不动：

- 打爆缓存的「每轮变化的 system 注入」是 Claude Code 特有行为，走本 PR 修的 anthropic→openai 路径；codex 的 developer 指令以顶层 instructions 为主，中段罕见且内容稳定
- MiniMax 严格要求 system 只能首条（否则 2013）是真实约束，该路径面向 chat-only 上游，收紧成「仅 MiniMax 生效」需要把上游能力穿透进纯转换函数，形状改动留给真实故障报告再说

## 验证

- `cargo fmt --check` 通过
- `cargo test --lib transform::` 67 通过（含新回归测试）