### PR TITLE
feat(relay): grok 档位支持「支持的模型」目录与选模型

### DIFF
--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -3386,6 +3386,17 @@ fn persist_provision_batch(
                 candidate.models.as_deref(),
                 provision::ProvisionStyle::default(),
             )
+        } else if matches!(app_type, AppType::GrokBuild) {
+            // grokbuild 同样落模型目录（收全部文本模型，见生成侧注释）——
+            // 主界面「支持的模型」芯片与托盘「模型」子菜单都从它取
+            provision::settings_config_with_models(
+                app_type,
+                &candidate.api_key,
+                &display_name,
+                &base_url,
+                &candidate.model,
+                candidate.models.as_deref(),
+            )
         } else {
             provision::settings_config_for(
                 app_type,
@@ -4421,8 +4432,8 @@ fn preserve_supported_codex_model(
 }
 
 /// [`preserve_supported_codex_model`] 的跨平台版：claude / gemini 走 env 形状
-/// （剥掉 `[1M]` 声明后对新目录查成员资格），其余平台没有「选模型」概念，
-/// 新默认直接接管。
+/// （剥掉 `[1M]` 声明后对新目录查成员资格），grokbuild 走 TOML 形状，其余平台
+/// 没有「选模型」概念，新默认直接接管。
 fn preserve_supported_model(
     app_type: &AppType,
     defaults: serde_json::Value,
@@ -4434,8 +4445,25 @@ fn preserve_supported_model(
             let catalog = models_from_settings(&defaults);
             provision::preserve_supported_env_model(app_type, defaults, previous, &catalog)
         }
+        AppType::GrokBuild => preserve_supported_grok_model(defaults, previous),
         _ => defaults,
     }
+}
+
+/// [`preserve_supported_codex_model`] 的 grok 版：读旧选中值（TOML 选中模型表的
+/// `model` 字段，[`provision::selected_model`]）对新目录查成员资格，命中就把新
+/// 默认的该字段改回旧值 —— profile 名、端点、密钥都不动。
+fn preserve_supported_grok_model(
+    defaults: serde_json::Value,
+    previous: &serde_json::Value,
+) -> serde_json::Value {
+    let Some(old) = provision::selected_model(&AppType::GrokBuild, previous) else {
+        return defaults;
+    };
+    if !models_from_settings(&defaults).iter().any(|m| m == &old) {
+        return defaults;
+    }
+    select_grok_model(&defaults, &old).unwrap_or(defaults)
 }
 
 fn select_codex_model(
@@ -4459,6 +4487,24 @@ fn select_codex_model(
         .ok_or_else(|| AppError::Config("这个 Codex 档位缺少 config.toml".to_string()))?;
     let updated_config = crate::codex_config::update_codex_toml_field(config, "model", model)
         .map_err(AppError::Config)?;
+    let mut updated = settings.clone();
+    updated["config"] = serde_json::Value::String(updated_config);
+    Ok(updated)
+}
+
+/// [`select_codex_model`] 的 grok 版（成员资格校验由调用方对着目录做，与 env 分支
+/// 对齐）：改写 config TOML 里选中模型表的 `model` 字段。profile 名
+/// （`models.default` 指向的表名）、端点、密钥、上下文窗口都与模型无关，不动；
+/// toml_edit 保格式，用户的手工编辑不丢。
+fn select_grok_model(
+    settings: &serde_json::Value,
+    model: &str,
+) -> Result<serde_json::Value, AppError> {
+    let config = settings
+        .get("config")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| AppError::Config("这个 Grok 档位缺少 config.toml".to_string()))?;
+    let updated_config = crate::grok_config::update_selected_model_string(config, "model", model)?;
     let mut updated = settings.clone();
     updated["config"] = serde_json::Value::String(updated_config);
     Ok(updated)
@@ -4655,10 +4701,14 @@ async fn select_tier_model_impl(
     quit_chatgpt: bool,
 ) -> Result<SwitchTierResult, AppError> {
     // 支持选模型的平台：codex（config TOML）/ claude（env.ANTHROPIC_MODEL）/
-    // gemini（env.GEMINI_MODEL）。目录（modelCatalog）三个平台同一份形状。
-    if !matches!(app_type, AppType::Codex | AppType::Claude | AppType::Gemini) {
+    // gemini（env.GEMINI_MODEL）/ grokbuild（config TOML 选中模型表的 model 字段）。
+    // 目录（modelCatalog）各平台同一份形状。
+    if !matches!(
+        app_type,
+        AppType::Codex | AppType::Claude | AppType::Gemini | AppType::GrokBuild
+    ) {
         return Err(AppError::Config(
-            "模型选择目前只支持 Codex / Claude / Gemini 档位".to_string(),
+            "模型选择目前只支持 Codex / Claude / Gemini / Grok 档位".to_string(),
         ));
     }
     if !crate::relay::is_managed(provider_id) {
@@ -4675,6 +4725,19 @@ async fn select_tier_model_impl(
         .settings_config;
     let settings = match &app_type {
         AppType::Codex => select_codex_model(&original_settings, model)?,
+        AppType::GrokBuild => {
+            let bare = model.trim();
+            if bare.is_empty()
+                || !models_from_settings(&original_settings)
+                    .iter()
+                    .any(|candidate| candidate == bare)
+            {
+                return Err(AppError::Config(format!(
+                    "模型 {bare:?} 不在这个档位支持的模型列表中"
+                )));
+            }
+            select_grok_model(&original_settings, bare)?
+        }
         // env 形状：成员资格对着目录校验（select_codex_model 内置，这里对齐）
         _ => {
             let bare = model.trim();
@@ -6691,6 +6754,55 @@ mod tests {
         let removed = codex_settings("gpt-removed", &["gpt-removed"]);
         let reset = preserve_supported_codex_model(defaults, &removed);
         assert_eq!(provision::extract_model(&reset).as_deref(), Some("gpt-a"));
+    }
+
+    /// 形状对齐 [`relay::provision`] 生成侧（`deeplink::build_grokbuild_settings`
+    /// + `modelCatalog`）：选中模型在 `[model."<default>"]` 表的 `model` 字段。
+    fn grok_settings(model: &str, models: &[&str]) -> serde_json::Value {
+        serde_json::json!({
+            "config": format!(
+                "[models]\ndefault = \"{model}\"\n\n[model.\"{model}\"]\nmodel = \"{model}\"\nbase_url = \"https://api.example.com\"\nname = \"Test\"\napi_key = \"sk-test\"\napi_backend = \"responses\"\ncontext_window = 500000\n"
+            ),
+            "modelCatalog": {
+                "models": models.iter().map(|model| serde_json::json!({ "model": model })).collect::<Vec<_>>()
+            }
+        })
+    }
+
+    #[test]
+    fn selecting_a_grok_model_only_updates_the_model_field() {
+        let settings = grok_settings("grok-4.5", &["grok-4.5", "grok-4.6"]);
+
+        let selected = select_grok_model(&settings, "grok-4.6").expect("supported model");
+        assert_eq!(
+            provision::selected_model(&AppType::GrokBuild, &selected).as_deref(),
+            Some("grok-4.6")
+        );
+        // profile 名（models.default 指向的表）、端点、密钥、目录都不动 ——
+        // 它们与模型无关
+        let config = selected["config"].as_str().expect("config text");
+        assert!(config.contains("[model.\"grok-4.5\"]"), "{config}");
+        assert!(config.contains("base_url = \"https://api.example.com\""));
+        assert!(config.contains("api_key = \"sk-test\""));
+        assert_eq!(selected["modelCatalog"], settings["modelCatalog"]);
+    }
+
+    #[test]
+    fn refreshing_a_managed_grok_tier_keeps_only_a_still_supported_selection() {
+        let defaults = grok_settings("grok-4.5", &["grok-4.5", "grok-4.6"]);
+        let previous = grok_settings("grok-4.6", &["grok-4.5", "grok-4.6"]);
+        let kept = preserve_supported_grok_model(defaults.clone(), &previous);
+        assert_eq!(
+            provision::selected_model(&AppType::GrokBuild, &kept).as_deref(),
+            Some("grok-4.6")
+        );
+
+        let removed = grok_settings("grok-gone", &["grok-gone"]);
+        let reset = preserve_supported_grok_model(defaults, &removed);
+        assert_eq!(
+            provision::selected_model(&AppType::GrokBuild, &reset).as_deref(),
+            Some("grok-4.5")
+        );
     }
 
     /// ⭐ `relay_list_sponsors` 发给前端的**键名**必须是 camelCase。

--- a/src-tauri/src/grok_config.rs
+++ b/src-tauri/src/grok_config.rs
@@ -226,7 +226,12 @@ pub fn extract_base_url(config_toml: &str) -> Option<String> {
     Some(extract_model_config(config_toml)?.base_url)
 }
 
-fn update_selected_model_string(
+/// 把选中模型表（`[model."<models.default>"]`）里的一个字符串字段改写为 `value`，
+/// toml_edit 保格式保注释，用户的手工编辑不丢。
+///
+/// 供托管档位的「选模型」改 `model` 字段用（profile 名、端点、密钥、窗口都与模型
+/// 无关，不动）；proxy 接管与 sk 刷新也走这里改 `base_url` / `api_key`。
+pub fn update_selected_model_string(
     config_toml: &str,
     field: &str,
     value: &str,

--- a/src-tauri/src/relay/provision.rs
+++ b/src-tauri/src/relay/provision.rs
@@ -893,12 +893,17 @@ pub fn extract_model(settings_config: &serde_json::Value) -> Option<String> {
 /// 从 settings_config 读档位**选中的模型**（跨平台）。
 ///
 /// codex 系读 config TOML 的 `model` 行（[`extract_model`]）；claude 读
-/// `env.ANTHROPIC_MODEL`；gemini 读 `env.GEMINI_MODEL`。其余平台（没有
-/// 「档位选模型」概念）返回 `None`。目录本身统一走 `modelCatalog`
-/// （`commands::models_from_settings`，与 codex 同一份形状）。
+/// `env.ANTHROPIC_MODEL`；gemini 读 `env.GEMINI_MODEL`；grokbuild 读 config TOML 里
+/// 选中模型表的 `model` 字段（[`grok_config::extract_model_config`]，与目录同一
+/// 标识空间）。其余平台（没有「档位选模型」概念）返回 `None`。目录本身统一走
+/// `modelCatalog`（`commands::models_from_settings`，与 codex 同一份形状）。
 pub fn selected_model(app_type: &AppType, settings: &serde_json::Value) -> Option<String> {
     let env_key = match app_type {
         AppType::Codex | AppType::CodexImage => return extract_model(settings),
+        AppType::GrokBuild => {
+            let config = settings.get("config")?.as_str()?;
+            return crate::grok_config::extract_model_config(config).map(|c| c.model);
+        }
         AppType::Claude => "ANTHROPIC_MODEL",
         AppType::Gemini => "GEMINI_MODEL",
         _ => return None,
@@ -1122,6 +1127,8 @@ const CODEX_MAIN_CANDIDATES: &[&str] = &["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.
 ///   挑出的模型名对支持 1M 的新一代模型附 `[1M]` 后缀声明（见 [`maybe_one_m`]）。
 /// - **codex**：主模型候选顺延（首位 `DEFAULT_MODEL` 命中即保持现状）。
 /// - **gemini**：优先取第一个 `gemini-*` 模型；没有时回落列表首项。
+/// - **grok**：`grok-*` 家族里取版本号新的那代（[`grok_model_rank`]）；没有该家族
+///   时回落列表首项。
 /// - **其它平台**：模型列表第一个文本模型。
 /// - **纯生图分组**（只有 `gpt-image-*`）：仍写最新的生图模型（复用作 `pick_model`）。
 /// - **列表拉不到**：回落 `DEFAULT_MODEL`（旧行为，最坏退化）。
@@ -1149,6 +1156,23 @@ pub fn pick_tier_models(app_type: &AppType, models: Option<&[String]>) -> TierMo
             main: models
                 .iter()
                 .find(|model| model.to_ascii_lowercase().starts_with("gemini-"))
+                .cloned()
+                .unwrap_or_else(|| models[0].clone()),
+            claude_roles: None,
+        },
+        AppType::GrokBuild => TierModels {
+            // 版本号排新而不是照抄列表首项（`normalize_model_names` 已排序，字典序会
+            // 把 grok-4.5 排在 grok-4.6 前面 —— 选旧弃新）。与 codex 的候选表不同，
+            // 这里不写死代名：grok 家族没有「跨全部站点查证过」的候选，而版本号是
+            // 模型名自带的数据，新一代自动跟上，不必改代码。
+            main: models
+                .iter()
+                .filter(|model| model.to_ascii_lowercase().starts_with("grok"))
+                .max_by(|a, b| {
+                    grok_model_rank(a)
+                        .cmp(&grok_model_rank(b))
+                        .then_with(|| a.as_str().cmp(b.as_str()))
+                })
                 .cloned()
                 .unwrap_or_else(|| models[0].clone()),
             claude_roles: None,
@@ -1271,6 +1295,26 @@ fn image_model_rank(model: &str) -> Vec<u32> {
         .filter(|seg| !seg.is_empty())
         .filter_map(|seg| seg.parse::<u32>().ok())
         .collect()
+}
+
+/// grok 家族模型名尾部的版本段（`grok-4.5` → `[4, 5]`），用于在多个 `grok-*` 里挑
+/// 最新一代。
+///
+/// 与 [`image_model_rank`] 同一动机：字典序会把 `grok-4.10` 排在 `grok-4.6` 前面、
+/// 把 `grok-4.5` 排在 `grok-4.6` 前面 —— 直接取排序后首项是**选旧弃新**。
+/// 取**最后一个 `-` 之后的版本号**：`grok-4.5` → `4.5`、`grok-code-4.6` → `4.6`。
+/// 尾段认不出数字（名字里没有版本号）返回空 —— 那种名字无从判断新旧，让它输给能判的。
+fn grok_model_rank(model: &str) -> Vec<u32> {
+    model
+        .rsplit('-')
+        .next()
+        .map(|tail| {
+            tail.split('.')
+                .filter(|seg| !seg.is_empty())
+                .filter_map(|seg| seg.parse::<u32>().ok())
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// 这个模型名是生图模型吗（[`IMAGE_MODEL_PREFIX`] 前缀）。
@@ -2356,6 +2400,70 @@ mod tests {
             settings.get("modelCatalog").is_none(),
             "没有 gemini-* 时不能写一个空目录"
         );
+    }
+
+    /// grok 档位落模型目录：收全部**文本**模型（生图剔除），与其它平台同一份
+    /// JSON 形状；选中模型落在 config TOML 的选中模型表里，`selected_model`
+    /// 读得回来（与目录同一标识空间）。
+    #[test]
+    fn grok_settings_persist_the_text_model_catalog() {
+        let models = vec![
+            "grok-4.5".to_string(),
+            "grok-code-4.5".to_string(),
+            "gpt-image-2".to_string(),
+        ];
+        let settings = settings_config_with_models(
+            &AppType::GrokBuild,
+            "sk-test",
+            "Test",
+            "https://api.example.com",
+            "grok-4.5",
+            Some(&models),
+        )
+        .expect("Grok config");
+
+        assert_eq!(
+            settings["modelCatalog"]["models"],
+            serde_json::json!([
+                { "model": "grok-4.5" },
+                { "model": "grok-code-4.5" }
+            ])
+        );
+        assert_eq!(
+            selected_model(&AppType::GrokBuild, &settings).as_deref(),
+            Some("grok-4.5")
+        );
+    }
+
+    /// grok 默认模型按版本号挑最新一代，不照抄排序后首项（字典序会把
+    /// `grok-4.5` 排在 `grok-4.6` 前面 —— 选旧弃新）；没有 grok 家族时回落首项。
+    #[test]
+    fn grok_default_picks_the_newest_generation() {
+        let models = vec![
+            "grok-4.5".to_string(),
+            "grok-code-4.5".to_string(),
+            "grok-4.6".to_string(),
+        ];
+        let picked = pick_tier_models(&AppType::GrokBuild, Some(&models));
+        assert_eq!(picked.main, "grok-4.6");
+        assert!(picked.claude_roles.is_none());
+
+        // 没有该家族 → 回落列表首项，不报错（目录是异源数据，宁可用也不炸）
+        let no_family = vec!["gpt-5.6-sol".to_string(), "gpt-5.6-terra".to_string()];
+        let picked = pick_tier_models(&AppType::GrokBuild, Some(&no_family));
+        assert_eq!(picked.main, "gpt-5.6-sol");
+    }
+
+    /// 版本段解析：`grok-4.5` → [4,5]、`grok-4.10` > `grok-4.6`、
+    /// 带别名的 `grok-code-4.6` 取尾段、认不出数字的排最后。
+    #[test]
+    fn grok_model_rank_extracts_the_trailing_version() {
+        assert_eq!(grok_model_rank("grok-4.5"), vec![4, 5]);
+        assert_eq!(grok_model_rank("grok-4"), vec![4]);
+        assert_eq!(grok_model_rank("grok-code-4.6"), vec![4, 6]);
+        assert!(grok_model_rank("grok-4.10") > grok_model_rank("grok-4.6"));
+        assert!(grok_model_rank("grok-custom").is_empty());
+        assert!(grok_model_rank("grok-4.5") > grok_model_rank("grok-custom"));
     }
 
     /// env 形状的选模型：写 env 键（claude 补 [1M]）；保留偏好对「目录里还有」

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -511,7 +511,7 @@ fn tray_menu_providers(
 /// 返回 `(当前模型, 目录)`；其余情况 `None`（不挂子菜单）。
 ///
 /// 与主界面 `TierInfo.models` 同一份 `modelCatalog`（`models_from_settings`）。
-/// 目录按平台落库（codex / claude / gemini），没有目录的 app 自然不挂；
+/// 目录按平台落库（codex / claude / gemini / grokbuild），没有目录的 app 自然不挂；
 /// 非托管 provider 没有「选模型」这个概念，不预埋。
 fn tier_model_choices(
     provider: &crate::provider::Provider,
@@ -680,7 +680,7 @@ pub fn handle_provider_tray_event(app: &tauri::AppHandle, event_id: &str) -> boo
                 return true;
             }
 
-            // 处理「模型」子菜单点击（只挂在 Codex 当前托管档位下）
+            // 处理「模型」子菜单点击（只挂在目录非空的当前托管档位下）
             if let Some(model) = suffix.strip_prefix(TIER_MODEL_EVENT_PREFIX) {
                 log::info!("切换{}档位模型: {model}", section.label);
                 let app_handle = app.clone();
@@ -930,9 +930,9 @@ fn handle_managed_tier_click(
     }
 }
 
-/// 托盘点「模型」子菜单：对**当前**托管 Codex 档位执行 `switch_tier_model_command`
+/// 托盘点「模型」子菜单：对**当前**托管档位执行 `switch_tier_model_command`
 /// （校验模型 ∈ 落库目录 → 更新 provider → 走切档位编排，失败回滚）。
-/// 模型子菜单只在当前档位是托管 Codex 项时才会挂出来，这里再验一遍是防
+/// 模型子菜单只在当前档位是托管项且目录非空时才会挂出来，这里再验一遍是防
 /// 菜单陈旧（刚切走、菜单还没重建）时点了个已不属于当前档位的模型。
 fn handle_tier_model_click(
     app: &tauri::AppHandle,
@@ -952,12 +952,14 @@ fn handle_tier_model_click(
     }
 
     // 点的就是当前模型 → 无操作（与主界面 `handleSelectTierModel` 的守卫对齐，
-    // 否则每次误点都会走一遍「退 ChatGPT」确认）。
+    // 否则每次误点都会走一遍「退 ChatGPT」确认）。读当前模型走按平台分派的
+    // `selected_model`（grok 档位的 config TOML 与 codex 不同形，codex 专用的
+    // `extract_model` 在那边读对只是靠行序的巧合）。
     let current = app_state
         .db
         .get_provider_by_id(&provider_id, app_type.as_str())?;
     if let Some(provider) = current {
-        if crate::relay::provision::extract_model(&provider.settings_config).as_deref()
+        if crate::relay::provision::selected_model(app_type, &provider.settings_config).as_deref()
             == Some(model)
         {
             return Ok(());


### PR DESCRIPTION
## Summary / 概述

grok 分组的中转站档位此前与 claude / codex / gemini 不同：provision 时 `/v1/models` 拉了却**不落 `modelCatalog`**，于是主界面分组卡上的「支持的模型」芯片、托盘「模型」子菜单都不出现，也没有点选默认模型的能力。本 PR 把 grokbuild 补齐到与其它平台同一形状（改动全部落在既有按平台分派的扩展位上，前端零改动）：

- `persist_provision_batch`：grokbuild 落库带模型目录（收全部文本模型，生图剔除——生成侧过滤逻辑本就覆盖非 codex 平台）
- `provision::selected_model`：grokbuild 读 config TOML 选中模型表（`[model."<default>"]`）的 `model` 字段，与目录同一标识空间
- `select_tier_model_impl`：放开 grokbuild；改写走 `grok_config::update_selected_model_string`（toml_edit 保格式，profile 名 / 端点 / 密钥 / 窗口都不动），成员资格校验对着目录做（与 codex 同一套）
- `preserve_supported_model`：刷新档位时保留「新目录里仍有」的 grok 选模偏好，上游下架则新默认接管
- `pick_tier_models`：grok 家族按模型名尾段版本号取最新一代（排序后首项会把 `grok-4.5` 排在 `grok-4.6` 前面——选旧弃新；不写死代名，新一代自动跟上）
- 托盘 `handle_tier_model_click` 的「点的是当前模型」守卫改用按平台分派的 `selected_model`（原来用 codex 专用的 `extract_model`，grok 档位能读对只是靠 TOML 行序的巧合；顺带让 claude / gemini 档位的托盘点选也获得与主界面对齐的当前模型无操作守卫）

存量 grok 档位在下一次「刷新 / 获取密钥」时经 preserve 路径**自动补上目录**，无需手动重建。

## Related Issue / 关联 Issue

无（维护者需求：grok 档位补齐「支持的模型」露出）

## Screenshots / 截图

纯后端数据链路补齐，UI 形状与 claude / codex 现有芯片一致，无新增界面元素。

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查（未动前端，跳过）
- [ ] `pnpm format:check` passes / 通过代码格式检查（未动前端，跳过）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（无新增用户可见文案）
