### PR TITLE
fix(proxy): 省心模式开启即含请求内故障转移（判据唯源 failover_active）

### DIFF
--- a/src-tauri/src/proxy/auto_mode_e2e_tests.rs
+++ b/src-tauri/src/proxy/auto_mode_e2e_tests.rs
@@ -427,6 +427,25 @@ async fn failing_tier_fails_over_and_returns_when_recovered() {
     fx.server.stop().await.expect("stop server");
 }
 
+/// 省心模式开启即含请求内故障转移：显式「自动故障转移」开关（默认关）不再
+/// 单独决定重试行为 —— 否则省心模式退化成「一次请求只试一家」，每个死档位
+/// 都把原始错误抛给 CLI，靠 CLI 自己的重试预算一家一家试。
+#[tokio::test]
+#[serial]
+async fn easy_mode_fails_over_in_request_even_with_failover_toggle_off() {
+    let fx = E2eFixture::new().await;
+    let mut config = fx.db.get_proxy_config_for_app("claude").await.unwrap();
+    config.auto_failover_enabled = false;
+    fx.db.update_proxy_config_for_app(config).await.unwrap();
+
+    fx.cheap.set_status(500).await;
+
+    let marker = response_text(send_message(fx.port, "sess-e2e-implied-0001").await).await;
+    assert_eq!(marker, "served-by-expensive");
+    assert_eq!(fx.cheap.hits(), 1, "故障档位只应被探测一次");
+    fx.server.stop().await.expect("stop server");
+}
+
 /// 4. 被动模型监控：换芯流量（Claude 线路回 OpenAI 形状）→ 异源指纹 Anomaly
 ///    落库 + history(source=passive) + 档位看板点亮；干净档位零报告；
 ///    转发本身不受观察影响（客户端仍拿到 200 与原样响应体）。

--- a/src-tauri/src/proxy/auto_strategy.rs
+++ b/src-tauri/src/proxy/auto_strategy.rs
@@ -148,6 +148,16 @@ pub fn is_auto_mode_enabled(db: &Database, app_type: &str) -> bool {
         .is_some_and(|value| value == "true")
 }
 
+/// 该 app 的故障转移行为（请求内换档、重试、超时）是否生效。
+///
+/// 显式开关或省心模式任一开启即生效：省心模式的产品语义就是系统自动挑档并无缝
+/// 切换，不依赖用户再去高级区打开旧开关（它默认关）。选路侧省心模式优先于故障
+/// 转移队列（`provider_router::select_providers`），这里是转发/响应侧的同一判据
+/// —— 两处必须同真同假，别各写一份。
+pub fn failover_active(db: &Database, app_type: &str, auto_failover_enabled: bool) -> bool {
+    auto_failover_enabled || is_auto_mode_enabled(db, app_type)
+}
+
 /// 读全局策略（缺省 cheapest）。
 pub fn get_strategy(db: &Database) -> AutoStrategy {
     db.get_setting(SETTING_STRATEGY)
@@ -732,6 +742,21 @@ mod tests {
 
         set_enabled(&db, "claude", false).unwrap();
         assert!(!is_auto_mode_enabled(&db, "claude"));
+    }
+
+    /// 故障转移生效判据：显式开关或省心模式任一开启即生效（按 app 隔离）。
+    #[test]
+    fn failover_active_when_either_source_enabled() {
+        let db = Database::memory().unwrap();
+        assert!(!failover_active(&db, "claude", false));
+        assert!(failover_active(&db, "claude", true));
+
+        set_enabled(&db, "claude", true).unwrap();
+        assert!(
+            failover_active(&db, "claude", false),
+            "省心模式开启即蕴含故障转移"
+        );
+        assert!(!failover_active(&db, "codex", false), "按 app 隔离");
     }
 
     /// 模型偏好过滤：有偏好时只留「目录含该模型」的档位（无目录档位不保留 ——

--- a/src-tauri/src/proxy/handler_context.rs
+++ b/src-tauri/src/proxy/handler_context.rs
@@ -37,6 +37,12 @@ pub struct RequestContext {
     pub start_time: Instant,
     /// 应用级代理配置（per-app，包含重试次数和超时配置）
     pub app_config: AppProxyConfig,
+    /// 本次请求的故障转移行为（请求内换档、重试、超时）是否启用：显式
+    /// 「自动故障转移」开关或省心模式任一开启即为真（判据唯源
+    /// [`auto_strategy::failover_active`]）。转发与响应侧统一读这里，别再各看
+    /// `app_config.auto_failover_enabled` —— 两处判据分叉时省心模式会退化成
+    /// 「单请求只试一家」，每个死档位都把原始错误抛给 CLI。
+    pub failover_active: bool,
     /// 选中的 Provider（故障转移链的第一个）
     pub provider: Provider,
     /// 完整的 Provider 列表（用于故障转移）
@@ -102,6 +108,13 @@ impl RequestContext {
             .await
             .map_err(|e| ProxyError::DatabaseError(e.to_string()))?;
 
+        // 故障转移行为判据（显式开关或省心模式），本请求内唯源
+        let failover_active = crate::proxy::auto_strategy::failover_active(
+            &state.db,
+            app_type_str,
+            app_config.auto_failover_enabled,
+        );
+
         // 从数据库读取整流器配置
         let rectifier_config = state.db.get_rectifier_config().unwrap_or_default();
         let optimizer_config = state.db.get_optimizer_config().unwrap_or_default();
@@ -160,6 +173,7 @@ impl RequestContext {
         Ok(Self {
             start_time,
             app_config,
+            failover_active,
             provider,
             providers,
             current_provider_id,
@@ -199,25 +213,24 @@ impl RequestContext {
     /// - 故障转移开启：超时配置正常生效（0 表示禁用超时）
     /// - 故障转移关闭：超时配置不生效（全部传入 0）
     pub fn create_forwarder(&self, state: &ProxyState) -> RequestForwarder {
-        let (non_streaming_timeout, first_byte_timeout, idle_timeout) =
-            if self.app_config.auto_failover_enabled {
-                // 故障转移开启：使用配置的值（0 = 禁用超时）
-                (
-                    self.app_config.non_streaming_timeout as u64,
-                    self.app_config.streaming_first_byte_timeout as u64,
-                    self.app_config.streaming_idle_timeout as u64,
-                )
-            } else {
-                // 故障转移关闭：不启用超时配置
-                log::debug!(
-                    "[{}] Failover disabled, timeout configs are bypassed",
-                    self.tag
-                );
-                (0, 0, 0)
-            };
+        let (non_streaming_timeout, first_byte_timeout, idle_timeout) = if self.failover_active {
+            // 故障转移开启：使用配置的值（0 = 禁用超时）
+            (
+                self.app_config.non_streaming_timeout as u64,
+                self.app_config.streaming_first_byte_timeout as u64,
+                self.app_config.streaming_idle_timeout as u64,
+            )
+        } else {
+            // 故障转移关闭：不启用超时配置
+            log::debug!(
+                "[{}] Failover disabled, timeout configs are bypassed",
+                self.tag
+            );
+            (0, 0, 0)
+        };
 
         // 故障转移关闭时强制 max_retries=0（仅尝试 1 个 provider），与「不超时 + 不切换」语义一致。
-        let max_retries = if self.app_config.auto_failover_enabled {
+        let max_retries = if self.failover_active {
             self.app_config.max_retries
         } else {
             0
@@ -264,7 +277,7 @@ impl RequestContext {
     /// - 故障转移关闭：返回 0（禁用超时检查）
     #[inline]
     pub fn streaming_timeout_config(&self) -> StreamingTimeoutConfig {
-        if self.app_config.auto_failover_enabled {
+        if self.failover_active {
             // 故障转移开启：使用配置的值（0 = 禁用超时）
             StreamingTimeoutConfig {
                 first_byte_timeout: self.app_config.streaming_first_byte_timeout as u64,

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -539,12 +539,11 @@ async fn handle_claude_transform(
     }
 
     // 非流式响应转换 (OpenAI/Responses → Anthropic)
-    let body_timeout =
-        if ctx.app_config.auto_failover_enabled && ctx.app_config.non_streaming_timeout > 0 {
-            std::time::Duration::from_secs(ctx.app_config.non_streaming_timeout as u64)
-        } else {
-            std::time::Duration::ZERO
-        };
+    let body_timeout = if ctx.failover_active && ctx.app_config.non_streaming_timeout > 0 {
+        std::time::Duration::from_secs(ctx.app_config.non_streaming_timeout as u64)
+    } else {
+        std::time::Duration::ZERO
+    };
     let enforce_codex_web_search_limit_while_aggregating =
         aggregate_codex_oauth_responses_sse && hosted_web_search_max_uses.is_some();
     let (mut response_headers, direct_anthropic_response, upstream_response) =
@@ -1217,12 +1216,11 @@ async fn handle_codex_responses_namespace_restore(
     // Non-streaming: restore the flattened function-call names in the full body,
     // then account usage from the (restore-neutral) Responses payload.
     let _connection_guard = connection_guard;
-    let body_timeout =
-        if ctx.app_config.auto_failover_enabled && ctx.app_config.non_streaming_timeout > 0 {
-            std::time::Duration::from_secs(ctx.app_config.non_streaming_timeout as u64)
-        } else {
-            std::time::Duration::ZERO
-        };
+    let body_timeout = if ctx.failover_active && ctx.app_config.non_streaming_timeout > 0 {
+        std::time::Duration::from_secs(ctx.app_config.non_streaming_timeout as u64)
+    } else {
+        std::time::Duration::ZERO
+    };
     let (mut response_headers, status, body_bytes) =
         read_decoded_body(response, ctx.tag, body_timeout).await?;
     strip_hop_by_hop_response_headers(&mut response_headers);
@@ -1417,12 +1415,11 @@ async fn handle_codex_chat_to_responses_transform(
     }
 
     let _connection_guard = connection_guard;
-    let body_timeout =
-        if ctx.app_config.auto_failover_enabled && ctx.app_config.non_streaming_timeout > 0 {
-            std::time::Duration::from_secs(ctx.app_config.non_streaming_timeout as u64)
-        } else {
-            std::time::Duration::ZERO
-        };
+    let body_timeout = if ctx.failover_active && ctx.app_config.non_streaming_timeout > 0 {
+        std::time::Duration::from_secs(ctx.app_config.non_streaming_timeout as u64)
+    } else {
+        std::time::Duration::ZERO
+    };
     let (mut response_headers, status, body_bytes) =
         read_decoded_body(response, ctx.tag, body_timeout).await?;
     let body_str = String::from_utf8_lossy(&body_bytes);
@@ -1577,12 +1574,11 @@ async fn handle_codex_anthropic_to_responses_transform(
         );
     }
 
-    let body_timeout =
-        if ctx.app_config.auto_failover_enabled && ctx.app_config.non_streaming_timeout > 0 {
-            std::time::Duration::from_secs(ctx.app_config.non_streaming_timeout as u64)
-        } else {
-            std::time::Duration::ZERO
-        };
+    let body_timeout = if ctx.failover_active && ctx.app_config.non_streaming_timeout > 0 {
+        std::time::Duration::from_secs(ctx.app_config.non_streaming_timeout as u64)
+    } else {
+        std::time::Duration::ZERO
+    };
     let (mut response_headers, status, body_bytes) =
         read_decoded_body(response, ctx.tag, body_timeout).await?;
     let body_str = String::from_utf8_lossy(&body_bytes);
@@ -1802,12 +1798,11 @@ async fn handle_codex_chat_error_response(
     ctx: &RequestContext,
     status: axum::http::StatusCode,
 ) -> Result<axum::response::Response, ProxyError> {
-    let body_timeout =
-        if ctx.app_config.auto_failover_enabled && ctx.app_config.non_streaming_timeout > 0 {
-            std::time::Duration::from_secs(ctx.app_config.non_streaming_timeout as u64)
-        } else {
-            std::time::Duration::ZERO
-        };
+    let body_timeout = if ctx.failover_active && ctx.app_config.non_streaming_timeout > 0 {
+        std::time::Duration::from_secs(ctx.app_config.non_streaming_timeout as u64)
+    } else {
+        std::time::Duration::ZERO
+    };
     let (mut response_headers, _status, body_bytes) =
         read_decoded_body(response, ctx.tag, body_timeout).await?;
 

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -223,13 +223,12 @@ pub async fn handle_non_streaming(
     // guard 在函数 scope 内持有，整包响应读取完成后随函数返回一并 drop
     _connection_guard: Option<ActiveConnectionGuard>,
 ) -> Result<Response, ProxyError> {
-    // 整包超时：仅在故障转移开启且配置值非零时生效
-    let body_timeout =
-        if ctx.app_config.auto_failover_enabled && ctx.app_config.non_streaming_timeout > 0 {
-            Duration::from_secs(ctx.app_config.non_streaming_timeout as u64)
-        } else {
-            Duration::ZERO
-        };
+    // 整包超时：仅在故障转移行为启用（显式开关或省心模式）且配置值非零时生效
+    let body_timeout = if ctx.failover_active && ctx.app_config.non_streaming_timeout > 0 {
+        Duration::from_secs(ctx.app_config.non_streaming_timeout as u64)
+    } else {
+        Duration::ZERO
+    };
     let (mut response_headers, status, body_bytes) =
         read_decoded_body(response, ctx.tag, body_timeout).await?;
     // 托管档的非流式响应顺路观察（解压后的明文形状；满即丢不阻塞）


### PR DESCRIPTION
## 病灶

省心模式开着、档位故障时用户仍连续看到原始 403/429 报错，CLI 重试额度被死档位逐个烧光后才放弃。

## 根因

「要不要故障转移」有两个 owner，判定分叉：

- `auto_mode_enabled_<app>`（省心模式）只管 `select_providers` 的候选排序；
- `proxy_config.auto_failover_enabled`（**默认关**，UI 藏在省心 tab「高级」折叠区）才管转发器的重试与超时——关闭时强制 `max_retries=0`，单请求只试一家。

于是省心模式的「切换」只剩跨请求层：每个死档位消耗 CLI 的一次重试并向用户暴露一次原始错误（线上实测：同站三个无余额分组连撞三次 403 + 一家 429 即耗尽 CLI 重试预算）。E2E fixture 一直是两个开关同开才测出「故障转移回切」，即事实契约，但产品层从未联动。

## 修法（修根，非数据联动）

新增 `auto_strategy::failover_active(db, app_type, auto_failover_enabled)`：显式开关或省心模式任一开启即生效。`RequestContext` 每请求计算一次作为唯源，转发侧（超时 / `max_retries` / `streaming_timeout_config`）与响应侧（handlers ×5 + response_processor ×1 的非流式整包超时）全部改读该值。

- 不采用「开省心时把 `auto_failover_enabled` 写成 true」：两个事实仍分叉，关省心后留幽灵 true（尺子 1.4）。
- 旧开关本体保留：它继续 owner 旧队列模式与 UI/命令层语义，不属于本次修的请求内行为判据。

## 测试

- E2E 回归闸 `easy_mode_fails_over_in_request_even_with_failover_toggle_off`：省心开 + 显式开关关 + 便宜档 500 → **同一请求内**落到贵档，客户端拿 200（修复前实测 RED：500 直接透传）。
- 单测 `failover_active_when_either_source_enabled`（按 app 隔离）。
- 全量 `cargo test` 3732 通过；`cargo fmt --check`、`cargo clippy --all-targets -D warnings` 干净。