### PR TITLE
feat(easymode): 看板纯价格序 + 失败原因外露 + newapi sk 余额直查

### DIFF
--- a/src-tauri/src/commands/auto_mode.rs
+++ b/src-tauri/src/commands/auto_mode.rs
@@ -350,7 +350,8 @@ pub async fn set_easy_mode_manual_order(
 pub struct TierBoardTier {
     pub provider_id: String,
     pub name: String,
-    /// 展示序即选路优先级序（含亲和置顶/手动序）。
+    /// 展示序 = 纯策略序（自动）或用户手动序；不含选路时的会话亲和置顶 ——
+    /// 当前档位靠 `is_current` 徽章表达，不靠排到第一。
     pub position: usize,
     pub is_current: bool,
     pub rate_multiplier: Option<f64>,
@@ -360,11 +361,19 @@ pub struct TierBoardTier {
     pub effective_model: Option<String>,
     pub avg_first_token_ms: Option<u64>,
     /// 站点钱包余额（美元）。sub2api 用档位 sk 直查 `GET /v1/usage`（同站各档
-    /// 共享一个账号钱包）；newapi 无此路 → `None`（前端显示 —，走登录态的余额链）。
+    /// 共享一个账号钱包）；问不出时回落 one-api 系 billing 双端点（newapi 站），
+    /// 仍问不到 → `None`，前端显示 —。
     pub balance_usd: Option<f64>,
     /// 模型验真合并判定（两源读侧合并、跨模型取最严重）。只上异常：
     /// "anomaly" | "suspicious"；Trusted/无报告 = `None`（被动监控不背书）。
     pub verification_verdict: Option<String>,
+    /// 健康快照（`provider_health`；缺行时 DAO 合成默认健康行 —— 契约如此）。
+    /// 从未失败 = `Some(true)` / `Some(0)` / `None`，前端据此不显示健康标记。
+    pub is_healthy: Option<bool>,
+    pub consecutive_failures: Option<u32>,
+    /// 最近一次失败的上游报错原文（`ProxyError::to_string()`，成功即被清空）。
+    /// 「为什么不选用」标签的数据源。
+    pub last_error: Option<String>,
 }
 
 /// 省心模式档位看板：首页省心视图一次拉全的聚合 DTO。
@@ -398,7 +407,10 @@ pub(crate) async fn tier_board_impl(state: &AppState, app_type: &str) -> Result<
     require_auto_mode_app(app_type)?;
     let db = &state.db;
     let providers = db.get_all_providers(app_type).map_err(|e| e.to_string())?;
-    let ranked = auto_strategy::rank_managed_tier_candidates(db, app_type, true)
+    // honor_affinity=false：看板展示纯策略序/手动序。会话亲和置顶是选路语义
+    // （防中途换档丢提示词缓存），展示要的是「价格序 + 谁在用标当前 + 没在用
+    // 的给出原因」的心智模型，两者别共用一个形状。
+    let ranked = auto_strategy::rank_managed_tier_candidates(db, app_type, false)
         .map_err(|e| e.to_string())?
         .unwrap_or_default();
     let multipliers = db.get_tier_rate_multipliers(app_type).unwrap_or_default();
@@ -409,6 +421,15 @@ pub(crate) async fn tier_board_impl(state: &AppState, app_type: &str) -> Result<
     let current_id = auto_strategy::effective_current_provider_id(db, app_type);
 
     let balances = fetch_site_balances(app_type, &ranked).await;
+
+    // 健康快照（缺行时 DAO 合成默认健康行，见 get_provider_health 的契约）
+    let mut health: std::collections::HashMap<String, crate::proxy::types::ProviderHealth> =
+        std::collections::HashMap::new();
+    for p in &ranked {
+        if let Ok(h) = db.get_provider_health(&p.id, app_type).await {
+            health.insert(p.id.clone(), h);
+        }
+    }
 
     // 验真判定（两源读侧合并已在 store 层做完）：跨模型取最严重，只上异常
     let provider_ids: Vec<String> = ranked.iter().map(|p| p.id.clone()).collect();
@@ -461,6 +482,9 @@ pub(crate) async fn tier_board_impl(state: &AppState, app_type: &str) -> Result<
             avg_first_token_ms: ttft.get(&p.id).copied(),
             balance_usd: balances.get(&p.id).copied(),
             verification_verdict: verification_verdict(&p.id),
+            is_healthy: health.get(&p.id).map(|h| h.is_healthy),
+            consecutive_failures: health.get(&p.id).map(|h| h.consecutive_failures),
+            last_error: health.get(&p.id).and_then(|h| h.last_error.clone()),
             provider_id: p.id.clone(),
             name: p.name.clone(),
             position,
@@ -477,10 +501,12 @@ pub(crate) async fn tier_board_impl(state: &AppState, app_type: &str) -> Result<
     })
 }
 
-/// sub2api 站点钱包余额：按「站点 origin」去重，每个 origin 用第一把 sk 查一次
-/// `GET /v1/usage`（登录态过期也能查），回填到该站的全部档位上。newapi 站
-/// 403/404 → 该站各档 `None`。只对 https 端点发起（http/本地/无 sk 自然跳过，
-/// 单元测试零网络）。
+/// 站点钱包余额：按「站点 origin」去重，每个 origin 用第一把 sk 查一次，回填到
+/// 该站的全部档位上。两路按序试：先 sub2api 的 `GET /v1/usage`（sub2api 站短路，
+/// 不多花请求）；问不出（典型 newapi：该端点 404）再回落 one-api 系 billing 双端
+/// 点（见 [`crate::relay::api::billing_balance_with_api_key`] 的口径与限制）。
+/// 两路都拿不到 → 该站各档 `None`。只对 https 端点发起（http/本地/无 sk 自然
+/// 跳过，单元测试零网络）。
 async fn fetch_site_balances(
     app_type: &str,
     tiers: &[crate::provider::Provider],
@@ -517,7 +543,7 @@ async fn fetch_site_balances(
     let queries: Vec<_> = origin_key
         .into_iter()
         .map(|(origin, key)| async move {
-            let balance = crate::relay::api::usage_with_api_key(&origin, &key)
+            let sub2api_wallet = crate::relay::api::usage_with_api_key(&origin, &key)
                 .await
                 .ok()
                 .and_then(|usage| {
@@ -525,6 +551,13 @@ async fn fetch_site_balances(
                         .data
                         .and_then(|items| items.first().and_then(|item| item.remaining))
                 });
+            let balance = match sub2api_wallet {
+                Some(balance) => Some(balance),
+                None => crate::relay::api::billing_balance_with_api_key(&origin, &key)
+                    .await
+                    .ok()
+                    .flatten(),
+            };
             (origin, balance)
         })
         .collect();
@@ -665,6 +698,119 @@ mod tests {
         let board = tier_board_impl(&state, "claude").await.unwrap();
         assert_eq!(board.mode, "manual");
         assert_eq!(board.tiers[0].provider_id, expensive, "手动序优先");
+    }
+
+    /// ⭐ 看板是纯策略序：选路的会话亲和置顶只在请求时发生，展示不打乱顺序 ——
+    /// 当前档位靠 `is_current` 徽章表达，不靠排到第一。用户读看板的心智模型是
+    /// 「价格序 + 谁在用标当前 + 没在用的给出原因」。
+    #[tokio::test]
+    #[serial]
+    async fn tier_board_stays_pure_price_order_with_active_current() {
+        let _home = test_home();
+        let db = Arc::new(Database::memory().unwrap());
+        let state = AppState::new(db.clone());
+
+        let expensive = crate::relay::provision::provider_id_for("https://a.example", Some(1), 1);
+        let cheap = crate::relay::provision::provider_id_for("https://b.example", Some(1), 2);
+        let tier = |id: &str| {
+            crate::provider::Provider::with_id(
+                id.to_string(),
+                id.to_string(),
+                json!({ "config": "model = \"m-x\"\n" }),
+                None,
+            )
+        };
+        db.save_provider("claude", &tier(&expensive)).unwrap();
+        db.save_provider("claude", &tier(&cheap)).unwrap();
+        db.set_tier_rate_multiplier("claude", &expensive, Some(2.0))
+            .unwrap();
+        db.set_tier_rate_multiplier("claude", &cheap, Some(0.5))
+            .unwrap();
+        db.set_current_provider("claude", &expensive).unwrap();
+
+        // 当前档位（贵）30 分钟内有流量 → 选路会亲和置顶；看板必须保持纯价格序
+        seed_board_activity(&db, "claude", &expensive);
+
+        let board = tier_board_impl(&state, "claude").await.unwrap();
+        assert_eq!(
+            board.tiers[0].provider_id, cheap,
+            "看板第一张是最便宜的，不被亲和置顶顶走"
+        );
+        let current = board.tiers.iter().find(|t| t.is_current).unwrap();
+        assert_eq!(current.provider_id, expensive);
+        assert_eq!(current.position, 1, "当前徽章在它自己的价格位上");
+    }
+
+    /// ⭐ 失败原因透出：`provider_health` 的健康态/连续失败/`last_error`（上游
+    /// 报错原文）跟着看板走，给「为什么不选用」的标签用；没失败过的档位全 None。
+    #[tokio::test]
+    #[serial]
+    async fn tier_board_surfaces_provider_health_for_failed_tiers() {
+        let _home = test_home();
+        let db = Arc::new(Database::memory().unwrap());
+        let state = AppState::new(db.clone());
+
+        let dead = crate::relay::provision::provider_id_for("https://a.example", Some(1), 1);
+        let fine = crate::relay::provision::provider_id_for("https://b.example", Some(1), 2);
+        let tier = |id: &str| {
+            crate::provider::Provider::with_id(
+                id.to_string(),
+                id.to_string(),
+                json!({ "config": "model = \"m-x\"\n" }),
+                None,
+            )
+        };
+        db.save_provider("claude", &tier(&dead)).unwrap();
+        db.save_provider("claude", &tier(&fine)).unwrap();
+
+        db.update_provider_health_with_threshold(
+            &dead,
+            "claude",
+            false,
+            Some("上游 HTTP 403: {\"error\":{\"message\":\"无可用渠道\"}}".to_string()),
+            1,
+        )
+        .await
+        .unwrap();
+
+        let board = tier_board_impl(&state, "claude").await.unwrap();
+        let by_id = |id: &str| board.tiers.iter().find(|t| t.provider_id == id).unwrap();
+        assert_eq!(by_id(&dead).is_healthy, Some(false));
+        assert_eq!(by_id(&dead).consecutive_failures, Some(1));
+        assert!(
+            by_id(&dead)
+                .last_error
+                .as_deref()
+                .is_some_and(|e| e.contains("403")),
+            "上游报错原文必须原样透出"
+        );
+        assert_eq!(
+            by_id(&fine).is_healthy,
+            Some(true),
+            "没失败过的档位 = 健康（缺行时 DAO 合成默认健康行）"
+        );
+        assert_eq!(by_id(&fine).consecutive_failures, Some(0));
+        assert_eq!(by_id(&fine).last_error, None);
+    }
+
+    /// 亲和判据与选路同源（proxy_request_logs 近期流量），见
+    /// `auto_strategy::AFFINITY_WINDOW_SECS`。
+    fn seed_board_activity(db: &Database, app_type: &str, provider_id: &str) {
+        let conn = db.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO proxy_request_logs (
+                request_id, provider_id, app_type, model,
+                input_tokens, output_tokens, total_cost_usd,
+                latency_ms, first_token_ms, status_code, created_at
+            ) VALUES (?1, ?2, ?3, 'm', 1, 1, '0', 10, 10, 200, ?4)",
+            rusqlite::params![
+                format!("board-{provider_id}"),
+                provider_id,
+                app_type,
+                chrono::Utc::now().timestamp(),
+            ],
+        )
+        .unwrap();
     }
 
     fn test_home() -> tempfile::TempDir {

--- a/src-tauri/src/relay/api.rs
+++ b/src-tauri/src/relay/api.rs
@@ -1029,6 +1029,94 @@ fn usage_not_found(error: String) -> UsageResult {
     }
 }
 
+/// newapi（one-api 家族）sk 直查钱包余额：OpenAI 兼容的 billing 双端点。
+///
+/// - `GET /v1/dashboard/billing/subscription` → `hard_limit_usd`（美元）
+/// - `GET /v1/dashboard/billing/usage` → `total_usage`（已用，美分）
+///
+/// 余额 = `hard_limit_usd − total_usage / 100`（one-api 系社区通行的合成口径）。
+/// **两个端点都必须给出字段才算数** —— 只有额度没有用量时把额度当余额会虚高。
+/// 部分站方会关闭 billing 兼容层，或把 `hard_limit_usd` 配成 key 限额而非账户
+/// 余额；这类站点查出来的字段缺失或端点 404/403/401 一律 `Ok(None)`，与
+/// [`usage_with_api_key`] 同一条「查不到不算错」纪律 —— 拿不到就不显示。
+pub async fn billing_balance_with_api_key(
+    site_origin: &str,
+    api_key: &str,
+) -> Result<Option<f64>, AppError> {
+    let subscription =
+        billing_compat_get(site_origin, "/v1/dashboard/billing/subscription", api_key).await?;
+    let usage = billing_compat_get(site_origin, "/v1/dashboard/billing/usage", api_key).await?;
+    parse_billing_balance(&subscription, &usage)
+}
+
+/// billing 兼容层的单端点 GET。端点不存在/无权限（404/403/401）返回空串 ——
+/// 上层把空串当「这一路问不出」处理，不算错。
+async fn billing_compat_get(
+    site_origin: &str,
+    path: &str,
+    api_key: &str,
+) -> Result<String, AppError> {
+    let url = format!("{site_origin}{path}");
+    let resp = build_client()?
+        .get(&url)
+        .bearer_auth(api_key)
+        .send()
+        .await
+        .map_err(|e| AppError::Config(format!("查询余额失败: {}", describe_send_error(&e))))?;
+
+    let status = resp.status();
+    if status == reqwest::StatusCode::NOT_FOUND
+        || status == reqwest::StatusCode::FORBIDDEN
+        || status == reqwest::StatusCode::UNAUTHORIZED
+    {
+        return Ok(String::new());
+    }
+    if !status.is_success() {
+        return Err(AppError::Config(format!(
+            "查询余额失败: HTTP {}",
+            status.as_u16()
+        )));
+    }
+
+    resp.text()
+        .await
+        .map_err(|e| AppError::Config(format!("查询余额失败: 读响应出错 {e}")))
+}
+
+/// billing 双端点响应合成余额（纯函数，离线可测）。空串 = 端点不可用 → `None`；
+/// 缺 `hard_limit_usd` 或 `total_usage` → `None`（不猜）；坏 JSON → `Err`。
+pub(crate) fn parse_billing_balance(
+    subscription_body: &str,
+    usage_body: &str,
+) -> Result<Option<f64>, AppError> {
+    if subscription_body.trim().is_empty() || usage_body.trim().is_empty() {
+        return Ok(None);
+    }
+
+    #[derive(Deserialize)]
+    struct Subscription {
+        #[serde(default)]
+        hard_limit_usd: Option<f64>,
+    }
+    #[derive(Deserialize)]
+    struct UsageBody {
+        #[serde(default)]
+        total_usage: Option<f64>,
+    }
+
+    let subscription: Subscription = serde_json::from_str(subscription_body)
+        .map_err(|e| AppError::Config(format!("查询余额失败: 订阅响应解析出错 {e}")))?;
+    let usage: UsageBody = serde_json::from_str(usage_body)
+        .map_err(|e| AppError::Config(format!("查询余额失败: 用量响应解析出错 {e}")))?;
+
+    match (subscription.hard_limit_usd, usage.total_usage) {
+        (Some(hard_limit_usd), Some(total_usage_cents)) => {
+            Ok(Some(hard_limit_usd - total_usage_cents / 100.0))
+        }
+        _ => Ok(None),
+    }
+}
+
 /// 用 refresh token 换一对新的 token。
 ///
 /// 这个端点**不需要** Bearer（refresh token 就在请求体里），所以是自由函数而不是

--- a/src-tauri/src/relay/balance.rs
+++ b/src-tauri/src/relay/balance.rs
@@ -391,4 +391,48 @@ mod tests {
         assert_eq!(usage.remaining, Some(12.5));
         assert_eq!(usage.unit.as_deref(), Some("USD"));
     }
+
+    /// ⭐ newapi（one-api 家族）sk 直查余额：billing 双端点合成，
+    /// 余额 = `hard_limit_usd` − `total_usage`（美分）/100。
+    #[test]
+    fn billing_subscription_and_usage_compose_wallet_balance() {
+        let balance = api::parse_billing_balance(
+            r#"{"object":"billing.subscription","has_payment_method":true,"hard_limit_usd":12.5}"#,
+            r#"{"object":"list","total_usage":250.0}"#,
+        )
+        .expect("双端点合法 JSON 应能合成余额");
+        assert_eq!(balance, Some(10.0), "12.5 − 250美分/100 = 10.0 美元");
+    }
+
+    /// ⭐ 缺任一字段/端点不可用（空响应）不算数，坏 JSON 是 Err。
+    /// 只有额度没有用量时宁可不显示，也不能把额度当余额。
+    #[test]
+    fn billing_missing_fields_or_empty_bodies_are_not_a_balance() {
+        assert_eq!(
+            api::parse_billing_balance(
+                r#"{"object":"billing.subscription"}"#,
+                r#"{"object":"list","total_usage":1.0}"#,
+            )
+            .unwrap(),
+            None,
+            "没有 hard_limit_usd 就不猜"
+        );
+        assert_eq!(
+            api::parse_billing_balance(
+                r#"{"object":"billing.subscription","hard_limit_usd":5.0}"#,
+                r#"{"object":"list"}"#,
+            )
+            .unwrap(),
+            None,
+            "没有 total_usage 就不猜"
+        );
+        // 端点不可用（404/403/401）时上层给空串 —— 查不到不算错
+        assert_eq!(api::parse_billing_balance("", r#"{}"#).unwrap(), None);
+        assert_eq!(
+            api::parse_billing_balance(r#"{"hard_limit_usd":1.0}"#, "").unwrap(),
+            None
+        );
+        assert!(api::parse_billing_balance("not json", r#"{}"#).is_err());
+        assert!(api::parse_billing_balance(r#"{}"#, "not json").is_err());
+    }
 }

--- a/src/components/easymode/TierList.tsx
+++ b/src/components/easymode/TierList.tsx
@@ -4,6 +4,7 @@
  * dnd 形状抄 `RelayTierList`（同一套 sensors/strategy/把手注入）；卡片只展示
  * 后端看板算好的事实（顺序/倍率/单价/余额/耗时/命中），不在前端拼业务判据。
  */
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   DndContext,
@@ -22,8 +23,15 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { GripVertical } from "lucide-react";
+import { Check, Copy, GripVertical } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { copyText } from "@/lib/clipboard";
+import { cn } from "@/lib/utils";
 import type { TierBoardTier } from "@/lib/api/autoMode";
 import type { DraggableAttributes } from "@dnd-kit/core";
 import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
@@ -101,7 +109,7 @@ function SortableTierCard({ tier }: { tier: TierBoardTier }) {
   );
 }
 
-/** 档位卡：序号 + 名称 + 当前命中 + 倍率/单价/余额/首字耗时。未知值显示 —/「价格未知」。 */
+/** 档位卡：序号 + 名称 + 当前命中 + 失败原因 + 倍率/单价/余额/首字耗时。未知值显示 —/「价格未知」。 */
 function TierCard({
   tier,
   dragHandleProps,
@@ -142,6 +150,7 @@ function TierCard({
               {t("autoMode.board.current", { defaultValue: "当前" })}
             </Badge>
           ) : null}
+          <TierHealthBadge tier={tier} />
           {tier.verificationVerdict === "anomaly" ||
           tier.verificationVerdict === "suspicious" ? (
             <span
@@ -201,5 +210,80 @@ function TierCard({
         </div>
       </div>
     </div>
+  );
+}
+
+/**
+ * 失败原因徽章：「为什么不选用」的外露标签 —— 熔断（不健康）/降级（有连续
+ * 失败但仍健康）二态，点击展开上游报错原文（可复制）。健康且零失败的档位不
+ * 显示任何标记（全绿徽章是噪音）；没有原文时只显示徽章不挂 Popover。
+ */
+function TierHealthBadge({ tier }: { tier: TierBoardTier }) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  const failures = tier.consecutiveFailures ?? 0;
+  const circuitOpen = tier.isHealthy === false;
+  if (!circuitOpen && failures === 0) {
+    return null;
+  }
+
+  const label = circuitOpen
+    ? t("health.circuitOpen", { defaultValue: "熔断" })
+    : t("health.degraded", { defaultValue: "降级" });
+  const badgeClass = cn(
+    "inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium leading-none",
+    circuitOpen
+      ? "border-red-500/60 bg-red-500/10 text-red-600 dark:text-red-400"
+      : "border-amber-500/60 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+  );
+
+  const handleCopy = async () => {
+    if (!tier.lastError) return;
+    try {
+      await copyText(tier.lastError);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // 复制失败不打扰：原文一直可见，用户可以手动选中。
+    }
+  };
+
+  if (!tier.lastError) {
+    return <span className={badgeClass}>{label}</span>;
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button type="button" className={cn(badgeClass, "cursor-pointer")}>
+          {label}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-96 max-w-[80vw]" sideOffset={6}>
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-xs font-medium text-muted-foreground">
+              {label}
+            </span>
+            <button
+              type="button"
+              onClick={() => void handleCopy()}
+              aria-label={t("common.copy", { defaultValue: "复制" })}
+              className="inline-flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+            >
+              {copied ? (
+                <Check className="h-3.5 w-3.5 text-emerald-500" />
+              ) : (
+                <Copy className="h-3.5 w-3.5" />
+              )}
+            </button>
+          </div>
+          <p className="max-h-40 select-text overflow-y-auto break-all font-mono text-xs leading-relaxed">
+            {tier.lastError}
+          </p>
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/src/lib/api/autoMode.ts
+++ b/src/lib/api/autoMode.ts
@@ -23,7 +23,7 @@ export interface AutoModeStatus {
   cliInstalled: boolean;
 }
 
-/** 档位看板的一行：展示序即选路优先级序（后端唯源，前端只渲染）。 */
+/** 档位看板的一行：展示序 = 纯策略序/手动序（后端唯源，前端只渲染）。 */
 export interface TierBoardTier {
   providerId: string;
   name: string;
@@ -39,6 +39,11 @@ export interface TierBoardTier {
   balanceUsd: number | null;
   /** 模型验真合并判定，只上异常（`'anomaly' | 'suspicious'`）；`null` = 无异常（不背书）。 */
   verificationVerdict: "anomaly" | "suspicious" | null;
+  /** 健康快照（`provider_health`；`null` = 后端读失败）。健康且零失败 → 前端不显示标记。 */
+  isHealthy: boolean | null;
+  consecutiveFailures: number | null;
+  /** 最近一次失败的上游报错原文；`null` = 没有失败记录。 */
+  lastError: string | null;
 }
 
 export interface TierBoard {

--- a/tests/components/EasyBoard.test.tsx
+++ b/tests/components/EasyBoard.test.tsx
@@ -127,8 +127,7 @@ describe("EasyBoard", () => {
             ...nulls,
             isHealthy: false,
             consecutiveFailures: 4,
-            lastError:
-              "上游 HTTP 403: {\"error\":{\"message\":\"无可用渠道\"}}",
+            lastError: '上游 HTTP 403: {"error":{"message":"无可用渠道"}}',
           },
           {
             providerId: "tier-fine",

--- a/tests/components/EasyBoard.test.tsx
+++ b/tests/components/EasyBoard.test.tsx
@@ -51,6 +51,9 @@ function boardFixture(overrides: Partial<TierBoard> = {}): TierBoard {
         avgFirstTokenMs: 420,
         balanceUsd: 10.347,
         verificationVerdict: null,
+        isHealthy: null,
+        consecutiveFailures: null,
+        lastError: null,
       },
       {
         providerId: "tier-b",
@@ -63,6 +66,9 @@ function boardFixture(overrides: Partial<TierBoard> = {}): TierBoard {
         avgFirstTokenMs: null,
         balanceUsd: null,
         verificationVerdict: null,
+        isHealthy: null,
+        consecutiveFailures: null,
+        lastError: null,
       },
     ],
     ...overrides,
@@ -98,6 +104,49 @@ describe("EasyBoard", () => {
     expect(screen.getByText("余额 $10.35")).toBeDefined();
     expect(screen.getByText("价格未知")).toBeDefined();
     // 当前命中只在 isCurrent 档出现一次
+    expect(screen.getAllByText("当前")).toHaveLength(1);
+  });
+
+  it("失败档位外露原因徽章（熔断），健康档位不显示健康标记", () => {
+    const nulls = {
+      effectiveModel: null,
+      avgFirstTokenMs: null,
+      balanceUsd: null,
+      verificationVerdict: null,
+    };
+    setupBoard(
+      boardFixture({
+        tiers: [
+          {
+            providerId: "tier-dead",
+            name: "熔断档",
+            position: 0,
+            isCurrent: false,
+            rateMultiplier: 1,
+            unitPricePerMillion: null,
+            ...nulls,
+            isHealthy: false,
+            consecutiveFailures: 4,
+            lastError:
+              "上游 HTTP 403: {\"error\":{\"message\":\"无可用渠道\"}}",
+          },
+          {
+            providerId: "tier-fine",
+            name: "健康档",
+            position: 1,
+            isCurrent: true,
+            rateMultiplier: 1,
+            unitPricePerMillion: null,
+            ...nulls,
+            isHealthy: true,
+            consecutiveFailures: 0,
+            lastError: null,
+          },
+        ],
+      }),
+    );
+    expect(screen.getByText("熔断")).toBeDefined();
+    expect(screen.queryByText("降级")).toBeNull();
     expect(screen.getAllByText("当前")).toHaveLength(1);
   });
 


### PR DESCRIPTION
## 动机

用户对省心看板的三点反馈：① newapi 系站点档位余额全显示 "—"（查余额链只有 sub2api 的 `/v1/usage`，newapi 打它必 404，而仓里 newapi 余额只有登录态路径）；② 看板顺序被会话亲和置顶打乱（当前档位被顶到第一，不是纯价格位）；③ 排在前面但没在用的档位看不出「为什么不选用」。

## 改动

- **排序**：`tier_board_impl` 改 `honor_affinity=false`。会话亲和置顶是选路语义（防中途换档丢提示词缓存），展示用「价格序 + 谁在用标当前」的心智模型；选路行为不变。
- **失败原因外露**：`TierBoardTier` 透出 `provider_health` 的 `is_healthy` / `consecutive_failures` / `last_error`（存的就是上游报错原文）。TierCard 失败态显示「熔断」（不健康）/「降级」（有连续失败仍健康）徽章，点击 Popover 展示原文（等宽/限高/可选中）+ 复制按钮；健康档位不显示任何标记。i18n 全部复用既有 key（`health.*`、`common.copy`），零新增。
- **newapi sk 余额**：`fetch_site_balances` 每站先试 sub2api `/v1/usage`（sub2api 站短路不增请求），问不出回落 one-api 系 OpenAI 兼容 billing 双端点（`subscription.hard_limit_usd − usage.total_usage/100`，社区通行口径）。缺字段/端点关闭 → 保持 "—"，不谎报；解析拆纯函数配单测。

## 测试（TDD，先红后绿）

- `billing_subscription_and_usage_compose_wallet_balance` / `billing_missing_fields_or_empty_bodies_are_not_a_balance`（解析契约闸）
- `tier_board_stays_pure_price_order_with_active_current`（亲和置顶不看板）
- `tier_board_surfaces_provider_health_for_failed_tiers`（健康三字段透出；缺行=DAO 合成默认健康行的既有契约）
- EasyBoard 组件测试补「熔断徽章外露、健康档无标记」断言

全量：cargo test 3736 绿、clippy `--all-targets -D warnings` 干净、fmt 过；pnpm typecheck / format:check / vitest 1292 绿。

## 边界

- 站点行的 `relay_balance` 三步链不动（登录账号余额语义）。
- 熔断器实时内存态不暴露（DB 健康度已够答「为什么不用」）。
- 看板不加轮询。