### PR TITLE
fix(relay): billing 合成余额拒收「无限额度」哨兵量级

### DIFF
--- a/src-tauri/src/relay/api.rs
+++ b/src-tauri/src/relay/api.rs
@@ -1111,11 +1111,23 @@ pub(crate) fn parse_billing_balance(
 
     match (subscription.hard_limit_usd, usage.total_usage) {
         (Some(hard_limit_usd), Some(total_usage_cents)) => {
-            Ok(Some(hard_limit_usd - total_usage_cents / 100.0))
+            let balance = hard_limit_usd - total_usage_cents / 100.0;
+            // one-api 系站点会把「无限额度」哨兵当 hard_limit 返回（实测：
+            // soft/hard/system 三个 limit 全 1e8、usage 0）。CLI 用户的预充值
+            // 不存在 $1e6 以上的量级 —— 超限即视为站点哨兵/单位错误，按
+            // 「查不到」处理显示 —，绝不显示假数字。
+            if balance > BILLING_BALANCE_CEILING_USD {
+                Ok(None)
+            } else {
+                Ok(Some(balance))
+            }
         }
         _ => Ok(None),
     }
 }
+
+/// billing 合成余额的可信上限（美元）：超过即视为站点哨兵值/单位错误。
+const BILLING_BALANCE_CEILING_USD: f64 = 1_000_000.0;
 
 /// 用 refresh token 换一对新的 token。
 ///

--- a/src-tauri/src/relay/balance.rs
+++ b/src-tauri/src/relay/balance.rs
@@ -435,4 +435,16 @@ mod tests {
         assert!(api::parse_billing_balance("not json", r#"{}"#).is_err());
         assert!(api::parse_billing_balance(r#"{}"#, "not json").is_err());
     }
+
+    /// ⭐ new-api「无限额度」哨兵不是余额：实测站点三个 limit 全返 1e8、usage 为 0
+    /// ——把一亿美元当余额显示是笑话。超出常规预充值量级（$1e6）即按查不到处理。
+    #[test]
+    fn billing_unlimited_sentinel_is_not_a_balance() {
+        let balance = api::parse_billing_balance(
+            r#"{"object":"billing_subscription","has_payment_method":true,"soft_limit_usd":100000000,"hard_limit_usd":100000000,"system_hard_limit_usd":100000000,"access_until":0}"#,
+            r#"{"object":"list","total_usage":0}"#,
+        )
+        .unwrap();
+        assert_eq!(balance, None, "哨兵量级的余额必须被拒收");
+    }
 }


### PR DESCRIPTION
看板 newapi sk 余额兜底（PR #241）实测翻车：某 new-api 站点 billing 端点把 soft/hard/system 三个 limit 全返 100000000、usage 0 ——「无限额度」哨兵被当真，看板显示 $100000000.00。

修法：`parse_billing_balance` 加余额上限 $1e6，超限一律 `None`（显示 —）。CLI 用户的站点预充值不存在更大量级，超限即站点哨兵值或单位错误；宁可显示「查不出」也不显示假数字。

测试：`billing_unlimited_sentinel_is_not_a_balance`（实测响应形状钉成回归闸，修复前红：Some(1e8)）。全量 cargo test 3737 绿、clippy 干净。