### PR TITLE
fix(updater): latest.json notes 带上 tag 正文，更新横幅滚动阅读全文

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -876,7 +876,9 @@ jobs:
   assemble-latest-json:
     name: Assemble latest.json
     runs-on: ubuntu-22.04
-    needs: publish-release
+    # 同 publish-release：直接 needs tag-notes 才能拿到它的 output（job output
+    # 只从直接依赖取）。tag 正文在这里进 updater manifest 的 notes 字段。
+    needs: [publish-release, tag-notes]
     permissions:
       contents: write
     steps:
@@ -898,11 +900,15 @@ jobs:
         env:
           REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
+          TAG_NOTES: ${{ needs.tag-notes.outputs.notes }}
         run: |
           set -euo pipefail
           VERSION="${TAG#v}"
           PUB_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           base_url="https://github.com/$REPO/releases/download/$TAG"
+          # tag 正文（发布说明唯一源）经 jq 转成合法 JSON 字符串。正文是自由文本，
+          # 拼进手写 JSON 必须走转义；这一段已用真实 tag 正文本地验证过逐字往返。
+          NOTES_JSON=$(printf '%s' "$TAG_NOTES" | jq -Rs .)
           # 初始化空平台映射
           mac_url=""; mac_sig=""
           win_x64_url=""; win_x64_sig=""
@@ -934,7 +940,7 @@ jobs:
           {
             echo '{'
             echo "  \"version\": \"$VERSION\",";
-            echo "  \"notes\": \"Release $TAG\",";
+            echo "  \"notes\": $NOTES_JSON,";
             echo "  \"pub_date\": \"$PUB_DATE\",";
             echo '  "platforms": {'
             first=1
@@ -969,6 +975,9 @@ jobs:
             echo '  }'
             echo '}'
           } > "$tmp_json"
+          # manifest 的 notes 现在是自由文本：一个坏转义上去就是「所有人检查更新失败」，
+          # 而且要到用户端才炸、CI 全绿。上传前先验一遍合法性，把它拦在发布当晚。
+          jq empty "$tmp_json"
           echo "Generated latest.json:" && cat "$tmp_json"
           # updater 未启用时一个 .sig 都不会有 ⇒ platforms 是空对象。那种 latest.json 传上去
           # 只会让人以为应用内更新已经能用（实际 lib.rs 里连插件都没注册），所以不传。

--- a/src/components/settings/AboutSection.tsx
+++ b/src/components/settings/AboutSection.tsx
@@ -996,7 +996,9 @@ export function AboutSection({ isPortable }: AboutSectionProps) {
               })}
             </p>
             {updateInfo.notes && (
-              <p className="text-muted-foreground line-clamp-3 leading-relaxed">
+              // notes 是 tag 正文（markdown 源文本），这里按纯文本滚动展示——
+              // 完整渲染的版本在旁边的「发行说明」按钮（GitHub Release 页），不重复造。
+              <p className="text-muted-foreground max-h-48 overflow-y-auto whitespace-pre-wrap leading-relaxed">
                 {updateInfo.notes}
               </p>
             )}


### PR DESCRIPTION
## Summary / 概述

检查更新横幅只显示 "Release v6.12.0" 一行、右侧大片空白。修根：发布说明唯一源（annotated tag 正文）本就被 `tag-notes` job 读出，但 `assemble-latest-json` 把 manifest 的 `notes` 写死成 `"Release $TAG"`——把这一截断链接上。

- **release.yml**：`assemble-latest-json` 直接 `needs: tag-notes` 取 output；notes 经 `jq -Rs` 转义注入（已用真实 tag 正文本地验证逐字往返）；上传前加 `jq empty` 合法性闸（自由文本进手写 JSON，坏转义 = 全员检查更新失败且 CI 全绿）。
- **AboutSection**：上游的 `line-clamp-3` 是为单行 notes 设计的，换成 `whitespace-pre-wrap` + `max-h` 滚动；仍按纯文本展示（不引 markdown 渲染依赖，完整渲染在旁边「发行说明」按钮）。

notes 与更新检查拉的是同一份 latest.json，零新增网络请求，无「读不到」分支；manifest 无 notes 时维持原样。

自下一个发版起生效；v6.12.0 已发布资产另行回填（仅 notes 字段）。

## Related Issue / 关联 Issue

无

## Screenshots / 截图

不涉及视觉重排（横幅内部文本区从 clamp 改滚动）。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）——未动 Rust
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件——无新增文案
