### PR TITLE
feat(easymode): 档位卡近期活动时间线 + 首字走势迷你图

### DIFF
--- a/src-tauri/src/commands/auto_mode.rs
+++ b/src-tauri/src/commands/auto_mode.rs
@@ -381,6 +381,9 @@ pub struct TierBoardTier {
     /// 7 天缓存命中率（0..1 分数，与首字耗时同窗口）；`None` = 无可判流量
     /// （分母为 0 时不显示，别把「不知道」当 0%）。
     pub cache_hit_rate: Option<f64>,
+    /// 近 6 小时活动时间线（15 分钟一桶固定 24 桶，空桶补零）；
+    /// `None` = 窗口内没有任何请求，前端不渲染时间线。
+    pub recent_activity: Option<Vec<crate::services::usage_stats::ProviderActivityBucket>>,
 }
 
 /// 省心模式档位看板：首页省心视图一次拉全的聚合 DTO。
@@ -427,6 +430,9 @@ pub(crate) async fn tier_board_impl(state: &AppState, app_type: &str) -> Result<
     let today = db.get_provider_today_stats(app_type).unwrap_or_default();
     let cache_hit_rates = db
         .get_provider_cache_hit_rates(app_type, chrono::Utc::now().timestamp() - 7 * 86400)
+        .unwrap_or_default();
+    let recent_activity = db
+        .get_provider_activity_buckets(app_type, chrono::Utc::now().timestamp() - 6 * 3600, 900, 24)
         .unwrap_or_default();
     let model_pref = auto_strategy::get_model_pref(db, app_type);
     let current_id = auto_strategy::effective_current_provider_id(db, app_type);
@@ -499,6 +505,7 @@ pub(crate) async fn tier_board_impl(state: &AppState, app_type: &str) -> Result<
             today_cost_usd: today.get(&p.id).map(|(cost, _)| *cost),
             today_requests: today.get(&p.id).map(|(_, requests)| *requests),
             cache_hit_rate: cache_hit_rates.get(&p.id).copied(),
+            recent_activity: recent_activity.get(&p.id).cloned(),
             provider_id: p.id.clone(),
             name: p.name.clone(),
             position,
@@ -852,10 +859,46 @@ mod tests {
 
         // 今天两行：$0.5 + $0.25；fresh input 10、cache read 90（claude 语义
         // input_tokens=fresh，semantics 缺省 0=legacy 也按 fresh 归一）
-        seed_board_usage(&db, "claude", &busy, "busy-t1", 0.5, 10, 0, 90, 0);
-        seed_board_usage(&db, "claude", &busy, "busy-t2", 0.25, 10, 0, 90, 0);
+        seed_board_usage(
+            &db,
+            "claude",
+            &busy,
+            "busy-t1",
+            0.5,
+            200,
+            10,
+            0,
+            90,
+            Some(10),
+            0,
+        );
+        seed_board_usage(
+            &db,
+            "claude",
+            &busy,
+            "busy-t2",
+            0.25,
+            200,
+            10,
+            0,
+            90,
+            Some(10),
+            0,
+        );
         // 昨天一行（now−2 天，双时区安全）：$9 不计入今日；token 全 0 不进缓存率
-        seed_board_usage(&db, "claude", &busy, "busy-y1", 9.0, 0, 0, 0, -2 * 86400);
+        seed_board_usage(
+            &db,
+            "claude",
+            &busy,
+            "busy-y1",
+            9.0,
+            200,
+            0,
+            0,
+            0,
+            Some(10),
+            -2 * 86400,
+        );
         // cold 档没有任何行
 
         let board = tier_board_impl(&state, "claude").await.unwrap();
@@ -871,6 +914,105 @@ mod tests {
         assert_eq!(cold_tier.cache_hit_rate, None, "分母为 0 不显示 0%");
     }
 
+    /// ⭐ 近期活动时间线：6 小时 / 15 分钟一桶固定 24 桶，每桶成功数/失败数/
+    /// 均首字；窗外行不计；窗口内没有任何行的档位 → `None`（前端不渲染时间线）。
+    #[tokio::test]
+    #[serial]
+    async fn tier_board_surfaces_recent_activity_buckets() {
+        let _home = test_home();
+        let db = Arc::new(Database::memory().unwrap());
+        let state = AppState::new(db.clone());
+
+        let busy = crate::relay::provision::provider_id_for("https://a.example", Some(1), 1);
+        let cold = crate::relay::provision::provider_id_for("https://b.example", Some(1), 2);
+        let tier = |id: &str| {
+            crate::provider::Provider::with_id(
+                id.to_string(),
+                id.to_string(),
+                json!({ "config": "model = \"m-x\"\n" }),
+                None,
+            )
+        };
+        db.save_provider("claude", &tier(&busy)).unwrap();
+        db.save_provider("claude", &tier(&cold)).unwrap();
+
+        // 桶 0（窗口最早期）：两次成功 ttft 100/300 → 均 200
+        seed_board_usage(
+            &db,
+            "claude",
+            &busy,
+            "act-b0-a",
+            0.0,
+            200,
+            0,
+            0,
+            0,
+            Some(100),
+            -6 * 3600 + 120,
+        );
+        seed_board_usage(
+            &db,
+            "claude",
+            &busy,
+            "act-b0-b",
+            0.0,
+            200,
+            0,
+            0,
+            0,
+            Some(300),
+            -6 * 3600 + 240,
+        );
+        // 桶 23（最近）：一次失败（403，无首字）
+        seed_board_usage(
+            &db,
+            "claude",
+            &busy,
+            "act-b23-f",
+            0.0,
+            403,
+            0,
+            0,
+            0,
+            None,
+            -60,
+        );
+        // 窗外（8 小时前）：不计入
+        seed_board_usage(
+            &db,
+            "claude",
+            &busy,
+            "act-out",
+            0.0,
+            200,
+            0,
+            0,
+            0,
+            Some(10),
+            -8 * 3600,
+        );
+
+        let board = tier_board_impl(&state, "claude").await.unwrap();
+        let by_id = |id: &str| board.tiers.iter().find(|t| t.provider_id == id).unwrap();
+        let activity = by_id(&busy)
+            .recent_activity
+            .as_ref()
+            .expect("窗口内有行的档位必须有活动桶");
+        assert_eq!(activity.len(), 24, "固定 24 桶（空桶补零），时间线不断续");
+        assert_eq!(activity[0].success_count, 2);
+        assert_eq!(activity[0].fail_count, 0);
+        assert_eq!(activity[0].avg_first_token_ms, Some(200));
+        assert_eq!(activity[23].success_count, 0);
+        assert_eq!(activity[23].fail_count, 1);
+        assert_eq!(activity[23].avg_first_token_ms, None);
+        assert_eq!(activity[5].success_count, 0, "空桶补零");
+        assert_eq!(activity[5].avg_first_token_ms, None);
+        assert!(
+            by_id(&cold).recent_activity.is_none(),
+            "窗口内没有行的档位 → None，前端不渲染"
+        );
+    }
+
     /// 看板用量 seed：一行带花费与缓存 token 的明细（created_at = now + 偏移秒）。
     #[allow(clippy::too_many_arguments)]
     fn seed_board_usage(
@@ -879,9 +1021,11 @@ mod tests {
         provider_id: &str,
         request_id: &str,
         cost_usd: f64,
+        status_code: i64,
         input_tokens: i64,
         cache_creation: i64,
         cache_read: i64,
+        first_token_ms: Option<i64>,
         created_at_offset_secs: i64,
     ) {
         let conn = db.conn.lock().unwrap();
@@ -890,7 +1034,7 @@ mod tests {
                 request_id, provider_id, app_type, model,
                 input_tokens, cache_creation_tokens, cache_read_tokens,
                 total_cost_usd, latency_ms, first_token_ms, status_code, created_at
-            ) VALUES (?1, ?2, ?3, 'm', ?4, ?5, ?6, ?7, 10, 10, 200, ?8)",
+            ) VALUES (?1, ?2, ?3, 'm', ?4, ?5, ?6, ?7, 10, ?8, ?9, ?10)",
             rusqlite::params![
                 request_id,
                 provider_id,
@@ -899,6 +1043,8 @@ mod tests {
                 cache_creation,
                 cache_read,
                 cost_usd,
+                first_token_ms,
+                status_code,
                 chrono::Utc::now().timestamp() + created_at_offset_secs,
             ],
         )

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -15,6 +15,16 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
+/// 看板「近期活动时间线」的一桶（15 分钟）：成功数/失败数/均首字。
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderActivityBucket {
+    pub success_count: u32,
+    pub fail_count: u32,
+    /// 桶内成功请求的平均首字耗时（毫秒）；`None` = 桶内没有带首字的请求。
+    pub avg_first_token_ms: Option<u64>,
+}
+
 /// 使用量汇总
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -1365,6 +1375,58 @@ impl Database {
             if cacheable > 0 {
                 result.insert(provider_id, cache_read as f64 / cacheable as f64);
             }
+        }
+        Ok(result)
+    }
+
+    /// 看板「近期活动时间线」：窗口内各 provider 按 bucket 分桶的
+    /// 成功数/失败数/均首字。失败 = `status_code` 不在 2xx/3xx（网络层失败
+    /// 不落明细行，这里只能看到有响应的失败）。固定桶数、空桶补零 ——
+    /// 前端拿到的是不断续的时间线；窗口内没有任何行的 provider 不进 map。
+    pub fn get_provider_activity_buckets(
+        &self,
+        app_type: &str,
+        since: i64,
+        bucket_secs: i64,
+        bucket_count: usize,
+    ) -> Result<HashMap<String, Vec<ProviderActivityBucket>>, AppError> {
+        let conn = lock_conn!(self.conn);
+        let mut stmt = conn.prepare(
+            "SELECT provider_id,
+                    (created_at - ?2) / ?3,
+                    SUM(CASE WHEN status_code >= 200 AND status_code < 400 THEN 1 ELSE 0 END),
+                    SUM(CASE WHEN status_code >= 200 AND status_code < 400 THEN 0 ELSE 1 END),
+                    SUM(first_token_ms) / NULLIF(
+                        SUM(CASE WHEN first_token_ms IS NOT NULL THEN 1 ELSE 0 END), 0)
+             FROM proxy_request_logs
+             WHERE app_type = ?1 AND created_at >= ?2 AND created_at < ?2 + ?3 * ?4
+             GROUP BY provider_id, (created_at - ?2) / ?3",
+        )?;
+        let rows = stmt.query_map(
+            params![app_type, since, bucket_secs, bucket_count as i64],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, i64>(1)?,
+                    row.get::<_, Option<i64>>(2)?,
+                    row.get::<_, Option<i64>>(3)?,
+                    row.get::<_, Option<i64>>(4)?,
+                ))
+            },
+        )?;
+        let mut result: HashMap<String, Vec<ProviderActivityBucket>> = HashMap::new();
+        for row in rows {
+            let (provider_id, bucket, success, fail, avg_ttft) = row?;
+            let buckets = result
+                .entry(provider_id)
+                .or_insert_with(|| vec![ProviderActivityBucket::default(); bucket_count]);
+            // 窗口上界用严格 <，正常不会越界；min 兜底防时间戳毛刺
+            let idx = (bucket.max(0) as usize).min(bucket_count - 1);
+            buckets[idx] = ProviderActivityBucket {
+                success_count: success.unwrap_or(0).max(0) as u32,
+                fail_count: fail.unwrap_or(0).max(0) as u32,
+                avg_first_token_ms: avg_ttft.filter(|v| *v >= 0).map(|v| v as u64),
+            };
         }
         Ok(result)
     }

--- a/src/components/easymode/TierList.tsx
+++ b/src/components/easymode/TierList.tsx
@@ -128,7 +128,7 @@ function SortableTierCard({
 }
 
 /**
- * 档位卡：序号 + 名称 + 当前命中 + 失败原因 + 重新启用 + 指标行。
+ * 档位卡：序号 + 名称 + 当前命中 + 失败原因 + 指标行 + 近期时间线 + 重新启用。
  * 指标行顺序按语义分组：定价（倍率/单价）→ 运行（今日/首字/缓存）→ 供给（余额）；
  * 金额/整数走全仓唯源 fmtUsd/fmtInt，未知值统一 —。
  */
@@ -254,6 +254,7 @@ function TierCard({
           </span>
         </div>
       </div>
+      <TierActivityTimeline tier={tier} />
       {failed ? (
         <button
           type="button"
@@ -351,5 +352,107 @@ function TierHealthBadge({ tier }: { tier: TierBoardTier }) {
         </div>
       </PopoverContent>
     </Popover>
+  );
+}
+
+/**
+ * 近期活动时间线（卡片右缘）：上条 = 近 6 小时每 15 分钟一桶的成败
+ * （绿=全成、琥珀=有失败、红=全败、灰=无流量）；下线 = 桶均首字走势
+ * （缺口=该桶无首字样本，段间断开）。数据全部来自后端看板，前端只画。
+ */
+function TierActivityTimeline({ tier }: { tier: TierBoardTier }) {
+  const { t } = useTranslation();
+  const buckets = tier.recentActivity;
+  if (!buckets || buckets.length === 0) {
+    return null;
+  }
+  const ok = buckets.reduce((n, b) => n + b.successCount, 0);
+  const fail = buckets.reduce((n, b) => n + b.failCount, 0);
+  const ttftBuckets = buckets.filter((b) => b.avgFirstTokenMs != null);
+  const avgTtft = ttftBuckets.length
+    ? Math.round(
+        ttftBuckets.reduce((n, b) => n + (b.avgFirstTokenMs ?? 0), 0) /
+          ttftBuckets.length,
+      )
+    : null;
+
+  return (
+    <div className="flex w-24 shrink-0 flex-col gap-1" aria-hidden>
+      <div
+        className="flex h-3 items-stretch gap-px"
+        title={t("autoMode.board.recentTimeline", {
+          defaultValue:
+            "近 6 小时：成功 {{ok}} · 失败 {{fail}} · 首字 {{ttft}}",
+          ok,
+          fail,
+          ttft: avgTtft != null ? `${avgTtft}ms` : "—",
+        })}
+      >
+        {buckets.map((bucket, i) => {
+          const hasTraffic = bucket.successCount + bucket.failCount > 0;
+          const color = !hasTraffic
+            ? "bg-muted"
+            : bucket.successCount === 0
+              ? "bg-red-500"
+              : bucket.failCount > 0
+                ? "bg-amber-500"
+                : "bg-emerald-500/70";
+          return <div key={i} className={`flex-1 rounded-sm ${color}`} />;
+        })}
+      </div>
+      <TtftSparkline buckets={buckets} />
+    </div>
+  );
+}
+
+/** 首字走势迷你折线（纯 SVG，无图库依赖）：按窗口内 min/max 归一，空桶断段。 */
+function TtftSparkline({
+  buckets,
+}: {
+  buckets: NonNullable<TierBoardTier["recentActivity"]>;
+}) {
+  const values = buckets
+    .map((b) => b.avgFirstTokenMs)
+    .filter((v): v is number => v != null);
+  if (values.length < 2) {
+    return <div className="h-3" />;
+  }
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min || 1;
+  const x = (i: number) => (i / (buckets.length - 1)) * 96;
+  const y = (v: number) => 10 - ((v - min) / span) * 8;
+  // 连续非空段分别成线：缺首字的桶把走势断开，不硬连
+  const segments: string[][] = [];
+  let current: string[] = [];
+  buckets.forEach((b, i) => {
+    if (b.avgFirstTokenMs != null) {
+      current.push(`${x(i).toFixed(1)},${y(b.avgFirstTokenMs).toFixed(1)}`);
+    } else if (current.length > 0) {
+      segments.push(current);
+      current = [];
+    }
+  });
+  if (current.length > 0) segments.push(current);
+
+  return (
+    <svg
+      viewBox="0 0 96 12"
+      preserveAspectRatio="none"
+      className="h-3 w-full text-muted-foreground"
+    >
+      {segments
+        .filter((points) => points.length > 1)
+        .map((points, i) => (
+          <polyline
+            key={i}
+            points={points.join(" ")}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1"
+            vectorEffect="non-scaling-stroke"
+          />
+        ))}
+    </svg>
   );
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2663,7 +2663,8 @@
       "requestsUnit": "{{count}} calls",
       "cache": "Cache",
       "reenable": "Re-enable",
-      "retryAll": "Retry tripped tiers"
+      "retryAll": "Retry tripped tiers",
+      "recentTimeline": "Last 6h: {{ok}} ok · {{fail}} failed · TTFT {{ttft}}"
     },
     "modelHint": "With a model picked, only tiers whose catalog includes it are chosen; an explicit pick switches to the best tier immediately.",
     "advancedSection": "Advanced (failover queue & circuit breaker)",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2663,7 +2663,8 @@
       "requestsUnit": "{{count}} 回",
       "cache": "キャッシュ",
       "reenable": "再有効化",
-      "retryAll": "まとめて再有効化"
+      "retryAll": "まとめて再有効化",
+      "recentTimeline": "直近 6 時間：成功 {{ok}} · 失敗 {{fail}} · 初字 {{ttft}}"
     },
     "modelHint": "モデルを選ぶと、カタログにそのモデルを含むティアのみが対象になります。明示的に選ぶと即座に最適なティアへ切替えます。",
     "advancedSection": "詳細（フェイルオーバーキューとサーキットブレーカー）",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2664,7 +2664,8 @@
       "requestsUnit": "{{count}} 次",
       "cache": "快取",
       "reenable": "重新啟用",
-      "retryAll": "重試全部斷路檔位"
+      "retryAll": "重試全部斷路檔位",
+      "recentTimeline": "近 6 小時：成功 {{ok}} · 失敗 {{fail}} · 首字 {{ttft}}"
     },
     "modelHint": "選了模型後只在目錄含該模型的檔位裡挑；顯式點選會立即切到最優檔位",
     "advancedSection": "進階（故障轉移佇列與熔斷）",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2663,7 +2663,8 @@
       "requestsUnit": "{{count}} 次",
       "cache": "缓存",
       "reenable": "重新启用",
-      "retryAll": "重试全部熔断档位"
+      "retryAll": "重试全部熔断档位",
+      "recentTimeline": "近 6 小时：成功 {{ok}} · 失败 {{fail}} · 首字 {{ttft}}"
     },
     "modelHint": "选了模型后只在目录含该模型的档位里挑；显式点选会立即切到最优档位",
     "advancedSection": "高级（故障转移队列与熔断）",

--- a/src/lib/api/autoMode.ts
+++ b/src/lib/api/autoMode.ts
@@ -50,6 +50,15 @@ export interface TierBoardTier {
   todayRequests: number | null;
   /** 7 天缓存命中率（0..1 分数）；`null` = 无可判流量（前端显示 —）。 */
   cacheHitRate: number | null;
+  /** 近 6 小时活动时间线（15 分钟一桶固定 24 桶）；`null` = 窗口内无请求。 */
+  recentActivity: TierActivityBucket[] | null;
+}
+
+/** 近期活动时间线的一桶：成功数/失败数/桶内平均首字（ms）。 */
+export interface TierActivityBucket {
+  successCount: number;
+  failCount: number;
+  avgFirstTokenMs: number | null;
 }
 
 export interface TierBoard {

--- a/tests/components/EasyBoard.test.tsx
+++ b/tests/components/EasyBoard.test.tsx
@@ -70,6 +70,20 @@ function boardFixture(overrides: Partial<TierBoard> = {}): TierBoard {
         todayCostUsd: 0.75,
         todayRequests: 128,
         cacheHitRate: 0.87,
+        recentActivity: [
+          ...Array.from({ length: 10 }, () => ({
+            successCount: 5,
+            failCount: 0,
+            avgFirstTokenMs: 800,
+          })),
+          { successCount: 3, failCount: 1, avgFirstTokenMs: 1200 },
+          ...Array.from({ length: 12 }, () => ({
+            successCount: 4,
+            failCount: 0,
+            avgFirstTokenMs: 900,
+          })),
+          { successCount: 0, failCount: 2, avgFirstTokenMs: null },
+        ],
       },
       {
         providerId: "tier-b",
@@ -88,6 +102,7 @@ function boardFixture(overrides: Partial<TierBoard> = {}): TierBoard {
         todayCostUsd: null,
         todayRequests: null,
         cacheHitRate: null,
+        recentActivity: null,
       },
     ],
     ...overrides,
@@ -124,6 +139,11 @@ describe("EasyBoard", () => {
     expect(screen.getByText("价格未知")).toBeDefined();
     expect(screen.getByText("今日 $0.75 · 128 次")).toBeDefined();
     expect(screen.getByText("缓存 87%")).toBeDefined();
+    // 有近期流量的档渲染时间线（title 汇总 + 首字折线）；无流量的档不渲染
+    expect(
+      screen.getByTitle("近 6 小时：成功 101 · 失败 3 · 首字 870ms"),
+    ).toBeDefined();
+    expect(document.querySelectorAll("polyline").length).toBeGreaterThan(0);
     // 当前命中只在 isCurrent 档出现一次
     expect(screen.getAllByText("当前")).toHaveLength(1);
   });
@@ -137,6 +157,7 @@ describe("EasyBoard", () => {
       todayCostUsd: null,
       todayRequests: null,
       cacheHitRate: null,
+      recentActivity: null,
     };
     setupBoard(
       boardFixture({
@@ -183,6 +204,7 @@ describe("EasyBoard", () => {
       todayCostUsd: null,
       todayRequests: null,
       cacheHitRate: null,
+      recentActivity: null,
     };
     setupBoard(
       boardFixture({


### PR DESCRIPTION
第二批（瘦身版）：填上档位卡一直空着的右侧。

- **成败条带**：近 6 小时、15 分钟一桶固定 24 桶（空桶补零，时间线不断续）；绿=全成、琥珀=有失败、红=全败、灰=无流量；悬停 title 给窗口合计（成功/失败/均首字）。
- **首字走势**：纯 SVG 折线（无图库依赖），按窗口 min/max 归一；缺首字样本的桶断段不硬连；少于两个样本不画。
- 后端 `get_provider_activity_buckets` 单查询 GROUP BY 分桶；窗口内无请求的档位 `recent_activity = null`，前端不渲染。失败 = status_code 出 2xx/3xx（网络层失败不落明细行，只能看到有响应的失败——已知边界）。
- **全网实测小节本期不做**：线上 crowd 快照站点数为 0（k≥3 匿名 + 默认关闭 + 客户端覆盖未起），做了就是空壳，等数据积累再接。

测试（TDD）：`tier_board_surfaces_recent_activity_buckets`（24 桶/空桶补零/均首字/窗外不计/无行档 None）；组件测试补时间线 title 汇总与 polyline 渲染断言。全量 cargo test 3739 绿、clippy 干净；vitest 1293 绿、typecheck / format:check 过。