### PR TITLE
feat(easymode): 模型选择器 Combobox（输入过滤 + 档数与最低价）

### DIFF
--- a/src-tauri/src/commands/auto_mode.rs
+++ b/src-tauri/src/commands/auto_mode.rs
@@ -407,9 +407,21 @@ pub struct TierBoard {
     /// "cheapest" | "fastest"（全局一份）
     pub strategy: String,
     pub model: Option<String>,
-    pub available_models: Vec<String>,
+    /// 可选模型清单（目录并集，顺序 = 档位序 → 目录内序），带每模型的
+    /// 「几档可用 + 最便宜有效单价」——模型选择器的数据源。
+    pub model_options: Vec<TierBoardModelOption>,
     pub current_provider_id: Option<String>,
     pub tiers: Vec<TierBoardTier>,
+}
+
+/// 模型选择器的一行：模型名 + 覆盖度（几档的目录含它）+ 最便宜有效单价
+/// （倍率 × 模型单价，与排序同一套数据；价格/倍率未知 → `None`）。
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TierBoardModelOption {
+    pub model: String,
+    pub tier_count: u32,
+    pub cheapest_price_per_million: Option<f64>,
 }
 
 /// 省心模式档位看板（首页省心视图数据源）。
@@ -545,11 +557,48 @@ pub(crate) async fn tier_board_impl(state: &AppState, app_type: &str) -> Result<
         })
         .collect();
 
+    // 模型选项：全部托管档的目录并集（不按偏好过滤——选择器清单不因当前
+    // 偏好缩水），每模型统计覆盖档数与最便宜「倍率×单价」（与排序同源；
+    // 倍率或价格未知的档不参与最低价比较）
+    let mut model_options: Vec<TierBoardModelOption> = Vec::new();
+    for provider in providers.values() {
+        if !crate::relay::is_managed(&provider.id) {
+            continue;
+        }
+        let multiplier = multipliers.get(&provider.id).copied();
+        for model in auto_strategy::tier_models(provider) {
+            let unit_price = model_unit_price(db, &model);
+            match model_options
+                .iter_mut()
+                .find(|option| option.model == model)
+            {
+                Some(option) => {
+                    option.tier_count += 1;
+                    if let (Some(multiplier), Some(price)) = (multiplier, unit_price) {
+                        option.cheapest_price_per_million = match option.cheapest_price_per_million
+                        {
+                            Some(current) => Some(current.min(multiplier * price)),
+                            None => Some(multiplier * price),
+                        };
+                    }
+                }
+                None => model_options.push(TierBoardModelOption {
+                    model: model.clone(),
+                    tier_count: 1,
+                    cheapest_price_per_million: match (multiplier, unit_price) {
+                        (Some(multiplier), Some(price)) => Some(multiplier * price),
+                        _ => None,
+                    },
+                }),
+            }
+        }
+    }
+
     Ok(TierBoard {
         mode: auto_strategy::get_mode(db, app_type).as_str().to_string(),
         strategy: auto_strategy::get_strategy(db).as_str().to_string(),
         model: model_pref,
-        available_models: auto_strategy::auto_mode_models(&providers),
+        model_options,
         current_provider_id: current_id,
         tiers,
     })
@@ -625,6 +674,20 @@ async fn fetch_site_balances(
         }
     }
     balances
+}
+
+/// 模型单价（每百万 token 输入+输出之和，美元）；价表未收录 → `None`。
+/// 与 `auto_strategy::tier_unit_price` 同一张表，只是按模型名直查。
+fn model_unit_price(db: &crate::Database, model: &str) -> Option<f64> {
+    let conn = db
+        .conn
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let (input, output, _cache_read, _cache_creation) =
+        crate::services::usage_stats::find_model_pricing_row(&conn, model).ok()??;
+    let input: f64 = input.parse().ok()?;
+    let output: f64 = output.parse().ok()?;
+    Some(input + output)
 }
 
 /// 从 base_url 取 `scheme://authority`（`https://site/v1` → `https://site`）。
@@ -1018,6 +1081,64 @@ mod tests {
         assert_eq!(cold_tier.today_cost_usd, None, "没有行 → None，前端显示 —");
         assert_eq!(cold_tier.today_requests, None);
         assert_eq!(cold_tier.cache_hit_rate, None, "分母为 0 不显示 0%");
+    }
+
+    /// ⭐ 模型选项：目录并集带「几档可用 + 最便宜倍率×单价」；价表未收录或
+    /// 倍率未知的模型不给最低价（不猜）。
+    #[tokio::test]
+    #[serial]
+    async fn tier_board_model_options_carry_coverage_and_cheapest_price() {
+        let _home = test_home();
+        let db = Arc::new(Database::memory().unwrap());
+        let state = AppState::new(db.clone());
+
+        let cheap = crate::relay::provision::provider_id_for("https://a.example", Some(1), 1);
+        let expensive = crate::relay::provision::provider_id_for("https://b.example", Some(1), 2);
+        let with_catalog = |id: &str, models: &[&str]| {
+            crate::provider::Provider::with_id(
+                id.to_string(),
+                id.to_string(),
+                json!({ "modelCatalog": { "models": models.iter().map(|m| json!({ "model": m })).collect::<Vec<_>>() } }),
+                None,
+            )
+        };
+        db.save_provider("codex", &with_catalog(&cheap, &["m-x", "m-y"]))
+            .unwrap();
+        db.save_provider("codex", &with_catalog(&expensive, &["m-x"]))
+            .unwrap();
+        db.set_tier_rate_multiplier("codex", &cheap, Some(0.5))
+            .unwrap();
+        db.set_tier_rate_multiplier("codex", &expensive, Some(2.0))
+            .unwrap();
+        // 价表只收录 m-x：$1 输入 + $1 输出 = 单价 2
+        {
+            let conn = db.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO model_pricing (model_id, display_name, input_cost_per_million, output_cost_per_million)
+                 VALUES ('m-x', 'M X', '1', '1')",
+                [],
+            )
+            .unwrap();
+        }
+
+        let board = tier_board_impl(&state, "codex").await.unwrap();
+        let by_model = |model: &str| {
+            board
+                .model_options
+                .iter()
+                .find(|option| option.model == model)
+                .unwrap_or_else(|| panic!("缺 {model}"))
+        };
+        let m_x = by_model("m-x");
+        assert_eq!(m_x.tier_count, 2, "两档目录都含 m-x");
+        // 最低 = min(0.5×2, 2.0×2) = 1.0
+        assert!((m_x.cheapest_price_per_million.unwrap() - 1.0).abs() < 1e-9);
+        let m_y = by_model("m-y");
+        assert_eq!(m_y.tier_count, 1);
+        assert_eq!(
+            m_y.cheapest_price_per_million, None,
+            "价表未收录 → 不给最低价"
+        );
     }
 
     /// ⭐ 近期活动时间线：6 小时 / 15 分钟一桶固定 24 桶，每桶成功数/失败数/

--- a/src/components/easymode/EasyBoard.tsx
+++ b/src/components/easymode/EasyBoard.tsx
@@ -6,13 +6,7 @@
  */
 import { useTranslation } from "react-i18next";
 import { RefreshCw } from "lucide-react";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { ModelPicker } from "./ModelPicker";
 import { useProxyStatus } from "@/hooks/useProxyStatus";
 import {
   useAutoModeStatus,
@@ -26,9 +20,6 @@ import { useResetCircuitBreaker } from "@/lib/query/failover";
 import { cn } from "@/lib/utils";
 import { SelfManagedBar } from "./SelfManagedBar";
 import { TierList } from "./TierList";
-
-/** Select 不能用空串当 value 的哨兵（与 AutoModeTabContent 同一个约定）。 */
-const MODEL_ANY = "__any__";
 
 export function EasyBoard({ appId }: { appId: string }) {
   const { t } = useTranslation();
@@ -92,31 +83,13 @@ export function EasyBoard({ appId }: { appId: string }) {
         </div>
       ) : null}
       <div className="flex flex-wrap items-center gap-3">
-        {board.availableModels.length > 0 ? (
-          <Select
-            value={board.model ?? MODEL_ANY}
+        {board.modelOptions.length > 0 ? (
+          <ModelPicker
+            model={board.model}
+            modelOptions={board.modelOptions}
             disabled={setModel.isPending}
-            onValueChange={(value) =>
-              setModel.mutate({
-                appType: appId,
-                model: value === MODEL_ANY ? null : value,
-              })
-            }
-          >
-            <SelectTrigger className="w-64">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value={MODEL_ANY}>
-                {t("autoMode.modelAny", { defaultValue: "不限模型" })}
-              </SelectItem>
-              {board.availableModels.map((model) => (
-                <SelectItem key={model} value={model}>
-                  {model}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+            onSelect={(model) => setModel.mutate({ appType: appId, model })}
+          />
         ) : null}
 
         <div className="grid grid-cols-2 gap-2">

--- a/src/components/easymode/ModelPicker.tsx
+++ b/src/components/easymode/ModelPicker.tsx
@@ -1,0 +1,122 @@
+/**
+ * 省心视图的模型选择器：可输入过滤的 Combobox（形状抄 ProfileSwitcher
+ * 的 Command-in-Popover）。每行除了模型名，还带「N 档 · 最低 $X.XX/M」
+ * ——覆盖度与决策成本两个数，都由看板后端算好（唯源）。
+ */
+
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Check, ChevronsUpDown } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { fmtUsd } from "@/components/usage/format";
+import type { TierBoardModelOption } from "@/lib/api/autoMode";
+
+/** Select 不能用空串当 value 的哨兵（与 EasyBoard 同一个约定）。 */
+export const MODEL_ANY = "__any__";
+
+export function ModelPicker({
+  model,
+  modelOptions,
+  disabled,
+  onSelect,
+}: {
+  model: string | null;
+  modelOptions: TierBoardModelOption[];
+  disabled?: boolean;
+  onSelect: (model: string | null) => void;
+}) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+
+  const label = model ?? t("autoMode.modelAny", { defaultValue: "不限模型" });
+  const meta = (option: TierBoardModelOption) => {
+    const tiers = t("autoMode.board.tiersShort", { defaultValue: "档" });
+    const count = `${option.tierCount} ${tiers}`;
+    return option.cheapestPricePerMillion != null
+      ? `${count} · ${fmtUsd(option.cheapestPricePerMillion, 2)}/M`
+      : count;
+  };
+
+  const handleSelect = (value: string) => {
+    setOpen(false);
+    onSelect(value === MODEL_ANY ? null : value);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className="w-64 justify-between font-normal"
+        >
+          <span className="truncate">{label}</span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-72 p-0" align="start">
+        <Command label={label}>
+          <CommandInput
+            placeholder={t("autoMode.board.modelFilterPlaceholder", {
+              defaultValue: "输入模型名筛选…",
+            })}
+          />
+          <CommandList>
+            <CommandEmpty>
+              {t("autoMode.board.modelFilterEmpty", {
+                defaultValue: "没有匹配的模型",
+              })}
+            </CommandEmpty>
+            <CommandGroup>
+              <CommandItem value={MODEL_ANY} onSelect={handleSelect}>
+                <Check
+                  className={cn(
+                    "mr-2 h-4 w-4 shrink-0",
+                    model == null ? "opacity-100" : "opacity-0",
+                  )}
+                />
+                {t("autoMode.modelAny", { defaultValue: "不限模型" })}
+              </CommandItem>
+              {modelOptions.map((option) => (
+                <CommandItem
+                  key={option.model}
+                  value={option.model}
+                  onSelect={handleSelect}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4 shrink-0",
+                      model === option.model ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  <span className="min-w-0 flex-1 truncate">
+                    {option.model}
+                  </span>
+                  <span className="ml-2 shrink-0 text-xs text-muted-foreground tabular-nums">
+                    {meta(option)}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2670,7 +2670,10 @@
       "selfManagedTitle": "Official & self-managed",
       "switchBack": "Switch back",
       "selfManagedEmpty": "No official or self-managed providers yet (add in self-managed mode)",
-      "switchBackDone": "Switched back to {{name}}; this app is now self-managed"
+      "switchBackDone": "Switched back to {{name}}; this app is now self-managed",
+      "tiersShort": "tiers",
+      "modelFilterPlaceholder": "Filter models…",
+      "modelFilterEmpty": "No matching models"
     },
     "modelHint": "With a model picked, only tiers whose catalog includes it are chosen; an explicit pick switches to the best tier immediately.",
     "advancedSection": "Advanced (failover queue & circuit breaker)",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2670,7 +2670,10 @@
       "selfManagedTitle": "公式・自前",
       "switchBack": "切り替え",
       "selfManagedEmpty": "公式・自前のプロバイダーがまだありません（自選モードで追加）",
-      "switchBackDone": "{{name}} に切り替えました。このアプリは自選モードになりました"
+      "switchBackDone": "{{name}} に切り替えました。このアプリは自選モードになりました",
+      "tiersShort": "ティア",
+      "modelFilterPlaceholder": "モデル名で絞り込み…",
+      "modelFilterEmpty": "一致するモデルなし"
     },
     "modelHint": "モデルを選ぶと、カタログにそのモデルを含むティアのみが対象になります。明示的に選ぶと即座に最適なティアへ切替えます。",
     "advancedSection": "詳細（フェイルオーバーキューとサーキットブレーカー）",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2671,7 +2671,10 @@
       "selfManagedTitle": "官方與自建",
       "switchBack": "切回",
       "selfManagedEmpty": "還沒有官方或自建供應商（在自主模式新增）",
-      "switchBackDone": "已切回 {{name}}，該應用轉為自主模式"
+      "switchBackDone": "已切回 {{name}}，該應用轉為自主模式",
+      "tiersShort": "檔",
+      "modelFilterPlaceholder": "輸入模型名篩選…",
+      "modelFilterEmpty": "沒有符合的模型"
     },
     "modelHint": "選了模型後只在目錄含該模型的檔位裡挑；顯式點選會立即切到最優檔位",
     "advancedSection": "進階（故障轉移佇列與熔斷）",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2670,7 +2670,10 @@
       "selfManagedTitle": "官方与自建",
       "switchBack": "切回",
       "selfManagedEmpty": "还没有官方或自建供应商（在自主模式添加）",
-      "switchBackDone": "已切回 {{name}}，该应用转为自主模式"
+      "switchBackDone": "已切回 {{name}}，该应用转为自主模式",
+      "tiersShort": "档",
+      "modelFilterPlaceholder": "输入模型名筛选…",
+      "modelFilterEmpty": "没有匹配的模型"
     },
     "modelHint": "选了模型后只在目录含该模型的档位里挑；显式点选会立即切到最优档位",
     "advancedSection": "高级（故障转移队列与熔断）",

--- a/src/lib/api/autoMode.ts
+++ b/src/lib/api/autoMode.ts
@@ -67,11 +67,19 @@ export interface TierActivityBucket {
   avgFirstTokenMs: number | null;
 }
 
+/** 模型选择器的一行：模型名 + 覆盖档数 + 最便宜有效单价（倍率×单价）。 */
+export interface TierBoardModelOption {
+  model: string;
+  tierCount: number;
+  /** `null` = 价表未收录或倍率未知（不猜）。 */
+  cheapestPricePerMillion: number | null;
+}
+
 export interface TierBoard {
   mode: EasyModeMode;
   strategy: AutoModeStrategy;
   model: string | null;
-  availableModels: string[];
+  modelOptions: TierBoardModelOption[];
   currentProviderId: string | null;
   tiers: TierBoardTier[];
 }

--- a/tests/components/EasyBoard.test.tsx
+++ b/tests/components/EasyBoard.test.tsx
@@ -1,5 +1,13 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  describe,
+  expect,
+  it,
+  vi,
+  beforeEach,
+  beforeAll,
+  afterAll,
+} from "vitest";
 
 import { EasyBoard } from "@/components/easymode/EasyBoard";
 import type { TierBoard } from "@/lib/api/autoMode";
@@ -65,7 +73,14 @@ function boardFixture(overrides: Partial<TierBoard> = {}): TierBoard {
     mode: "auto",
     strategy: "cheapest",
     model: null,
-    availableModels: ["claude-fable-5", "deepseek-v4-flash"],
+    modelOptions: [
+      { model: "claude-fable-5", tierCount: 2, cheapestPricePerMillion: 1.5 },
+      {
+        model: "deepseek-v4-flash",
+        tierCount: 1,
+        cheapestPricePerMillion: null,
+      },
+    ],
     currentProviderId: "tier-b",
     tiers: [
       {
@@ -139,13 +154,35 @@ function setupBoard(board: TierBoard) {
       enabled: true,
       strategy: board.strategy,
       model: board.model,
-      availableModels: board.availableModels,
+      availableModels: board.modelOptions.map((option) => option.model),
       hasCandidates: true,
       cliInstalled: true,
     },
   });
   render(<EasyBoard appId="claude" />);
 }
+
+// cmdk（模型选择器）需要 scrollIntoView，jsdom 没有 —— 保存/恢复式打桩
+let scrollIntoViewDescriptor: PropertyDescriptor | undefined;
+beforeAll(() => {
+  scrollIntoViewDescriptor = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "scrollIntoView",
+  );
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: vi.fn(),
+  });
+});
+afterAll(() => {
+  if (scrollIntoViewDescriptor) {
+    Object.defineProperty(
+      HTMLElement.prototype,
+      "scrollIntoView",
+      scrollIntoViewDescriptor,
+    );
+  }
+});
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -414,6 +451,34 @@ describe("EasyBoard", () => {
         appType: "claude",
         providerId: "official-chatgpt",
         quitChatgpt: undefined,
+      }),
+    );
+  });
+
+  it("模型选择器：可输入过滤，候选项带档数与最低价", async () => {
+    setupBoard(boardFixture());
+    // 默认收起，触发器显示「不限模型」
+    expect(screen.getByRole("combobox", { name: "" })).toBeDefined();
+
+    fireEvent.click(screen.getByRole("combobox"));
+    expect(await screen.findByText("claude-fable-5")).toBeDefined();
+    expect(screen.getByText("2 档 · $1.50/M")).toBeDefined();
+    expect(screen.getByText("deepseek-v4-flash")).toBeDefined();
+    expect(screen.getByText("1 档")).toBeDefined();
+
+    // 输入过滤：只剩匹配项
+    fireEvent.change(await screen.findByPlaceholderText("输入模型名筛选…"), {
+      target: { value: "deepseek" },
+    });
+    expect(screen.queryByText("claude-fable-5")).toBeNull();
+    expect(screen.getByText("deepseek-v4-flash")).toBeDefined();
+
+    // 选中 deepseek → setModel 收到 null 语义反转前的真实模型名
+    fireEvent.click(screen.getByText("deepseek-v4-flash"));
+    await waitFor(() =>
+      expect(setModelMock).toHaveBeenCalledWith({
+        appType: "claude",
+        model: "deepseek-v4-flash",
       }),
     );
   });


### PR DESCRIPTION
省心视图的模型选择器升级：

- **可输入过滤**：shadcn Select 换 Command-in-Popover（形状抄 ProfileSwitcher），输入模型名即筛；「不限模型」置顶保留。
- **候选项带信息**（用户问「展示哪些信息合适且不难实现」的答案）：每个模型显示 **「N 档 · 最低 $X.XX/M」**——N 档 = 覆盖度（几档目录含它），最低价 = 最便宜档的倍率×单价（与排序同一套数据，后端唯源算好）。价表未收录或倍率未知 → 只显示档数，不猜价格。刻意不展示余额/验真/耗时：那些是**档位**属性不是**模型**属性，硬塞会与档位卡重复且误导（同名模型在不同档位表现不同）。
- `TierBoard.available_models` → `model_options`（结构化，唯源替换不留旧字段）；清单仍取全部托管档目录并集，不因当前偏好缩水。`AutoModeStatus.availableModels`（设置页）不受影响。
- i18n 三键四语；cmdk 需要的 scrollIntoView 桩照 CodexOAuthSection.test 的保存/恢复形状。

测试：后端 `tier_board_model_options_carry_coverage_and_cheapest_price`（并集/档数/最低价 min/未收录 None）；组件测试（打开/过滤/选中落 setModel/meta 格式）。cargo 3743 绿、vitest 1292 绿、typecheck/format 过。