### PR TITLE
fix(relay): new-api 纯生图分组落生图栏，不再扇出聊天栏

### DIFF
--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -3087,20 +3087,39 @@ fn newapi_app_types() -> [AppType; 3] {
     [AppType::Claude, AppType::Codex, AppType::Gemini]
 }
 
-fn newapi_observed_keep(
+/// 把「一个 new-api 分组被观察到了」这个事实写进 keep 白名单，**按分类只保真实槽位**。
+///
+/// keep 是 `prune_stale_tiers` 的白名单：不在里面的托管档位会被清掉。
+///
+/// - 分类已知（`models = Some(非空目录)`）：只保候选真正会落的槽位 —— 纯生图分组
+///   只占生图栏，它历史上被扇出到 claude/codex/gemini 的旧投影随这次 provision 一并
+///   清掉（那是「生图模型被写成聊天模型」的必 404 档位）。
+/// - 分类未知（`models = None`：目录拉不到、或分组对账没走完）：保全四个槽位 ——
+///   keep 的语义是「观察到了就别删」，宁可留旧档也不误删。
+///
+/// ⚠️ `Some` 必须非空：空目录的 [`provision::is_pure_image_group`] 是真空真，
+/// 会把「读不出目录」误判成「纯生图」（见该函数文档的闸说明）。
+fn newapi_keep_insert(
+    keep: &mut std::collections::HashSet<(String, String)>,
     site_origin: &str,
     account_id: i64,
-    observed_groups: &[newapi::GroupIdentity],
-) -> std::collections::HashSet<(String, String)> {
-    observed_groups
-        .iter()
-        .flat_map(|group| {
-            let provider_id = provision::newapi_provider_id_for(site_origin, account_id, &group.0);
-            newapi_app_types()
-                .into_iter()
-                .map(move |app_type| (app_type.as_str().to_string(), provider_id.clone()))
-        })
-        .collect()
+    identity: &newapi::GroupIdentity,
+    models: Option<&[String]>,
+) {
+    let provider_id = provision::newapi_provider_id_for(site_origin, account_id, &identity.0);
+    let app_types: Vec<AppType> = match models {
+        Some(models) if provision::is_pure_image_group(models) => vec![AppType::CodexImage],
+        Some(_) => newapi_app_types().into(),
+        None => vec![
+            AppType::Claude,
+            AppType::Codex,
+            AppType::Gemini,
+            AppType::CodexImage,
+        ],
+    };
+    for app_type in app_types {
+        keep.insert((app_type.as_str().to_string(), provider_id.clone()));
+    }
 }
 
 fn newapi_candidates_for_group(
@@ -3110,7 +3129,16 @@ fn newapi_candidates_for_group(
     models: &[String],
 ) -> Vec<ManagedProvisionCandidate> {
     let provider_id = provision::newapi_provider_id_for(site_origin, account_id, &group.identity.0);
-    newapi_app_types()
+    // 纯生图分组只出生图候选，不扇出到三个聊天栏：把生图模型写成聊天模型是**调用必
+    // 404** 的档位（claude 拿 nano-banana-2 当 ANTHROPIC_MODEL、gemini 拿 gpt-image-2
+    // 当 GEMINI_MODEL —— 2026-09-05 真实 new-api 站点的生图分组实测踩中）。判据与 sub2api 路径的
+    // `image_tier_app_type` 同源：[`provision::is_pure_image_group`]。
+    let app_types: Vec<AppType> = if provision::is_pure_image_group(models) {
+        vec![AppType::CodexImage]
+    } else {
+        newapi_app_types().into()
+    };
+    app_types
         .into_iter()
         .map(|app_type| {
             let picked = provision::pick_tier_models(&app_type, Some(models));
@@ -3238,11 +3266,9 @@ async fn provision_backend(
                 account_id: Some(result.account_id),
                 site_declaration,
                 candidates: Vec::new(),
-                observed_keep: newapi_observed_keep(
-                    &op.site_origin,
-                    result.account_id,
-                    &result.observed_groups,
-                ),
+                // 分类感知的槽位在下面的分组循环里逐个补（`newapi_keep_insert`），
+                // 不再一次性保三个聊天栏 —— 纯生图分组只保生图栏。
+                observed_keep: std::collections::HashSet::new(),
                 failures: result
                     .failures
                     .into_iter()
@@ -3261,6 +3287,25 @@ async fn provision_backend(
                 keys_created: result.tokens_created,
             };
 
+            // 对账没走完的分组（建/列/揭示密钥失败，拿不到 sk 也拉不了目录）：
+            // 分类未知，保全四个槽位 —— 观察到了就别删。
+            let reconciled: std::collections::HashSet<newapi::GroupIdentity> = result
+                .groups
+                .iter()
+                .map(|group| group.identity.clone())
+                .collect();
+            for identity in &result.observed_groups {
+                if !reconciled.contains(identity) {
+                    newapi_keep_insert(
+                        &mut batch.observed_keep,
+                        &op.site_origin,
+                        result.account_id,
+                        identity,
+                        None,
+                    );
+                }
+            }
+
             for group in result.groups {
                 let models = match api::list_models(&op.site_origin, &group.api_key).await {
                     Ok(models) => match normalize_newapi_model_catalog(models) {
@@ -3270,6 +3315,14 @@ async fn provision_backend(
                                 group_name: group.name,
                                 reason: "model_catalog: /v1/models 未返回可用模型目录".into(),
                             });
+                            // 目录拉不到 = 分类未知：保全四个槽位，别把旧档误删。
+                            newapi_keep_insert(
+                                &mut batch.observed_keep,
+                                &op.site_origin,
+                                result.account_id,
+                                &group.identity,
+                                None,
+                            );
                             continue;
                         }
                     },
@@ -3278,9 +3331,23 @@ async fn provision_backend(
                             group_name: group.name,
                             reason: format!("model_catalog: {error}"),
                         });
+                        newapi_keep_insert(
+                            &mut batch.observed_keep,
+                            &op.site_origin,
+                            result.account_id,
+                            &group.identity,
+                            None,
+                        );
                         continue;
                     }
                 };
+                newapi_keep_insert(
+                    &mut batch.observed_keep,
+                    &op.site_origin,
+                    result.account_id,
+                    &group.identity,
+                    Some(&models),
+                );
                 batch.candidates.extend(newapi_candidates_for_group(
                     &op.site_origin,
                     result.account_id,
@@ -8459,28 +8526,111 @@ mod tests {
         groups: &[crate::relay::newapi_provision::ReconciledGroup],
     ) -> ManagedProvisionBatch {
         let account_id = op.account_id.expect("test relay has account id");
-        let observed_groups = groups
+        // 与 provision_backend 同一条纪律：keep 槽位跟着分类走（混合目录 = 三个聊天栏）。
+        let mut observed_keep = std::collections::HashSet::new();
+        let candidates = groups
             .iter()
-            .map(|group| group.identity.clone())
-            .collect::<Vec<_>>();
+            .flat_map(|group| {
+                let models = newapi_models();
+                newapi_keep_insert(
+                    &mut observed_keep,
+                    &op.site_origin,
+                    account_id,
+                    &group.identity,
+                    Some(&models),
+                );
+                newapi_candidates_for_group(&op.site_origin, account_id, group, &models)
+            })
+            .collect();
         ManagedProvisionBatch {
             account_id: Some(account_id),
             site_declaration: None,
-            candidates: groups
-                .iter()
-                .flat_map(|group| {
-                    newapi_candidates_for_group(
-                        &op.site_origin,
-                        account_id,
-                        group,
-                        &newapi_models(),
-                    )
-                })
-                .collect(),
-            observed_keep: newapi_observed_keep(&op.site_origin, account_id, &observed_groups),
+            candidates,
+            observed_keep,
             failures: Vec::new(),
             keys_created: 0,
         }
+    }
+
+    /// **纯生图分组的 new-api 扇出只出生图候选**（2026-09-05 某 new-api 站点纯生图
+    /// 分组的实测形状：`gpt-image-2 + nano-banana-2`）。
+    ///
+    /// 旧行为把每个分组无条件扇出到 claude/codex/gemini：生图模型被写成聊天模型
+    /// （`ANTHROPIC_MODEL=nano-banana-2`、`GEMINI_MODEL=gpt-image-2`），切过去调用必
+    /// 404 —— 生图栏则永远零档位（「此账号在当前平台没有可用分组」）。
+    #[test]
+    fn newapi_pure_image_group_lands_only_in_the_image_column_and_migrates_legacy_tiers() {
+        let op = test_newapi_relay(7);
+        let group = test_newapi_group("图", "sk-image");
+        let image_models =
+            provision::normalize_model_names(vec!["nano-banana-2".into(), "gpt-image-2".into()]);
+        let account_id = 7;
+
+        let candidates =
+            newapi_candidates_for_group(&op.site_origin, account_id, &group, &image_models);
+        assert_eq!(candidates.len(), 1, "纯生图分组不该再扇出到聊天栏");
+        assert_eq!(candidates[0].app_type, AppType::CodexImage);
+        // 默认模型 = gpt-image 家族优先（跨家族并存时表里靠前的家族胜出）。
+        assert_eq!(candidates[0].model, "gpt-image-2");
+
+        // 先按旧行为落三栏（等价于升级前 provision 过的存量），再按新分类
+        // provision 一次：三个聊天栏的旧投影必须被清掉、生图栏出现新档位。
+        let db = Arc::new(crate::database::Database::memory().expect("memory db"));
+        let state = AppState::new(db.clone());
+        persist_provision_batch(&state, &op, newapi_batch(&op, std::slice::from_ref(&group)))
+            .expect("seed legacy three-column projections");
+        let provider_id =
+            provision::newapi_provider_id_for(&op.site_origin, account_id, &group.identity.0);
+        for app_type in newapi_app_types() {
+            assert!(db
+                .get_provider_by_id(&provider_id, app_type.as_str())
+                .expect("read legacy projection")
+                .is_some());
+        }
+
+        let mut keep = std::collections::HashSet::new();
+        newapi_keep_insert(
+            &mut keep,
+            &op.site_origin,
+            account_id,
+            &group.identity,
+            Some(&image_models),
+        );
+        let migrated = ManagedProvisionBatch {
+            account_id: Some(account_id),
+            site_declaration: None,
+            candidates,
+            observed_keep: keep,
+            failures: Vec::new(),
+            keys_created: 0,
+        };
+        let summary =
+            persist_provision_batch(&state, &op, migrated).expect("migrate to image column");
+        assert_eq!(summary.tiers.len(), 1);
+        assert_eq!(summary.tiers[0].app_id, AppType::CodexImage.as_str());
+        for app_type in newapi_app_types() {
+            assert!(
+                db.get_provider_by_id(&provider_id, app_type.as_str())
+                    .expect("read pruned projection")
+                    .is_none(),
+                "{} 的旧投影没被清掉",
+                app_type.as_str()
+            );
+        }
+        // 生图栏新档位：codex 形状（生图 MCP 的读取契约）+ 家族优先选出的模型。
+        let image_provider = db
+            .get_provider_by_id(&provider_id, AppType::CodexImage.as_str())
+            .expect("read image projection")
+            .expect("image projection exists");
+        assert_eq!(
+            provision::extract_model(&image_provider.settings_config).as_deref(),
+            Some("gpt-image-2")
+        );
+        assert_eq!(
+            provision::extract_api_key(&image_provider.settings_config, &AppType::CodexImage)
+                .as_deref(),
+            Some("sk-image")
+        );
     }
 
     #[test]
@@ -8604,7 +8754,7 @@ mod tests {
     }
 
     #[test]
-    fn newapi_observed_keep_retains_failed_group_and_prunes_only_the_current_account() {
+    fn newapi_unclassified_keep_retains_failed_group_and_prunes_only_the_current_account() {
         let account_seven = test_newapi_relay(7);
         let account_eight = test_newapi_relay(8);
         let db = Arc::new(crate::database::Database::memory().expect("memory db"));
@@ -8640,15 +8790,20 @@ mod tests {
             provision::newapi_provider_id_for(&account_seven.site_origin, 7, &observed.0);
         let removed_id =
             provision::newapi_provider_id_for(&account_seven.site_origin, 7, "removed");
+        // 对账没走完（拿到 observed 清单但没拿到 sk）：分类未知，保全四个槽位。
+        let mut failure_keep = std::collections::HashSet::new();
+        newapi_keep_insert(
+            &mut failure_keep,
+            &account_seven.site_origin,
+            7,
+            &observed,
+            None,
+        );
         let failure_batch = ManagedProvisionBatch {
             account_id: Some(7),
             site_declaration: None,
             candidates: Vec::new(),
-            observed_keep: newapi_observed_keep(
-                &account_seven.site_origin,
-                7,
-                std::slice::from_ref(&observed),
-            ),
+            observed_keep: failure_keep,
             failures: vec![FailureInfo {
                 group_name: "observed".into(),
                 reason: "reveal: temporary failure".into(),

--- a/src-tauri/src/relay/provision.rs
+++ b/src-tauri/src/relay/provision.rs
@@ -996,17 +996,32 @@ pub fn preserve_supported_env_model(
 /// 那个数组就是为此存在的（「读宽写窄」：认全部历史值，写入只产出当前值）。
 pub const DEFAULT_MODEL: &str = "gpt-5.6-sol";
 
-/// 生图模型的名字前缀。
+/// 生图模型的名字前缀家族。**一个表唯源**：[`is_image_model`]（认不认）与
+/// [`image_model_rank`]（谁更新）都从这里取 —— 两者必须对同一个集合给出一致答案。
 ///
-/// 判据来自上游 sub2api 的 `IsGPTImageGenerationModel`（`service/openai_images.go`）——
-/// **它先 `strings.ToLower` + `strings.TrimSpace` 再比前缀**，所以本仓的比较也必须
-/// 归一化，见 [`is_image_model`]。别在这里自造一套（如加上 `dall-e`：sub2api 不认它，
-/// 我们认了只会写出转发不了的配置）。
+/// ## 家族与准入依据
 ///
-/// ⚠️ 有意**只对齐 GPT 那一族**，不含上游 `isOpenAIImageGenerationModel` 另外认的三个
-/// grok 别名（`grok-imagine` / `-edit` / `-image*`）—— 生图工具只装在 codex 档位上
+/// - `gpt-image-`：对齐上游 sub2api 的 `IsGPTImageGenerationModel`
+///   （`service/openai_images.go`，`ToLower` + `TrimSpace` 后比前缀）。
+/// - `nano-banana`：Google 系生图模型在 new-api 站点的常用名。2026-09-05 实测准入：
+///   `nano-banana-2` 与 `gpt-image-2` 同走 `/v1/images/generations`（OpenAI images
+///   语义，b64_json 返回）。不认它的话，「`gpt-image-*` + `nano-banana-*`」的纯生图
+///   分组会被当混合分组落进聊天栏。
+///
+/// 仍然**不收** `dall-e` / `flux` / `imagen`：它们虽在 new-api 上游官方表
+/// `ImageGenerationModels`（`common/model.go`）里，但那张表是静态的、连 `gpt-image-2`
+/// 都没有，站点 fork 普遍自行扩展（实测有站点同时服务 `gpt-image-2` 与 `nano-banana-2`，
+/// 都不在官方表里）—— 即 new-api 侧**不存在一张可照抄的权威表**，本仓的准入口径是
+/// 「有站点实测背书才收」。目前也无 LoongPort 用户的真实分组踩到那三族；而且收了
+/// 会波及 sub2api 侧（其上游 `IsGPTImageGenerationModel` 只有 GPT 族，认了只会写出
+/// 转发不了的配置）。谁踩到新家族就在这里加一行 —— [`image_model_rank`] 的家族
+/// 优先级随之生效（**表里越靠前的家族跨家族并存时越优先**，`gpt-image-*` 是生图
+/// 管线的原生家族）。
+///
+/// ⚠️ 有意不含上游 `isOpenAIImageGenerationModel` 另外认的三个 grok 别名
+/// （`grok-imagine` / `-edit` / `-image*`）—— 生图工具只装在 codex 档位上
 /// （openai 平台），grok 档位落的是另一个 CLI。
-const IMAGE_MODEL_PREFIX: &str = "gpt-image-";
+const IMAGE_MODEL_FAMILIES: &[&str] = &["gpt-image-", "nano-banana"];
 
 /// 一条档位该落到哪一栏：纯生图的进 [`AppType::CodexImage`]，其余原样返回。
 ///
@@ -1061,8 +1076,8 @@ pub fn pick_model(available: Option<&[String]>) -> String {
         return DEFAULT_MODEL.to_string();
     };
     // 有任何一个非生图模型 ⇒ 这不是纯生图分组，照旧写默认文本模型。
-    // 走 `is_image_model` 而不是裸 `starts_with` —— 归一化在那个函数里，见它的文档。
-    if !models.iter().all(|m| is_image_model(m)) {
+    // 纯生图的判据见 [`is_pure_image_group`]（唯源），归一化在 [`is_image_model`] 里。
+    if !is_pure_image_group(models) {
         return DEFAULT_MODEL.to_string();
     }
     // 取**最新的那一代**，见 `image_model_rank`。
@@ -1139,8 +1154,8 @@ pub fn pick_tier_models(app_type: &AppType, models: Option<&[String]>) -> TierMo
             claude_roles: None,
         };
     };
-    // 纯生图分组（只有 gpt-image-*）：写它自己的生图模型，不分角色。
-    if models.iter().all(|m| is_image_model(m)) {
+    // 纯生图分组（只有生图模型）：写它自己的生图模型，不分角色。
+    if is_pure_image_group(models) {
         return TierModels {
             main: pick_model(Some(models)),
             claude_roles: None,
@@ -1266,7 +1281,7 @@ fn maybe_one_m(model: &str) -> String {
     }
 }
 
-/// 生图模型的「代」，用于在多个 `gpt-image-*` 里挑最新的那个。
+/// 生图模型的「家族优先级 + 版本代」，用于在多个生图模型里挑默认。
 ///
 /// ## 为什么不能直接比字符串（review 抓出）
 ///
@@ -1277,24 +1292,32 @@ fn maybe_one_m(model: &str) -> String {
 ///
 /// 换成 `max()` 也不对：字典序下 `"gpt-image-10" < "gpt-image-2"`。
 ///
-/// 所以按数字段比：`gpt-image-1.5` → `[1, 5]`、`gpt-image-2` → `[2]`、
-/// `gpt-image-10` → `[10]`。逐段比较，段数不同时短的算小（`1` < `1.5`）。
-/// 认不出数字的排最后（那种名字我们无从判断新旧，让它输给能判的）。
-fn image_model_rank(model: &str) -> Vec<u32> {
+/// 所以返回 `(家族优先级, 版本段)`：跨家族先比家族（[`IMAGE_MODEL_FAMILIES`] 里越靠前
+/// 优先级越高），同家族再按数字段比 —— `gpt-image-1.5` → `[1, 5]`、`gpt-image-2` →
+/// `[2]`、`gpt-image-10` → `[10]`，逐段比较，段数不同时短的算小（`1` < `1.5`）。
+/// 认不出数字的版本段排空（那种名字无从判断新旧，让它输给能判的）。
+fn image_model_rank(model: &str) -> (u32, Vec<u32>) {
     let normalized = model.trim().to_ascii_lowercase();
-    let Some(rest) = normalized.strip_prefix(IMAGE_MODEL_PREFIX) else {
-        return Vec::new();
-    };
-    // `1.5-mini` → 只取前面连续的数字与点，后缀（`-mini` 之类）不参与比较。
-    let version: String = rest
-        .chars()
-        .take_while(|c| c.is_ascii_digit() || *c == '.')
-        .collect();
-    version
-        .split('.')
-        .filter(|seg| !seg.is_empty())
-        .filter_map(|seg| seg.parse::<u32>().ok())
-        .collect()
+    for (index, prefix) in IMAGE_MODEL_FAMILIES.iter().enumerate() {
+        let Some(rest) = normalized.strip_prefix(prefix) else {
+            continue;
+        };
+        let precedence = (IMAGE_MODEL_FAMILIES.len() - index - 1) as u32;
+        // `gpt-image-1.5-mini` / `nano-banana-2` → 只取连续的数字与点，
+        // 前导 `-`（家族前缀不带尾连字符时）与后缀（`-mini`）不参与比较。
+        let version: String = rest
+            .trim_start_matches('-')
+            .chars()
+            .take_while(|c| c.is_ascii_digit() || *c == '.')
+            .collect();
+        let segments = version
+            .split('.')
+            .filter(|seg| !seg.is_empty())
+            .filter_map(|seg| seg.parse::<u32>().ok())
+            .collect();
+        return (precedence, segments);
+    }
+    (0, Vec::new())
 }
 
 /// grok 家族模型名尾部的版本段（`grok-4.5` → `[4, 5]`），用于在多个 `grok-*` 里挑
@@ -1317,7 +1340,7 @@ fn grok_model_rank(model: &str) -> Vec<u32> {
         .unwrap_or_default()
 }
 
-/// 这个模型名是生图模型吗（[`IMAGE_MODEL_PREFIX`] 前缀）。
+/// 这个模型名是生图模型吗（[`IMAGE_MODEL_FAMILIES`] 前缀家族）。
 ///
 /// UI 据此显示「生图档位」标记。判据放在**模型名**而不是「拉一次 `/v1/models` 看看」，
 /// 是因为 `relay_list_relays` 那条路**只读本地不发网络**（首屏契约）——
@@ -1336,10 +1359,22 @@ fn grok_model_rank(model: &str) -> Vec<u32> {
 /// **只归一化比较，不改写要写入的值** —— 服务端给什么名字就照原样写进配置，
 /// 那是它认得的形式。
 pub fn is_image_model(model: &str) -> bool {
-    model
-        .trim()
-        .to_ascii_lowercase()
-        .starts_with(IMAGE_MODEL_PREFIX)
+    let normalized = model.trim().to_ascii_lowercase();
+    IMAGE_MODEL_FAMILIES
+        .iter()
+        .any(|prefix| normalized.starts_with(prefix))
+}
+
+/// 这个分组是不是「纯生图分组」：目录里一个非生图模型都没有。
+///
+/// 这是「分组落到哪一栏」的唯源判据（[`pick_model`] / [`pick_tier_models`] 的分支、
+/// new-api 扇出是否只出生图候选，都问它）—— 判据写成「全部是生图模型」而不是
+/// 「分组允许生图」：允许生图的**混合**分组仍然能聊天，该留在聊天栏。
+///
+/// ⚠️ **空目录恒为 true**（`all` 对空集的真空真）—— 调用方必须先保证目录非空才准问
+/// （new-api 路径里模型目录归一化后为空会走失败分支而不是走到这里，就是那道闸）。
+pub fn is_pure_image_group(models: &[String]) -> bool {
+    models.iter().all(|model| is_image_model(model))
 }
 
 /// sk 在各 CLI 的 `settings_config` 里的字段路径。[`patch_api_key`]、
@@ -1906,12 +1941,46 @@ mod tests {
 
     /// `is_image_model` 是 UI 判据（显示「生图档位」标记），别把文本模型认成生图的。
     #[test]
-    fn is_image_model_only_matches_the_image_prefix() {
+    fn is_image_model_only_matches_the_image_families() {
         assert!(is_image_model("gpt-image-2"));
         assert!(is_image_model("gpt-image-3-turbo"));
+        // nano-banana 家族（2026-09-05 实测准入，见 IMAGE_MODEL_FAMILIES 的文档）。
+        assert!(is_image_model("nano-banana-2"));
+        assert!(is_image_model("Nano-Banana-Pro"));
         assert!(!is_image_model(DEFAULT_MODEL));
         assert!(!is_image_model("gpt-5.4-mini"));
         assert!(!is_image_model(""));
+    }
+
+    /// 跨家族并存时表里靠前的家族（`gpt-image-*`）优先 —— 2026-09-05 实测的某 new-api
+    /// 站点纯生图分组正是 `gpt-image-2 + nano-banana-2` 混编：默认模型必须是 gpt-image-2
+    /// （站点教程背书的生图主力），而不是字典序/家族序碰巧选出的那个。
+    #[test]
+    fn gpt_image_wins_over_nano_banana_when_both_families_exist() {
+        let mixed = vec!["nano-banana-2".to_string(), "gpt-image-2".to_string()];
+        assert!(
+            is_pure_image_group(&mixed),
+            "两个都是生图模型，该判纯生图分组"
+        );
+        assert_eq!(
+            pick_model(Some(&mixed)),
+            "gpt-image-2",
+            "跨家族并存时 gpt-image 家族必须胜出"
+        );
+    }
+
+    /// 只有 nano-banana 家族时：认它（纯生图分组）、版本号新的胜出。
+    #[test]
+    fn a_nano_banana_only_group_gets_its_own_newest_model() {
+        let only = vec!["nano-banana-2".to_string()];
+        assert!(is_pure_image_group(&only));
+        assert_eq!(
+            pick_model(Some(&only)),
+            "nano-banana-2",
+            "独家生图模型必须被原样写出 —— 写 DEFAULT_MODEL 是选中即 404"
+        );
+        let newer = vec!["nano-banana-2".to_string(), "nano-banana-3".to_string()];
+        assert_eq!(pick_model(Some(&newer)), "nano-banana-3");
     }
 
     #[test]


### PR DESCRIPTION
## 问题

new-api 站点的纯生图分组（如 `gpt-image-2 + nano-banana-2`）此前被无条件扇出到 claude/codex/gemini 三栏：

- **生图栏（codex-image）恒为空** —— 该 tab 对这些站点显示「此账号在当前平台没有可用分组」；生图 MCP（`/v1/images/generations`，与站点生图端点完全兼容）没有档位可用。
- **聊天栏出现必 404 档位** —— 生图模型被写成聊天模型（claude 拿 nano-banana-2 当 `ANTHROPIC_MODEL`、gemini 拿 gpt-image-2 当 `GEMINI_MODEL`）。
- 混合分组目录里的 nano-banana-* 会出现在 codex 模型芯片里，可点、选中即 404。

## 修法（判据唯源 `provision::is_pure_image_group`）

1. **生图模型家族表**：`IMAGE_MODEL_PREFIX`（单前缀）改为 `IMAGE_MODEL_FAMILIES` —— `gpt-image-`（对齐 sub2api 上游 `IsGPTImageGenerationModel`）+ `nano-banana`（实测准入：与 gpt-image-2 同走 OpenAI images 语义端点，b64_json 返回）。`is_image_model` 与 `image_model_rank` 同表取数，rank 增家族优先级：跨家族并存时 gpt-image 胜出（站点生图主力，教程口径）。
2. **new-api 扇出分类感知**：纯生图分组只出一条 CodexImage 候选（模型按家族优先级 + 版本代选出），混合分组照旧三栏扇出。
3. **keep 白名单分类感知**：`newapi_observed_keep`（无条件保三栏）改为 `newapi_keep_insert` —— 分类已知只保真实槽位，存量聊天栏旧投影随下次 provision 自然清掉；分类未知（目录拉不到 / 对账未走完）保全四槽，不误删旧档。

## 为什么不照抄 new-api 上游官方表

new-api 上游 `ImageGenerationModels`（`common/model.go`）是静态表且连 `gpt-image-2` 都没有（仅 gpt-image-1 / dall-e / flux / imagen），站点 fork 普遍自行扩展 —— 不存在可照抄的权威表。本仓口径为「有站点实测背书才收」；`dall-e` 等有意不预埋：sub2api 侧上游不认，认了会写出转发不了的配置。

## 测试

- `newapi_pure_image_group_lands_only_in_the_image_column_and_migrates_legacy_tiers`：纯生图分组只出生图候选 + 存量三栏旧投影被 prune + 生图栏新档位为 codex 形状。
- `gpt_image_wins_over_nano_banana_when_both_families_exist` / `a_nano_banana_only_group_gets_its_own_newest_model`：家族优先级与独家家族选型。
- 全量 3748 条测试绿，clippy --all-targets 干净，cargo fmt 已过。