### PR TITLE
feat(relay): 模型选型表支持远端配置覆盖（新代际免发版跟进）

### DIFF
--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -3127,6 +3127,7 @@ fn newapi_candidates_for_group(
     account_id: i64,
     group: &newapi_provision::ReconciledGroup,
     models: &[String],
+    tables: &provision::ModelSelectionTables,
 ) -> Vec<ManagedProvisionCandidate> {
     let provider_id = provision::newapi_provider_id_for(site_origin, account_id, &group.identity.0);
     // 纯生图分组只出生图候选，不扇出到三个聊天栏：把生图模型写成聊天模型是**调用必
@@ -3141,7 +3142,7 @@ fn newapi_candidates_for_group(
     app_types
         .into_iter()
         .map(|app_type| {
-            let picked = provision::pick_tier_models(&app_type, Some(models));
+            let picked = provision::pick_tier_models_with(&app_type, Some(models), tables);
             ManagedProvisionCandidate {
                 provider_id: provider_id.clone(),
                 app_type,
@@ -3180,6 +3181,9 @@ async fn provision_backend(
     op: &creds::Relay,
     browser_fallback: Option<api::BrowserApiFallback>,
 ) -> Result<ManagedProvisionBatch, AppError> {
+    // 一次 provision 解析一次选型表（内置 + 远端覆盖），两个 backend 共用 ——
+    // sub2api 与 newapi 的选型纪律必须来自同一份数据（尺子 1.4：一个事实一个 owner）。
+    let tables = provision::ModelSelectionTables::resolve();
     // 站点声明探测与 backend 无关（约定路径是 LoongPort 的约定，newapi 站长同样能放）：
     // 404/失败/格式不认都是 None，绝不打断登录主流程。
     let site_declaration = crate::relay::site_config::fetch_site_declaration(&op.site_origin).await;
@@ -3204,7 +3208,7 @@ async fn provision_backend(
             if let Some(fallback) = browser_fallback {
                 client = client.with_browser_fallback(fallback);
             }
-            let mut result = provision::provision(&client).await?;
+            let mut result = provision::provision(&client, &tables).await?;
             provision::sort_tiers(&mut result.tiers);
             let keys_created = result
                 .tiers
@@ -3353,6 +3357,7 @@ async fn provision_backend(
                     result.account_id,
                     &group,
                     &models,
+                    &tables,
                 ));
             }
             Ok(batch)
@@ -8539,7 +8544,14 @@ mod tests {
                     &group.identity,
                     Some(&models),
                 );
-                newapi_candidates_for_group(&op.site_origin, account_id, group, &models)
+                newapi_candidates_for_group(
+                    &op.site_origin,
+                    account_id,
+                    group,
+                    &models,
+                    // 测试钉内置表：选型断言不随本机真实远端缓存漂移。
+                    &provision::ModelSelectionTables::builtin(),
+                )
             })
             .collect();
         ManagedProvisionBatch {
@@ -8566,8 +8578,13 @@ mod tests {
             provision::normalize_model_names(vec!["nano-banana-2".into(), "gpt-image-2".into()]);
         let account_id = 7;
 
-        let candidates =
-            newapi_candidates_for_group(&op.site_origin, account_id, &group, &image_models);
+        let candidates = newapi_candidates_for_group(
+            &op.site_origin,
+            account_id,
+            &group,
+            &image_models,
+            &provision::ModelSelectionTables::builtin(),
+        );
         assert_eq!(candidates.len(), 1, "纯生图分组不该再扇出到聊天栏");
         assert_eq!(candidates[0].app_type, AppType::CodexImage);
         // 默认模型 = gpt-image 家族优先（跨家族并存时表里靠前的家族胜出）。

--- a/src-tauri/src/relay/provision.rs
+++ b/src-tauri/src/relay/provision.rs
@@ -190,7 +190,10 @@ pub struct TargetedTier {
 ///
 /// 这比「按当前 tab 拉」好在：用户在任何一个 tab 登录一次，全部平台的档位都备好了 ——
 /// 不必为每个 tab 各点一次「获取密钥」，也不可能把某个平台的 sk 写成另一个平台的形状。
-pub async fn provision(client: &Client) -> Result<ProvisionResult, AppError> {
+pub async fn provision(
+    client: &Client,
+    tables: &ModelSelectionTables,
+) -> Result<ProvisionResult, AppError> {
     // 账号身份从 `client` 取，**不另收一个参数** —— 「用哪个账号建 Key」与
     // 「用哪个账号发请求」必须是同一个答案，两处各传一遍就可能不一致。
     let account_id = client.account_id();
@@ -232,7 +235,7 @@ pub async fn provision(client: &Client) -> Result<ProvisionResult, AppError> {
 
     let mut result = ProvisionResult::default();
     for (group, app_type) in usable {
-        match ensure_key_for(client, account_id, &app_type, &group, &existing).await {
+        match ensure_key_for(client, account_id, &app_type, &group, &existing, tables).await {
             Ok(tier) => {
                 // **纯生图分组落到生图那一栏**，不是 codex。
                 //
@@ -314,6 +317,7 @@ async fn ensure_key_for(
     app_type: &AppType,
     group: &Group,
     existing: &[ApiKey],
+    tables: &ModelSelectionTables,
 ) -> Result<Tier, AppError> {
     let (api_key, created) = match claim_key(existing, account_id, &group.platform, group.id) {
         // 正常路径：认领到了就直接用，不发任何写请求。
@@ -374,8 +378,8 @@ async fn ensure_key_for(
             None
         }
     };
-    let picked = pick_tier_models(app_type, models.as_deref());
-    if picked.main != DEFAULT_MODEL {
+    let picked = pick_tier_models_with(app_type, models.as_deref(), tables);
+    if picked.main != tables.default_model {
         // 写了非默认模型是**要留痕的判断**：它决定这条档位能不能用，
         // 而判据（模型列表）是网络来的、事后无从复现。
         log::info!(
@@ -987,13 +991,13 @@ pub fn preserve_supported_env_model(
 /// ⚠️ **它不再无条件套给每条 codex 档位** —— 纯生图分组（`/v1/models` 里只有
 /// `gpt-image-*`）写它就是必定 404。选哪个模型走 [`pick_model`]，本常量是那里的回落值。
 ///
-/// ## ⚠️ 改这个值时必须把旧值加进 [`HISTORICAL_DEFAULT_MODELS`]
+/// ## 换值的真实影响面（2026-09-05 重核，替换原先那段「必须把旧值加进历史表」的说法）
 ///
-/// 已存在的档位**不会**被 provision 改写模型名（只换 sk），所以改了这个常量之后，
-/// 它们的配置里还是旧模型 ⇒ 与「用户改过没有」的比对基准对不上 ⇒
-/// **界面上每一个档位都显示「已手动维护」**，而用户一个字都没改过。
-///
-/// 那个数组就是为此存在的（「读宽写窄」：认全部历史值，写入只产出当前值）。
+/// 「已手动维护」是**存库标记**（编辑页置位、恢复默认复位），不是内容比对 ——
+/// 换这个值（或远端覆盖它，见 [`ModelSelectionTables`]）不会把存量档位误标成手动
+/// 维护。重放对未编辑档位走 `preserve_supported_model`：旧模型还在新目录就保留 ⇒
+/// 换默认值只影响**新建**的档位与「旧模型已从目录下架」的档位 —— 后者正是想要的
+/// 「新一代自动跟上」。
 pub const DEFAULT_MODEL: &str = "gpt-5.6-sol";
 
 /// 生图模型的名字前缀家族。**一个表唯源**：[`is_image_model`]（认不认）与
@@ -1071,14 +1075,22 @@ pub fn image_tier_app_type(app_type: &AppType, model: &str) -> AppType {
 /// `list_models` 可能因为站点没这个端点、权限不够、或临时故障而返回 `None`。
 /// 那时回落到旧行为：**最坏情况是退化成现状**（纯生图分组写错模型名、选中 404），
 /// 而报错会让整个「获取密钥」失败，把一个「某个档位模型名不对」放大成「一个档位都没有」。
+/// [`pick_model_with`] 的内置表形态：主链路走 `_with`（远端合并表），这个入口留给
+/// 测试与「不关心远端覆盖」的调用方 —— 测试钉内置表，选型断言不随本机缓存漂移。
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn pick_model(available: Option<&[String]>) -> String {
+    pick_model_with(available, &ModelSelectionTables::builtin())
+}
+
+/// [`pick_model`] 的选型表注入版：provision 主链路传远端合并后的表，测试传内置表。
+pub fn pick_model_with(available: Option<&[String]>, tables: &ModelSelectionTables) -> String {
     let Some(models) = available else {
-        return DEFAULT_MODEL.to_string();
+        return tables.default_model.clone();
     };
     // 有任何一个非生图模型 ⇒ 这不是纯生图分组，照旧写默认文本模型。
     // 纯生图的判据见 [`is_pure_image_group`]（唯源），归一化在 [`is_image_model`] 里。
     if !is_pure_image_group(models) {
-        return DEFAULT_MODEL.to_string();
+        return tables.default_model.clone();
     }
     // 取**最新的那一代**，见 `image_model_rank`。
     // 空列表在 `list_models` 里已经归成 `None` 了，走不到这里；真走到也回落默认值。
@@ -1089,11 +1101,11 @@ pub fn pick_model(available: Option<&[String]>) -> String {
                 .cmp(&image_model_rank(b))
                 // 同代时按名字定序，让结果是该分组的一个确定函数（不随
                 // `/v1/models` 的返回顺序抖动 —— 那个顺序实测不稳定，而抖动会让
-                // `is_user_edited` 的基准跟着抖 ⇒ 「已手动维护」标记随机出现又消失）。
+                // 选型结果跟着抖 ⇒ 同一分组两次 provision 写出不同的模型名）。
                 .then_with(|| a.as_str().cmp(b.as_str()))
         })
         .cloned()
-        .unwrap_or_else(|| DEFAULT_MODEL.to_string())
+        .unwrap_or_else(|| tables.default_model.clone())
 }
 
 /// 一条档位该写进配置的模型：主模型 + claude 平台的角色模型。
@@ -1127,6 +1139,110 @@ const CLAUDE_HAIKU_CANDIDATES: &[&str] = &["claude-haiku-4-5", "gpt-5.6-luna", "
 /// **顺延**而不是照旧写一个列表里不存在的模型 —— 那是选中即 404。
 const CODEX_MAIN_CANDIDATES: &[&str] = &["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.4"];
 
+/// 解析后的模型选型表：内置常量经远端覆盖合并后的产物，选型逻辑的**唯一数据源**。
+///
+/// ## 为什么收成一张表
+///
+/// 散落的常量读取点没法整体替换：远端覆盖（remote_config 的 `relay_model_selection`，
+/// 2026-09-05 起）需要一处明确的合并位置，并保证 [`first_hit`]/回落语义不因数据来源
+/// （内置/远端）而变。调整候选就是改 [`ModelSelectionTables::builtin`] 那一份内置 +
+/// 远端配置，选型函数不动。
+///
+/// ## 远程化的安全前提（与生图家族表的区别）
+///
+/// 候选的选中规则是「分组目录里**第一个精确命中**的」（[`first_hit`]）⇒ 远端给一个
+/// 目录里不存在的名字会被自然顺延，坏值的失败模式是「没生效」而不是「写出 404 档位」。
+/// 这是模型候选表敢远程化、而生图家族表（能力判据，认错即错栏）暂不远程化的原因。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelSelectionTables {
+    /// 目录拉不到时写的主模型回落值（内置 [`DEFAULT_MODEL`]）。
+    pub default_model: String,
+    /// codex 主模型候选（优先级序，内置 `CODEX_MAIN_CANDIDATES`）。
+    pub codex_main: Vec<String>,
+    /// claude 平台「最强档」候选（内置 `CLAUDE_OPUS_CANDIDATES`）。
+    pub claude_opus: Vec<String>,
+    /// claude 平台「次强档」候选（内置 `CLAUDE_SONNET_CANDIDATES`）。
+    pub claude_sonnet: Vec<String>,
+    /// claude 平台「弱档」候选（内置 `CLAUDE_HAIKU_CANDIDATES`）。
+    pub claude_haiku: Vec<String>,
+}
+
+/// 远端一张候选列表的清洗：条目 trim 后为空的剔除，剔完整张表空了就当没给。
+fn merged_list(remote: Option<&Vec<String>>, builtin: &[&str]) -> Vec<String> {
+    match remote {
+        Some(list) => {
+            let filtered: Vec<String> = list
+                .iter()
+                .map(|entry| entry.trim().to_string())
+                .filter(|entry| !entry.is_empty())
+                .collect();
+            if filtered.is_empty() {
+                builtin.iter().map(|entry| entry.to_string()).collect()
+            } else {
+                filtered
+            }
+        }
+        None => builtin.iter().map(|entry| entry.to_string()).collect(),
+    }
+}
+
+impl ModelSelectionTables {
+    /// 内置表。测试与「无远端覆盖」的回落共用这一份 —— 也因此选型测试不碰真实缓存。
+    pub fn builtin() -> Self {
+        Self {
+            default_model: DEFAULT_MODEL.to_string(),
+            codex_main: CODEX_MAIN_CANDIDATES
+                .iter()
+                .map(|entry| entry.to_string())
+                .collect(),
+            claude_opus: CLAUDE_OPUS_CANDIDATES
+                .iter()
+                .map(|entry| entry.to_string())
+                .collect(),
+            claude_sonnet: CLAUDE_SONNET_CANDIDATES
+                .iter()
+                .map(|entry| entry.to_string())
+                .collect(),
+            claude_haiku: CLAUDE_HAIKU_CANDIDATES
+                .iter()
+                .map(|entry| entry.to_string())
+                .collect(),
+        }
+    }
+
+    /// 字段级**部分覆盖**：远端给了才替换，缺席回落内置（与 vendor 侧
+    /// `tier_configs` / `RemoteClaudeRoleModels` 同一语义）—— 远端只想调 codex
+    /// 候选时不必复述 claude 那三张表。
+    pub fn merge(remote: Option<&crate::relay::remote_config::RemoteModelSelection>) -> Self {
+        let Some(remote) = remote else {
+            return Self::builtin();
+        };
+        Self {
+            default_model: remote
+                .default_model
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(str::to_string)
+                .unwrap_or_else(|| DEFAULT_MODEL.to_string()),
+            codex_main: merged_list(remote.codex_main.as_ref(), CODEX_MAIN_CANDIDATES),
+            claude_opus: merged_list(remote.claude_opus.as_ref(), CLAUDE_OPUS_CANDIDATES),
+            claude_sonnet: merged_list(remote.claude_sonnet.as_ref(), CLAUDE_SONNET_CANDIDATES),
+            claude_haiku: merged_list(remote.claude_haiku.as_ref(), CLAUDE_HAIKU_CANDIDATES),
+        }
+    }
+
+    /// 生产解析：从**已验签**的远端缓存合并。缓存缺失/字段缺席都自然回落内置。
+    /// 签名保证的是完整性；正确性靠 [`first_hit`] 的精确命中兜底（见结构体文档）。
+    pub fn resolve() -> Self {
+        Self::merge(
+            crate::relay::remote_config::load_cached()
+                .as_ref()
+                .and_then(|config| config.relay_model_selection.as_ref()),
+        )
+    }
+}
+
 /// 一条档位的模型名：**按平台**从该分组模型列表里挑，而不是写死 [`DEFAULT_MODEL`]。
 ///
 /// ## 为什么必须有（2026-08-08 修复）
@@ -1147,24 +1263,30 @@ const CODEX_MAIN_CANDIDATES: &[&str] = &["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.
 /// - **其它平台**：模型列表第一个文本模型。
 /// - **纯生图分组**（只有 `gpt-image-*`）：仍写最新的生图模型（复用作 `pick_model`）。
 /// - **列表拉不到**：回落 `DEFAULT_MODEL`（旧行为，最坏退化）。
-pub fn pick_tier_models(app_type: &AppType, models: Option<&[String]>) -> TierModels {
+///
+/// 候选的**数据源**是 [`ModelSelectionTables`]（内置 + 远端覆盖）。
+pub fn pick_tier_models_with(
+    app_type: &AppType,
+    models: Option<&[String]>,
+    tables: &ModelSelectionTables,
+) -> TierModels {
     let Some(models) = models else {
         return TierModels {
-            main: DEFAULT_MODEL.to_string(),
+            main: tables.default_model.clone(),
             claude_roles: None,
         };
     };
     // 纯生图分组（只有生图模型）：写它自己的生图模型，不分角色。
     if is_pure_image_group(models) {
         return TierModels {
-            main: pick_model(Some(models)),
+            main: pick_model_with(Some(models), tables),
             claude_roles: None,
         };
     }
     match app_type {
-        AppType::Claude => pick_claude_tier_models(models),
+        AppType::Claude => pick_claude_tier_models(models, tables),
         AppType::Codex | AppType::CodexImage => TierModels {
-            main: first_hit(CODEX_MAIN_CANDIDATES, models).unwrap_or_else(|| models[0].clone()),
+            main: first_hit(&tables.codex_main, models).unwrap_or_else(|| models[0].clone()),
             claude_roles: None,
         },
         AppType::Gemini => TierModels {
@@ -1199,20 +1321,27 @@ pub fn pick_tier_models(app_type: &AppType, models: Option<&[String]>) -> TierMo
     }
 }
 
+/// [`pick_tier_models_with`] 的内置表形态：主链路走 `_with`（远端合并表），这个入口
+/// 留给测试与「不关心远端覆盖」的调用方 —— 测试钉内置表，选型断言不随本机缓存漂移。
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn pick_tier_models(app_type: &AppType, models: Option<&[String]>) -> TierModels {
+    pick_tier_models_with(app_type, models, &ModelSelectionTables::builtin())
+}
+
 /// claude 平台的角色档位挑选：各角色取候选里第一个命中的，取不到顺延相邻档位。
 ///
 /// 主模型（`ANTHROPIC_MODEL`）用最高档（opus）；某个角色 miss 时指向 main，保证
-/// 结果可用且确定（同一列表每次挑出同一个值 —— `is_user_edited` 的比对基准不抖）。
-fn pick_claude_tier_models(models: &[String]) -> TierModels {
+/// 结果可用且确定（同一列表每次挑出同一个值）。
+fn pick_claude_tier_models(models: &[String], tables: &ModelSelectionTables) -> TierModels {
     let first_text = models.iter().find(|m| !is_image_model(m)).cloned();
-    let opus = first_hit(CLAUDE_OPUS_CANDIDATES, models);
-    let sonnet = first_hit(CLAUDE_SONNET_CANDIDATES, models);
-    let haiku = first_hit(CLAUDE_HAIKU_CANDIDATES, models);
+    let opus = first_hit(&tables.claude_opus, models);
+    let sonnet = first_hit(&tables.claude_sonnet, models);
+    let haiku = first_hit(&tables.claude_haiku, models);
     let main = opus
         .clone()
         .or_else(|| sonnet.clone())
         .or_else(|| first_text.clone())
-        .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+        .unwrap_or_else(|| tables.default_model.clone());
     let opus = opus.unwrap_or_else(|| main.clone());
     let sonnet = sonnet.unwrap_or_else(|| main.clone());
     let haiku = haiku.unwrap_or_else(|| main.clone());
@@ -1234,11 +1363,14 @@ fn pick_claude_tier_models(models: &[String]) -> TierModels {
 }
 
 /// 从候选列表里取第一个在模型列表里**精确存在**的模型名。
-fn first_hit(candidates: &[&str], models: &[String]) -> Option<String> {
+///
+/// 候选来自 [`ModelSelectionTables`]（内置或远端合并后的）；精确命中意味着远端给的
+/// 目录里不存在的名字会被自然顺延 —— 那是远端候选「坏值只敢不生效」的安全前提。
+fn first_hit(candidates: &[String], models: &[String]) -> Option<String> {
     candidates
         .iter()
-        .find(|c| models.iter().any(|m| m == *c))
-        .map(|c| c.to_string())
+        .find(|candidate| models.iter().any(|model| model == *candidate))
+        .map(|candidate| candidate.to_string())
 }
 
 /// 该模型是否支持 1M 上下文 —— claude 平台档位给它附 `[1M]` 后缀声明。
@@ -1981,6 +2113,92 @@ mod tests {
         );
         let newer = vec!["nano-banana-2".to_string(), "nano-banana-3".to_string()];
         assert_eq!(pick_model(Some(&newer)), "nano-banana-3");
+    }
+
+    /// 远端选型表是**字段级部分覆盖**：给了才替换，缺席/清洗后为空回落内置。
+    /// 这是它敢远程化的纪律面（安全面在 [`ModelSelectionTables`] 的结构体文档）。
+    #[test]
+    fn model_selection_tables_partial_override_with_sanitization() {
+        let builtin = ModelSelectionTables::builtin();
+        let remote = crate::relay::remote_config::RemoteModelSelection {
+            // 空白值 → 回落内置。
+            default_model: Some("   ".into()),
+            // 有实条目 → 生效（空白条目被剔除）。
+            codex_main: Some(vec![" gpt-6-astra ".into(), " ".into()]),
+            // 整张清洗后为空 → 当没给。
+            claude_opus: Some(vec!["".into(), "  ".into()]),
+            claude_sonnet: None,
+            claude_haiku: None,
+        };
+        let merged = ModelSelectionTables::merge(Some(&remote));
+        assert_eq!(merged.default_model, builtin.default_model);
+        assert_eq!(merged.codex_main, vec!["gpt-6-astra".to_string()]);
+        assert_eq!(merged.claude_opus, builtin.claude_opus);
+        assert_eq!(merged.claude_sonnet, builtin.claude_sonnet);
+        assert_eq!(merged.claude_haiku, builtin.claude_haiku);
+
+        let trimmed = crate::relay::remote_config::RemoteModelSelection {
+            default_model: Some(" gpt-6-astra ".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            ModelSelectionTables::merge(Some(&trimmed)).default_model,
+            "gpt-6-astra"
+        );
+        assert_eq!(
+            ModelSelectionTables::merge(None),
+            builtin,
+            "远端缺席 = 内置表，这是三层回落（远端 > 缓存 > 内置）落到选型的形态"
+        );
+    }
+
+    /// 远端候选**真的改变选型**，且坏值只敢「不生效」：
+    /// 目录里第一个精确命中的候选胜出，目录没有的远端名字被顺延、不会写进配置。
+    #[test]
+    fn pick_tier_models_with_honors_remote_candidates() {
+        let tables = ModelSelectionTables {
+            codex_main: vec!["gpt-6-astra".into(), "gpt-5.6-sol".into()],
+            ..ModelSelectionTables::builtin()
+        };
+        // 远端首位不在目录 → 顺延到次位（内置同款纪律：不写目录里不存在的模型）。
+        let catalog = vec!["gpt-5.6-sol".to_string(), "gpt-5.6-terra".to_string()];
+        assert_eq!(
+            pick_tier_models_with(&AppType::Codex, Some(&catalog), &tables).main,
+            "gpt-5.6-sol"
+        );
+        // 目录里有远端首位 → 命中。
+        let with_new = vec!["gpt-6-astra".to_string()];
+        assert_eq!(
+            pick_tier_models_with(&AppType::Codex, Some(&with_new), &tables).main,
+            "gpt-6-astra"
+        );
+
+        // claude 角色表覆盖；挑出的名字照常过 `[1M]` 声明规则（opus-6 不在名单 → 无后缀）。
+        let claude_tables = ModelSelectionTables {
+            claude_opus: vec!["claude-opus-6".into()],
+            ..ModelSelectionTables::builtin()
+        };
+        let claude_catalog = vec!["claude-opus-6".to_string(), "claude-haiku-4-5".to_string()];
+        let picked = pick_tier_models_with(&AppType::Claude, Some(&claude_catalog), &claude_tables);
+        let roles = picked.claude_roles.expect("claude 必须有角色模型");
+        assert_eq!(picked.main, "claude-opus-6");
+        assert_eq!(roles.opus, "claude-opus-6");
+
+        // default_model 覆盖：目录拉不到时的回落值跟着换。
+        let fallback = ModelSelectionTables {
+            default_model: "gpt-6-astra".into(),
+            ..ModelSelectionTables::builtin()
+        };
+        assert_eq!(
+            pick_tier_models_with(&AppType::Codex, None, &fallback).main,
+            "gpt-6-astra"
+        );
+        // 纯生图分组不受选型表影响（它写自己的生图模型，不走候选）。
+        let image_group = vec!["gpt-image-2".to_string()];
+        assert_eq!(
+            pick_tier_models_with(&AppType::CodexImage, Some(&image_group), &fallback).main,
+            "gpt-image-2"
+        );
     }
 
     #[test]

--- a/src-tauri/src/relay/remote_config.rs
+++ b/src-tauri/src/relay/remote_config.rs
@@ -249,6 +249,34 @@ pub struct StarRewardConfig {
     pub amount_usd: u64,
 }
 
+/// 中转站档位的**模型选型表**（远端可部分覆盖）。
+///
+/// 服务的场景：外部模型代际更替（新模型在中转站目录里铺开）快于客户端发版节奏，
+/// 维护者查证后可以直接调表，不必等一版客户端。合并纪律在
+/// `provision::ModelSelectionTables::merge`：字段级部分覆盖、缺席/清洗后为空回落内置。
+///
+/// 安全前提（为什么敢远程化，而生图家族表不敢）：候选的选中规则是「分组目录里
+/// **第一个精确命中**的」—— 远端给一个目录里不存在的名字会被自然顺延，坏值的
+/// 失败模式是「没生效」，不是「写出 404 档位」。
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Default)]
+pub struct RemoteModelSelection {
+    /// 目录拉不到时写的主模型回落值（内置 `DEFAULT_MODEL`）。
+    #[serde(default)]
+    pub default_model: Option<String>,
+    /// codex 主模型候选，优先级序（内置 `CODEX_MAIN_CANDIDATES`）。
+    #[serde(default)]
+    pub codex_main: Option<Vec<String>>,
+    /// claude 平台「最强档」候选（内置 `CLAUDE_OPUS_CANDIDATES`）。
+    #[serde(default)]
+    pub claude_opus: Option<Vec<String>>,
+    /// claude 平台「次强档」候选（内置 `CLAUDE_SONNET_CANDIDATES`）。
+    #[serde(default)]
+    pub claude_sonnet: Option<Vec<String>>,
+    /// claude 平台「弱档」候选（内置 `CLAUDE_HAIKU_CANDIDATES`）。
+    #[serde(default)]
+    pub claude_haiku: Option<Vec<String>>,
+}
+
 /// 远端配置的全文。
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Default)]
 pub struct RemoteConfig {
@@ -300,6 +328,10 @@ pub struct RemoteConfig {
     /// [`RemoteConfig::promo_codes`] 上的注释。
     #[serde(default)]
     pub star_reward: Option<StarRewardConfig>,
+    /// 中转站档位的模型选型表（部分覆盖内置）。`None`（旧线上配置/未配置）= 内置表，
+    /// 双向兼容的理由同 [`RemoteConfig::promo_codes`] 上的注释。
+    #[serde(default)]
+    pub relay_model_selection: Option<RemoteModelSelection>,
 }
 
 /// 端点与公钥都配好了没。任一没配就整条链路 no-op（走缓存/内置）。
@@ -762,6 +794,35 @@ mod tests {
     use serde::Deserialize;
     use std::sync::Mutex;
 
+    /// `relay_model_selection` 的双向兼容：老配置（无此键）解出 `None` 走内置表；
+    /// 新配置带此键正常解出 —— 字段级部分覆盖由 `provision` 侧 merge 落实。
+    #[test]
+    fn relay_model_selection_is_optional_and_parses() {
+        let legacy: RemoteConfig = serde_json::from_str("{}").expect("老配置必须可解");
+        assert!(legacy.relay_model_selection.is_none());
+
+        let with_field: RemoteConfig = serde_json::from_str(
+            r#"{
+                "relay_model_selection": {
+                    "codex_main": ["gpt-6-astra", "gpt-5.6-sol"],
+                    "claude_opus": ["claude-opus-6"]
+                }
+            }"#,
+        )
+        .expect("新配置必须可解");
+        let selection = with_field.relay_model_selection.expect("字段在场");
+        assert_eq!(
+            selection.codex_main,
+            Some(vec!["gpt-6-astra".to_string(), "gpt-5.6-sol".to_string()])
+        );
+        assert_eq!(
+            selection.claude_opus,
+            Some(vec!["claude-opus-6".to_string()])
+        );
+        assert_eq!(selection.default_model, None);
+        assert_eq!(selection.claude_sonnet, None);
+    }
+
     #[derive(Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]
     struct DirectoryV2Contract {
@@ -1068,6 +1129,7 @@ mod tests {
             tier_configs: std::collections::BTreeMap::new(),
             relay_directory: RelayDirectoryPolicy::default(),
             star_reward: None,
+            relay_model_selection: None,
         }
     }
 
@@ -1083,6 +1145,7 @@ mod tests {
             tier_configs: std::collections::BTreeMap::new(),
             relay_directory: RelayDirectoryPolicy::default(),
             star_reward: None,
+            relay_model_selection: None,
         }
     }
 


### PR DESCRIPTION
## 动机

外部模型代际更替快于客户端发版：新模型在中转站目录里铺开时，编译期候选表（`DEFAULT_MODEL` / `CODEX_MAIN_CANDIDATES` / claude 三档候选）还认识不到新名字，新档位只能落到顺延位或目录首项。落在 remote config 后，维护者查证即可当天调表，不必等发版。

## 形状

- `RemoteConfig` 新增 `relay_model_selection`（`RemoteModelSelection`）：**字段级部分覆盖** —— 远端给了才替换，缺席/清洗后为空回落内置；serde 双向兼容与 `promo_codes` 同款机制（老客户端忽略新键，新客户端 `#[serde(default)]` 读旧配置）。
- `provision::ModelSelectionTables`（builtin / merge / resolve）：内置常量 + 远端合并后的**唯一数据源**；`resolve` 读已验签缓存，三层回落（远端 > 缓存 > 内置）。
- `pick_model` / `pick_tier_models` 拆出 `_with` 注入版：provision 主链路（sub2api 与 new-api 两路，`provision_backend` 一次解析共用）传远端合并表；无参版钉内置表，测试选型断言不随本机缓存漂移。
- 顺带修正 `DEFAULT_MODEL` 文档里陈年的 `HISTORICAL_DEFAULT_MODELS` 说法：`user_edited` 实为存库标记（编辑页置位），换默认值不会把存量档位误报「已手动维护」；重放由 `preserve_supported_model` 保留旧选中（还在目录内才保留）⇒ 换默认值只影响新建档位与「旧模型已下架」的档位。

## 为什么生图家族表不跟着远程化

候选的选中规则是「分组目录里**第一个精确命中**的」—— 远端坏名字被自然顺延，失败模式是「没生效」而非「写出 404 档位」，这是本表敢远程化的安全前提。生图家族表是能力判据（认错即错栏），维持编译期内置，等真实漏判触发再议。

## 上线步骤（客户端合入后）

远端配置加 `relayModelSelection`/对应蛇形键 → 签名 → deploy → 提交源（v1/config.json）。不加 = 一直走内置表，零风险默认。

## 测试

- `model_selection_tables_partial_override_with_sanitization`：字段级覆盖、空白清洗、空表回落、缺席=内置。
- `pick_tier_models_with_honors_remote_candidates`：远端候选真实改变选型 + 坏名字顺延不写配置 + default_model 回落 + 纯生图分组不受影响。
- `relay_model_selection_is_optional_and_parses`：新旧配置双向兼容。
- 全量 3749 条测试绿，clippy --all-targets 干净。