### PR TITLE
fix(easymode): 档位看板策略兜底文案对齐（价格最低/响应最快）

### DIFF
--- a/src/components/easymode/EasyBoard.tsx
+++ b/src/components/easymode/EasyBoard.tsx
@@ -1,7 +1,7 @@
 /**
  * 首页省心视图：省心模式生效时替换该 app 的 provider 页。
  *
- * 用户只做三件事：选模型、选模式（自动/手动）；自动下选策略（省钱/省时），
+ * 用户只做三件事：选模型、选模式（自动/手动）；自动下选策略（价格最低/响应最快），
  * 手动下拖动档位卡排序。全部档位事实来自后端看板（唯源），这里只渲染。
  */
 import { useTranslation } from "react-i18next";
@@ -116,14 +116,14 @@ export function EasyBoard({ appId }: { appId: string }) {
               disabled={setStrategy.isPending}
               onClick={() => setStrategy.mutate({ strategy: "cheapest" })}
             >
-              {t("autoMode.strategy.cheapest", { defaultValue: "省钱" })}
+              {t("autoMode.strategy.cheapest", { defaultValue: "价格最低" })}
             </ChoiceButton>
             <ChoiceButton
               active={board.strategy === "fastest"}
               disabled={setStrategy.isPending}
               onClick={() => setStrategy.mutate({ strategy: "fastest" })}
             >
-              {t("autoMode.strategy.fastest", { defaultValue: "省时" })}
+              {t("autoMode.strategy.fastest", { defaultValue: "响应最快" })}
             </ChoiceButton>
           </div>
         ) : null}

--- a/tests/components/EasyBoard.test.tsx
+++ b/tests/components/EasyBoard.test.tsx
@@ -416,7 +416,7 @@ describe("EasyBoard", () => {
 
   it("点策略按钮落到 setStrategy mutation", () => {
     setupBoard(boardFixture());
-    fireEvent.click(screen.getByText("省时"));
+    fireEvent.click(screen.getByText("响应最快"));
     expect(setStrategyMock).toHaveBeenCalledWith({ strategy: "fastest" });
   });
 


### PR DESCRIPTION
## 问题
`autoMode.strategy.cheapest/fastest` 的 defaultValue 两处分叉：
- EasyBoard（档位看板）：`省钱 / 省时`
- AutoModeTabContent（设置页）：`价格最低 / 响应最快`

语言包（zh/zh-TW/en/ja 四语）定义的是后者，所以运行时显示一直正确；前者只在 locale 缺 key 时才会露出——潜伏的展示分叉，同一标签两个兜底源。

## 变更
- EasyBoard 两个 defaultValue 对齐为「价格最低 / 响应最快」（与语言包、设置页一致）
- 组件顶部注释（省钱/省时 → 价格最低/响应最快）同步

## 验证
- `pnpm format:check` 通过；`src/` 全量 grep 零「省钱」字样
- 语言包与 i18n key 未动，loongportLocales requiredKeys 不受影响

随下个小版本 tag 带出，不单独发版。