### PR TITLE
copy: 广场实测区不再展示任何精确计数

### DIFF
--- a/src/components/relay/directory/CrowdMeasuredSection.tsx
+++ b/src/components/relay/directory/CrowdMeasuredSection.tsx
@@ -1,4 +1,4 @@
-import { Lock, Users } from "lucide-react";
+import { Lock } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
@@ -32,7 +32,6 @@ interface CrowdMeasuredSectionProps {
  * 前端不复制常量。 */
 function DistBars({ bins, edges }: { bins: number[]; edges: number[] }) {
   const { t } = useTranslation();
-  const total = bins.reduce((a, b) => a + b, 0);
   const max = Math.max(...bins, 1);
   const label = (ms: number) =>
     ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${ms}ms`;
@@ -59,7 +58,6 @@ function DistBars({ bins, edges }: { bins: number[]; edges: number[] }) {
               title={t("loongport.crowd.distTooltip", {
                 range:
                   hi != null ? `${label(lo)}–${label(hi)}` : `≥${label(lo)}`,
-                count,
               })}
             />
           );
@@ -69,9 +67,7 @@ function DistBars({ bins, edges }: { bins: number[]; edges: number[] }) {
         <span>{t("loongport.crowd.distFast")}</span>
         <span>{t("loongport.crowd.distSlow")}</span>
       </div>
-      <span className="sr-only">
-        {t("loongport.crowd.distSr", { count: total })}
-      </span>
+      <span className="sr-only">{t("loongport.crowd.distSr")}</span>
     </div>
   );
 }
@@ -131,7 +127,6 @@ function HourBars({ stats }: { stats: CrowdSiteStats }) {
                 ? t("loongport.crowd.hourTooltip", {
                     slot: String(slot).padStart(2, "0"),
                     value: formatLatency(height),
-                    count: slots[slot].samples,
                   })
                 : t("loongport.crowd.hourEmpty", {
                     slot: String(slot).padStart(2, "0"),
@@ -200,14 +195,9 @@ export function CrowdMeasuredSection({
         </h4>
         {active && (
           <span className="inline-flex items-center gap-1 text-[10px] text-muted-foreground">
-            <Users className="h-3 w-3" />
-            {t("loongport.crowd.noteSources", {
-              count: active.sources,
-              samples: active.samples.toLocaleString(),
-            })}
             {stats?.w24
-              ? ` · ${t("loongport.crowd.window24")}`
-              : ` · ${t("loongport.crowd.window7")}`}
+              ? t("loongport.crowd.window24")
+              : t("loongport.crowd.window7")}
           </span>
         )}
       </div>

--- a/src/components/relay/directory/__tests__/CrowdMeasuredSection.test.tsx
+++ b/src/components/relay/directory/__tests__/CrowdMeasuredSection.test.tsx
@@ -78,7 +78,7 @@ describe("CrowdMeasuredSection 三态", () => {
     expect(screen.queryByText("loongport.crowd.ttftP50")).toBeNull();
   });
 
-  it("参与且有数据：指标卡 + 来源注脚 + 时段条形", () => {
+  it("参与且有数据：指标卡 + 统计窗口 + 时段条形", () => {
     render(
       <CrowdMeasuredSection
         stats={makeStats()}
@@ -89,9 +89,7 @@ describe("CrowdMeasuredSection 三态", () => {
     // 812.5ms 落在 [800,1200) 的毫秒格式化（取整 813ms）。
     expect(screen.getByText("813ms")).toBeTruthy();
     expect(screen.getByText("2.1s")).toBeTruthy();
-    expect(
-      screen.getByText(/loongport.crowd.noteSources.*"count":3/u),
-    ).toBeTruthy();
+    expect(screen.getByText("loongport.crowd.window24")).toBeTruthy();
     // 24 根时段条都在（t 被 mock 成 key+JSON，按 mock 输出断言）。
     const bars = screen.getAllByTitle(/loongport.crowd.hour(Tooltip|Empty)/u);
     expect(bars).toHaveLength(24);
@@ -119,7 +117,7 @@ describe("CrowdMeasuredSection 三态", () => {
     );
     const bars = screen.getAllByTitle(/loongport.crowd.distTooltip/u);
     expect(bars).toHaveLength(12);
-    expect(screen.getByTitle(/"range":"200ms–400ms".*"count":8/u)).toBeTruthy();
+    expect(screen.getByTitle(/"range":"200ms–400ms"/u)).toBeTruthy();
   });
 
   it("分布图：缺 edges（旧快照）不渲染分布条", () => {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3333,20 +3333,19 @@
       "sectionTitle": "User measurements",
       "window24": "last 24h",
       "window7": "last 7 days",
-      "noteSources": "{{count}} users · {{samples}} samples",
       "ttftP50": "TTFT p50",
       "ttftP95": "TTFT p95",
       "errRate": "Error rate",
       "cacheHit": "Cache hit",
       "costRef": "Cost ref.",
       "hoursTitle": "Median TTFT by hour (last 7 days · UTC)",
-      "hourTooltip": "UTC {{slot}}:00 · {{value}} · {{count}} samples",
+      "hourTooltip": "UTC {{slot}}:00 · {{value}}",
       "hourEmpty": "UTC {{slot}}:00 · no data",
-      "noData": "No measurements yet (not enough samples or sources)",
+      "noData": "No measurements yet",
       "lockedTitle": "Join the crowd data program to view",
       "lockedBody": "Share aggregated site metrics from your machine (first-token time, error rate, …) to unlock measurements from all users.",
       "join": "Join",
-      "footnote": "Crowd-sourced from LoongPort users: hourly aggregates published behind a privacy threshold; cost is a blended reference value.",
+      "footnote": "Crowd-sourced anonymously from LoongPort users; data with too few samples is not shown. Cost is a blended reference value.",
       "notice": {
         "title": "Crowd-measured site stats",
         "question": "Want to see real-world stats for each relay site (first-token time, error rate)?",
@@ -3354,11 +3353,11 @@
         "accept": "Agree",
         "decline": "Not now"
       },
-      "distTitle": "First-token time distribution (sample counts)",
-      "distTooltip": "{{range}} · {{count}} samples",
+      "distTitle": "First-token time distribution",
+      "distTooltip": "{{range}}",
       "distFast": "fast",
       "distSlow": "slow",
-      "distSr": "Histogram of first-token times, {{count}} samples total"
+      "distSr": "Histogram of first-token times"
     },
     "site": {
       "removed": "Removed {{label}}"

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3333,20 +3333,19 @@
       "sectionTitle": "ユーザー実測",
       "window24": "直近 24 時間",
       "window7": "直近 7 日間",
-      "noteSources": "{{count}} ユーザー · {{samples}} サンプル",
       "ttftP50": "初トークン p50",
       "ttftP95": "初トークン p95",
       "errRate": "エラー率",
       "cacheHit": "キャッシュ命中",
       "costRef": "費用参考",
       "hoursTitle": "時間帯別の初トークン中央値（直近 7 日 · UTC）",
-      "hourTooltip": "UTC {{slot}}:00 · {{value}} · {{count}} サンプル",
+      "hourTooltip": "UTC {{slot}}:00 · {{value}}",
       "hourEmpty": "UTC {{slot}}:00 · データなし",
-      "noData": "実測データはまだありません（サンプルまたはソース不足）",
+      "noData": "実測データはまだありません",
       "lockedTitle": "共同データに参加すると閲覧できます",
       "lockedBody": "使用中のサイトの集計指標（初トークン時間・エラー率など）を共有すると、全ユーザーの実測データを閲覧できます。",
       "join": "参加する",
-      "footnote": "LoongPort ユーザーによる共同データ：時間単位の集計をプライバシーしきい値付きで公開。費用はモデル混合の参考値。",
+      "footnote": "データは LoongPort ユーザーによる匿名の共同構築です。サンプルが少ないデータは表示されません。費用はモデル混合の参考値です。",
       "notice": {
         "title": "サイト実測データの共同利用",
         "question": "各サイトの初トークン時間やエラー率などの実測データを表示しますか？",
@@ -3354,11 +3353,11 @@
         "accept": "同意する",
         "decline": "後で"
       },
-      "distTitle": "初トークン時間の分布（サンプル数）",
-      "distTooltip": "{{range}} · {{count}} サンプル",
+      "distTitle": "初トークン時間の分布",
+      "distTooltip": "{{range}}",
       "distFast": "速い",
       "distSlow": "遅い",
-      "distSr": "初トークン時間のヒストグラム、合計 {{count}} サンプル"
+      "distSr": "初トークン時間のヒストグラム"
     },
     "site": {
       "removed": "{{label}} を削除しました"

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3334,20 +3334,19 @@
       "sectionTitle": "使用者實測",
       "window24": "近 24 小時",
       "window7": "近 7 天",
-      "noteSources": "{{count}} 位使用者 · {{samples}} 個樣本",
       "ttftP50": "首字 p50",
       "ttftP95": "首字 p95",
       "errRate": "錯誤率",
       "cacheHit": "快取命中",
       "costRef": "花費參考",
       "hoursTitle": "時段首字中位數（近 7 天 · UTC）",
-      "hourTooltip": "UTC {{slot}}:00 · {{value}} · {{count}} 個樣本",
+      "hourTooltip": "UTC {{slot}}:00 · {{value}}",
       "hourEmpty": "UTC {{slot}}:00 · 無資料",
-      "noData": "暫無實測資料（樣本或來源不足）",
+      "noData": "暫無實測資料",
       "lockedTitle": "加入共建後可查看",
       "lockedBody": "上傳你本機的站點聚合指標（首字耗時、錯誤率等），即可查看所有使用者的實測資料。",
       "join": "加入共建",
-      "footnote": "資料來自 LoongPort 使用者共建：按小時聚合、經隱私門檻發布；花費為混合模型的參考值。",
+      "footnote": "資料來自 LoongPort 使用者匿名共建，樣本不足時不展示；花費為混合模型的參考值。",
       "notice": {
         "title": "站點實測資料共建",
         "question": "是否願意查看各站點的首字耗時、錯誤率等實測資料？",
@@ -3355,11 +3354,11 @@
         "accept": "同意",
         "decline": "暫不"
       },
-      "distTitle": "首字耗時分布（樣本計數）",
-      "distTooltip": "{{range}} · {{count}} 個樣本",
+      "distTitle": "首字耗時分布",
+      "distTooltip": "{{range}}",
       "distFast": "快",
       "distSlow": "慢",
-      "distSr": "首字耗時分布直方圖，共 {{count}} 個樣本"
+      "distSr": "首字耗時分布直方圖"
     },
     "site": {
       "removed": "已移除 {{label}}"

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -3333,20 +3333,19 @@
       "sectionTitle": "用户实测",
       "window24": "近 24 小时",
       "window7": "近 7 天",
-      "noteSources": "{{count}} 位用户 · {{samples}} 个样本",
       "ttftP50": "首字 p50",
       "ttftP95": "首字 p95",
       "errRate": "错误率",
       "cacheHit": "缓存命中",
       "costRef": "花费参考",
       "hoursTitle": "时段首字中位数（近 7 天 · UTC）",
-      "hourTooltip": "UTC {{slot}}:00 · {{value}} · {{count}} 个样本",
+      "hourTooltip": "UTC {{slot}}:00 · {{value}}",
       "hourEmpty": "UTC {{slot}}:00 · 无数据",
-      "noData": "暂无实测数据（样本或来源不足）",
+      "noData": "暂无实测数据",
       "lockedTitle": "加入共建后可查看",
       "lockedBody": "上传你本地的站点聚合指标（首字耗时、错误率等），即可查看所有用户的实测数据。",
       "join": "加入共建",
-      "footnote": "数据来自 LoongPort 用户共建：按小时聚合、经隐私门槛发布；花费为混合模型的参考值。",
+      "footnote": "数据来自 LoongPort 用户匿名共建，样本不足时不展示；花费为混合模型的参考值。",
       "notice": {
         "title": "站点实测数据共建",
         "question": "是否愿意查看各站点的首字耗时、错误率等实测数据？",
@@ -3354,11 +3353,11 @@
         "accept": "同意",
         "decline": "暂不"
       },
-      "distTitle": "首字耗时分布（样本计数）",
-      "distTooltip": "{{range}} · {{count}} 个样本",
+      "distTitle": "首字耗时分布",
+      "distTooltip": "{{range}}",
       "distFast": "快",
       "distSlow": "慢",
-      "distSr": "首字耗时分布直方图，共 {{count}} 个样本"
+      "distSr": "首字耗时分布直方图"
     },
     "site": {
       "removed": "已移除 {{label}}"

--- a/tests/config/loongportLocales.test.ts
+++ b/tests/config/loongportLocales.test.ts
@@ -190,7 +190,6 @@ const requiredKeys = [
   "crowd.sectionTitle",
   "crowd.window24",
   "crowd.window7",
-  "crowd.noteSources",
   "crowd.ttftP50",
   "crowd.ttftP95",
   "crowd.errRate",


### PR DESCRIPTION
## 变更
与 website /status 页同轮同口径，app 内广场实测区去计数：

1. **注脚**：「X 位用户 · X 个样本」整条摘除，只留统计窗口标签（近 24 小时/近 7 天）。用户数与样本数都可反推各站活跃度，不再外显。
2. **tooltip**：时段条不再带逐时段样本数，分布条不再带桶计数；分布图标题去掉「样本计数」。
3. **文案**：noData 去掉「（样本或来源不足）」内部判据；脚注改为「匿名共建，样本不足时不展示」，与官网一致。
4. i18n key noteSources 移除，loongportLocales requiredKeys 与组件测试同步。

## 验证
- [x] pnpm vitest run（CrowdMeasuredSection + loongportLocales，32 用例）
- [x] prettier --check
- [x] pnpm typecheck