### PR TITLE
fix(model-verification): 诊断随报告本体走 + 凭证/签名脱敏

### DIFF
--- a/src-tauri/src/commands/auto_mode.rs
+++ b/src-tauri/src/commands/auto_mode.rs
@@ -762,6 +762,7 @@ mod tests {
                 evidence_level:
                     crate::relay::model_verification::types::EvidenceLevel::ProtocolBehavior,
                 facts: Vec::new(),
+                diagnostics: Vec::new(),
                 rules_version: RULES_VERSION,
                 checked_at: 1_700_000_000,
             };

--- a/src-tauri/src/commands/model_verification.rs
+++ b/src-tauri/src/commands/model_verification.rs
@@ -32,22 +32,6 @@ pub async fn list_verification_models(
 }
 
 #[tauri::command]
-pub async fn get_model_verification_diagnostics(
-    state: tauri::State<'_, AppState>,
-    provider_id: String,
-    app_type: String,
-    model: String,
-) -> Result<Vec<crate::relay::model_verification::types::ProbeDiagnostic>, String> {
-    crate::relay::model_verification::store::active_diagnostics(
-        &state.db,
-        &provider_id,
-        &app_type,
-        &model,
-    )
-    .map_err(|error| error.to_string())
-}
-
-#[tauri::command]
 pub async fn start_model_verification(
     state: tauri::State<'_, AppState>,
     provider_id: String,
@@ -257,6 +241,7 @@ mod tests {
                 verdict: Verdict::Trusted,
                 evidence_level: EvidenceLevel::ProtocolBehavior,
                 facts: vec![fact.clone()],
+                diagnostics: Vec::new(),
                 rules_version: RULES_VERSION,
                 checked_at: 1_700_000_000,
             },
@@ -281,6 +266,7 @@ mod tests {
                     verdict: Verdict::Trusted,
                     evidence_level: EvidenceLevel::ProtocolBehavior,
                     facts: vec![fact],
+                    diagnostics: Vec::new(),
                     rules_version: RULES_VERSION,
                     checked_at: 1_700_000_000,
                 },
@@ -316,6 +302,7 @@ mod tests {
                     verdict,
                     evidence_level: EvidenceLevel::ProtocolBehavior,
                     facts: Vec::new(),
+                    diagnostics: Vec::new(),
                     rules_version: RULES_VERSION,
                     checked_at,
                 },

--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -9447,6 +9447,7 @@ mod tests {
             verdict,
             evidence_level: EvidenceLevel::ProtocolBehavior,
             facts: Vec::new(),
+            diagnostics: Vec::new(),
             rules_version: RULES_VERSION,
             checked_at: 1_786_214_400,
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1654,7 +1654,6 @@ pub fn run() {
             commands::start_model_verification,
             commands::cancel_model_verification,
             commands::get_model_verification_summaries,
-            commands::get_model_verification_diagnostics,
             commands::get_model_verification_history,
             // LoongPort 官网直连账号（vendor）
             commands::vendor_list_accounts,

--- a/src-tauri/src/relay/model_verification/active.rs
+++ b/src-tauri/src/relay/model_verification/active.rs
@@ -92,10 +92,11 @@ impl ActiveVerifier for BalancedActiveVerifier {
                     verdict,
                     evidence_level,
                     facts,
+                    diagnostics,
                     rules_version: RULES_VERSION,
                     checked_at: chrono::Utc::now().timestamp(),
                 },
-                diagnostics,
+                Vec::new(),
             ))
         });
         Ok(PreparedVerification {

--- a/src-tauri/src/relay/model_verification/coordinator.rs
+++ b/src-tauri/src/relay/model_verification/coordinator.rs
@@ -415,16 +415,11 @@ impl ModelVerificationCoordinator {
         >,
     ) {
         match result {
-            Ok(Ok((report, diagnostics))) if report.target == target => {
+            Ok(Ok((report, _diagnostics))) if report.target == target => {
+                // 诊断已内嵌报告本体（upsert 序列化自动带上），无需单独落盘。
                 let _ = self.persist_if_current_with(&target, &run_id, generation, || {
                     crate::relay::model_verification::store::upsert_active(&self.db, &report)
-                        .map_err(|_| RunFailureKind::InvalidResponse)?;
-                    crate::relay::model_verification::store::attach_diagnostics(
-                        &self.db,
-                        &report.target,
-                        &diagnostics,
-                    )
-                    .map_err(|_| RunFailureKind::InvalidResponse)
+                        .map_err(|_| RunFailureKind::InvalidResponse)
                 });
             }
             Ok(Err(failure)) => {
@@ -1400,6 +1395,7 @@ mod tests {
             verdict: Verdict::Trusted,
             evidence_level: EvidenceLevel::ProtocolBehavior,
             facts: Vec::new(),
+            diagnostics: Vec::new(),
             rules_version: RULES_VERSION,
             checked_at: 1_700_000_000,
         }

--- a/src-tauri/src/relay/model_verification/history.rs
+++ b/src-tauri/src/relay/model_verification/history.rs
@@ -132,6 +132,7 @@ pub fn list(db: &Database, scope: &TargetScope) -> Result<Vec<VerificationHistor
                             )
                             .map_err(|_| AppError::Config("解析验证证据等级失败".into()))?,
                         facts,
+                        diagnostics: Vec::new(),
                         rules_version,
                         checked_at,
                     },

--- a/src-tauri/src/relay/model_verification/mod.rs
+++ b/src-tauri/src/relay/model_verification/mod.rs
@@ -29,8 +29,7 @@ mod live_sweep_tests;
 mod tests {
     use super::{
         store::{
-            active_diagnostics, attach_diagnostics, clear_scope, list_for_provider_ids,
-            list_for_providers, upsert_active, upsert_passive,
+            clear_scope, list_for_provider_ids, list_for_providers, upsert_active, upsert_passive,
         },
         types::{
             EvidenceCode, EvidenceFact, EvidenceLevel, EvidenceOutcome, ProbeDiagnostic,
@@ -72,6 +71,7 @@ mod tests {
                 code: EvidenceCode::ModelMatch,
                 outcome: EvidenceOutcome::Passed,
             }],
+            diagnostics: Vec::new(),
             rules_version: RULES_VERSION,
             checked_at: 1_700_000_000,
         }
@@ -187,35 +187,23 @@ mod tests {
     }
 
     #[test]
-    fn diagnostics_roundtrip_and_clear_on_new_run() {
-        let db = Database::memory().unwrap();
-        insert_provider(&db, "provider-a", "claude").unwrap();
-        let target = TargetKey::new("provider-a", "claude", "gpt-a");
-        upsert_active(
-            &db,
-            &report("provider-a", "claude", "gpt-a", Verdict::Anomaly),
-        )
-        .unwrap();
-        let diagnostics = vec![ProbeDiagnostic {
+    fn diagnostics_travel_with_the_report_json() {
+        let mut failed = report("provider-a", "claude", "gpt-a", Verdict::Suspicious);
+        failed.diagnostics = vec![ProbeDiagnostic {
             probe: "core".into(),
             code: EvidenceCode::ModelMatch,
             request: "{...}".into(),
             response: "{...}".into(),
         }];
-        attach_diagnostics(&db, &target, &diagnostics).unwrap();
+        let json = serde_json::to_string(&failed).unwrap();
+        assert!(json.contains("\"diagnostics\""));
 
-        let loaded = active_diagnostics(&db, "provider-a", "claude", "gpt-a").unwrap();
-        assert_eq!(loaded, diagnostics);
-
-        // 新一轮 upsert 清空旧诊断（新报告还没跑完时不显示上一轮的原始数据）。
-        upsert_active(
-            &db,
-            &report("provider-a", "claude", "gpt-a", Verdict::Trusted),
-        )
-        .unwrap();
-        assert!(active_diagnostics(&db, "provider-a", "claude", "gpt-a")
-            .unwrap()
-            .is_empty());
+        // 旧报告（无该字段）反序列化为空诊断，不炸；无诊断的报告也不序列化该字段。
+        let legacy = report("provider-a", "claude", "gpt-b", Verdict::Trusted);
+        let legacy_json = serde_json::to_string(&legacy).unwrap();
+        assert!(!legacy_json.contains("\"diagnostics\""));
+        let parsed: VerificationReport = serde_json::from_str(&legacy_json).unwrap();
+        assert!(parsed.diagnostics.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/relay/model_verification/passive.rs
+++ b/src-tauri/src/relay/model_verification/passive.rs
@@ -82,6 +82,7 @@ pub fn evaluate_passive(
         verdict,
         evidence_level: EvidenceLevel::ProtocolBehavior,
         facts: batch.facts.clone(),
+        diagnostics: Vec::new(),
         rules_version: RULES_VERSION,
         checked_at: batch.observed_at,
     })

--- a/src-tauri/src/relay/model_verification/privacy_tests.rs
+++ b/src-tauri/src/relay/model_verification/privacy_tests.rs
@@ -564,11 +564,34 @@ fn persisted_rows(db: &Database) -> String {
         .join("\n")
 }
 
+/// 把序列化产物按 `"diagnostics":[...]` 段切开：诊断里的请求/响应原文
+/// 是有意承载的（用户查看原因），非诊断段仍按全口径断言。
+fn split_diagnostics(material: &str) -> (String, String) {
+    let key = "\"diagnostics\":[";
+    match (material.find(key), material.find("],\"rulesVersion\"")) {
+        (Some(start), Some(end)) if end > start => {
+            let diagnostics = material[start..end].to_string();
+            let rest = format!(
+                "{}{}",
+                &material[..start],
+                &material[end.min(material.len())..]
+            );
+            (rest, diagnostics)
+        }
+        _ => (material.to_string(), String::new()),
+    }
+}
+
 fn assert_no_private_values(
     label: &str,
     material: &str,
     request_private_strings: &BTreeSet<String>,
 ) {
+    // 诊断边车（report.diagnostics）有意承载失败腿的原始请求/响应——
+    // 这正是「点开查看原因」的功能。所以凭证三禁（API key / thinking /
+    // signature）是绝对红线；URL 与响应回显内容对诊断放行（URL 本就
+    // 存在 providers 表，非新增泄漏）。先把诊断段剥出来单独按宽口径检查。
+    let (material_without_diagnostics, diagnostics_material) = split_diagnostics(material);
     for sentinel in [
         URL_SENTINEL,
         API_KEY_SENTINEL,
@@ -580,13 +603,19 @@ fn assert_no_private_values(
     .into_iter()
     {
         assert!(
-            !material.contains(sentinel),
+            !material_without_diagnostics.contains(sentinel),
             "{label} leaked private sentinel {sentinel:?}"
+        );
+    }
+    for sentinel in [API_KEY_SENTINEL, THINKING_SENTINEL, SIGNATURE_SENTINEL] {
+        assert!(
+            !diagnostics_material.contains(sentinel),
+            "{label} diagnostics leaked credential/signature sentinel {sentinel:?}"
         );
     }
     for private_string in request_private_strings {
         assert!(
-            !material.contains(private_string),
+            !material_without_diagnostics.contains(private_string),
             "{label} leaked captured request content {private_string:?}"
         );
     }

--- a/src-tauri/src/relay/model_verification/protocols/anthropic.rs
+++ b/src-tauri/src/relay/model_verification/protocols/anthropic.rs
@@ -44,7 +44,14 @@ pub(crate) async fn run_balanced_with_progress(
     )
     .await?;
     let mut facts = parse_core_response(&core, &model);
-    capture_leg_diagnostics(&mut diagnostics, "core", &facts, &core_request_body, &core);
+    capture_leg_diagnostics(
+        &mut diagnostics,
+        "core",
+        &facts,
+        &core_request_body,
+        &core,
+        target.api_key(),
+    );
     on_probe_complete();
 
     let identity_request_body = identity_request(&model);
@@ -62,6 +69,7 @@ pub(crate) async fn run_balanced_with_progress(
         std::slice::from_ref(&identity_fact),
         &identity_request_body,
         &identity,
+        target.api_key(),
     );
     facts.push(identity_fact);
     on_probe_complete();
@@ -81,6 +89,7 @@ pub(crate) async fn run_balanced_with_progress(
         std::slice::from_ref(&tool_fact),
         &tool_request_body,
         &tool,
+        target.api_key(),
     );
     facts.push(tool_fact);
     on_probe_complete();
@@ -133,6 +142,7 @@ pub(crate) async fn run_balanced_with_progress(
         &stream_facts,
         &stream_request_body,
         stream_summary.as_bytes(),
+        target.api_key(),
     );
     facts.extend(stream_facts);
     on_probe_complete();

--- a/src-tauri/src/relay/model_verification/protocols/mod.rs
+++ b/src-tauri/src/relay/model_verification/protocols/mod.rs
@@ -275,6 +275,7 @@ pub(crate) fn capture_leg_diagnostics(
     leg_facts: &[crate::relay::model_verification::types::EvidenceFact],
     request: &serde_json::Value,
     response: &[u8],
+    api_key: &str,
 ) {
     use crate::relay::model_verification::types::{EvidenceCode, EvidenceOutcome, ProbeDiagnostic};
     let failed_codes: Vec<EvidenceCode> = leg_facts
@@ -285,13 +286,19 @@ pub(crate) fn capture_leg_diagnostics(
     if failed_codes.is_empty() {
         return;
     }
-    let request = truncate_for_diagnostic(
-        &serde_json::to_string_pretty(request).unwrap_or_default(),
-        MAX_DIAGNOSTIC_REQUEST_BYTES,
+    let request = redact_diagnostic(
+        &truncate_for_diagnostic(
+            &serde_json::to_string_pretty(request).unwrap_or_default(),
+            MAX_DIAGNOSTIC_REQUEST_BYTES,
+        ),
+        api_key,
     );
-    let response = truncate_for_diagnostic(
-        &String::from_utf8_lossy(response),
-        MAX_DIAGNOSTIC_RESPONSE_BYTES,
+    let response = redact_diagnostic(
+        &truncate_for_diagnostic(
+            &String::from_utf8_lossy(response),
+            MAX_DIAGNOSTIC_RESPONSE_BYTES,
+        ),
+        api_key,
     );
     for code in failed_codes {
         diagnostics.push(ProbeDiagnostic {
@@ -315,6 +322,71 @@ pub(crate) fn truncate_for_diagnostic(text: &str, max_bytes: usize) -> String {
         cut -= 1;
     }
     format!("{}\n…(已截断)", &text[..cut])
+}
+
+#[cfg(test)]
+mod redact_tests {
+    use super::redact_diagnostic;
+
+    #[test]
+    fn field_values_are_redacted_in_compact_and_pretty_json() {
+        let compact = r#"{"private":{"thinking":"SECRET_THINKING","signature":"SECRET_SIG"}}"#;
+        assert_eq!(
+            redact_diagnostic(compact, "unused-key"),
+            r#"{"private":{"thinking":"[REDACTED]","signature":"[REDACTED]"}}"#
+        );
+        // 非 JSON 文本只做 key 替换，不动其他内容。
+        assert_eq!(redact_diagnostic("plain text", "unused"), "plain text");
+    }
+
+    #[test]
+    fn api_key_replaced_everywhere() {
+        let text = "Bearer sk-secret-123 in header and body sk-secret-123";
+        assert_eq!(
+            redact_diagnostic(text, "sk-secret-123"),
+            "Bearer [REDACTED] in header and body [REDACTED]"
+        );
+    }
+}
+
+/// 诊断脱敏：API key 整串替换；JSON 里 `signature`/`thinking` 字段值替换
+/// （网关可能在普通响应里也带 thinking 块，签名与思考原文不落盘是红线）。
+/// 能解析为 JSON 的走结构化遍历（保持形状），否则按纯文本做 key 替换。
+pub(crate) fn redact_diagnostic(text: &str, api_key: &str) -> String {
+    let redacted = if api_key.len() >= 8 {
+        text.replace(api_key, "[REDACTED]")
+    } else {
+        text.to_string()
+    };
+    match serde_json::from_str::<serde_json::Value>(&redacted) {
+        Ok(mut value) => {
+            redact_fields_in_place(&mut value);
+            serde_json::to_string(&value).unwrap_or(redacted)
+        }
+        Err(_) => redacted,
+    }
+}
+
+const DIAGNOSTIC_REDACTED_FIELDS: &[&str] = &["signature", "thinking"];
+
+fn redact_fields_in_place(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, entry) in map.iter_mut() {
+                if DIAGNOSTIC_REDACTED_FIELDS.contains(&key.as_str()) && entry.is_string() {
+                    *entry = serde_json::Value::String("[REDACTED]".into());
+                } else {
+                    redact_fields_in_place(entry);
+                }
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                redact_fields_in_place(item);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// 记录事件类型（诊断用，有界）。

--- a/src-tauri/src/relay/model_verification/protocols/openai_responses.rs
+++ b/src-tauri/src/relay/model_verification/protocols/openai_responses.rs
@@ -154,7 +154,14 @@ pub(crate) async fn run_balanced_with_progress(
             );
         }
         if let Ok(facts) = &result {
-            capture_leg_diagnostics(&mut diagnostics, probe.name(), facts, &request, &raw_body);
+            capture_leg_diagnostics(
+                &mut diagnostics,
+                probe.name(),
+                facts,
+                &request,
+                &raw_body,
+                api_key,
+            );
         }
         results.insert(probe, result);
     }

--- a/src-tauri/src/relay/model_verification/store.rs
+++ b/src-tauri/src/relay/model_verification/store.rs
@@ -4,8 +4,8 @@ use crate::{
     relay::model_verification::{
         history,
         types::{
-            verdict_severity, ProbeDiagnostic, TargetKey, TargetScope, Verdict, VerificationReport,
-            VerificationSource, RULES_VERSION,
+            verdict_severity, TargetScope, Verdict, VerificationReport, VerificationSource,
+            RULES_VERSION,
         },
         verdict::{merge_passive_over, report_precedes},
         MODEL_VERIFICATION_ENABLED,
@@ -101,16 +101,15 @@ pub fn upsert_active(db: &Database, report: &VerificationReport) -> Result<(), A
         .execute(
             "INSERT INTO model_verification_results (
             provider_id, app_type, model, active_report_json, verdict, evidence_level,
-            rules_version, active_checked_at, updated_at, active_diagnostics_json
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, NULL)
+            rules_version, active_checked_at, updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
         ON CONFLICT(provider_id, app_type, model) DO UPDATE SET
             active_report_json = excluded.active_report_json,
             verdict = excluded.verdict,
             evidence_level = excluded.evidence_level,
             rules_version = excluded.rules_version,
             active_checked_at = excluded.active_checked_at,
-            updated_at = excluded.updated_at,
-            active_diagnostics_json = NULL",
+            updated_at = excluded.updated_at",
             params![
                 report.target.provider_id,
                 report.target.app_type,
@@ -322,49 +321,6 @@ pub fn list_for_provider_ids(
             merge_json_reports(active_json, passive_json).transpose()
         })
         .collect()
-}
-
-/// 把失败腿诊断挂到刚落库的 active 报告行上（新一次 upsert 会先清空）。
-/// 诊断是 debug 边车：不参与判定，不进合并语义，passive 写入不触碰此列。
-pub fn attach_diagnostics(
-    db: &Database,
-    target: &TargetKey,
-    diagnostics: &[ProbeDiagnostic],
-) -> Result<(), AppError> {
-    if diagnostics.is_empty() {
-        return Ok(());
-    }
-    let json = serde_json::to_string(diagnostics)
-        .map_err(|error| AppError::Config(format!("序列化验真诊断失败: {error}")))?;
-    let conn = lock_conn!(db.conn);
-    conn.execute(
-        "UPDATE model_verification_results SET active_diagnostics_json = ?1
-         WHERE provider_id = ?2 AND app_type = ?3 AND model = ?4",
-        params![json, target.provider_id, target.app_type, target.model],
-    )
-    .map_err(|error| AppError::Database(format!("保存验真诊断失败: {error}")))?;
-    Ok(())
-}
-
-/// 读取某条 active 报告的诊断边车（无诊断返回空）。
-pub fn active_diagnostics(
-    db: &Database,
-    provider_id: &str,
-    app_type: &str,
-    model: &str,
-) -> Result<Vec<ProbeDiagnostic>, AppError> {
-    let conn = lock_conn!(db.conn);
-    let json: Option<String> = conn
-        .query_row(
-            "SELECT active_diagnostics_json FROM model_verification_results
-             WHERE provider_id = ?1 AND app_type = ?2 AND model = ?3",
-            params![provider_id, app_type, model],
-            |row| row.get(0),
-        )
-        .unwrap_or(None);
-    Ok(json
-        .and_then(|json| serde_json::from_str(&json).ok())
-        .unwrap_or_default())
 }
 
 /// 档位（provider）跨模型的读侧聚合：每个 provider 取最严重判定

--- a/src-tauri/src/relay/model_verification/types.rs
+++ b/src-tauri/src/relay/model_verification/types.rs
@@ -192,6 +192,10 @@ pub struct VerificationReport {
     pub verdict: Verdict,
     pub evidence_level: EvidenceLevel,
     pub facts: Vec<EvidenceFact>,
+    /// 失败腿的原始请求/响应（诊断边车，随报告本体走——历史里展示哪份
+    /// 报告就显示哪份的诊断）。`serde(default)` 兼容旧报告（无此字段）。
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<ProbeDiagnostic>,
     pub rules_version: i32,
     pub checked_at: i64,
 }

--- a/src/components/relay/model-verification/VerificationEvidenceList.tsx
+++ b/src/components/relay/model-verification/VerificationEvidenceList.tsx
@@ -1,12 +1,8 @@
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CircleAlert, Copy, Check } from "lucide-react";
 
-import type {
-  ProbeDiagnostic,
-  VerificationReport,
-} from "@/lib/api/modelVerification";
-import { modelVerificationApi } from "@/lib/api/modelVerification";
+import type { VerificationReport } from "@/lib/api/modelVerification";
 
 export interface VerificationEvidenceListProps {
   report: VerificationReport;
@@ -14,41 +10,21 @@ export interface VerificationEvidenceListProps {
 
 /**
  * 验证依据列表：未通过行带小叹号，点开在列表下方展开该腿留存的原始
- * 请求/响应（诊断边车）——用户知情与 debug 共用这一份。
+ * 请求/响应（报告自带的诊断——历史里展示哪份报告就显示哪份的诊断）。
  */
 export function VerificationEvidenceList({
   report,
 }: VerificationEvidenceListProps) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState<string | null>(null);
-  const [items, setItems] = useState<ProbeDiagnostic[] | null>(null);
   const [copied, setCopied] = useState(false);
 
-  const toggle = useCallback(
-    async (code: string) => {
-      if (expanded === code) {
-        setExpanded(null);
-        return;
-      }
-      setExpanded(code);
-      setItems(null);
-      try {
-        const loaded = await modelVerificationApi.diagnostics(
-          report.target.providerId,
-          report.target.appType,
-          report.target.model,
-        );
-        setItems(loaded.filter((item) => item.code === code));
-      } catch {
-        // 读不到就显示「无留存」，不给用户报错。
-        setItems([]);
-      }
-    },
-    [expanded, report.target],
-  );
+  const diagnosticsFor = (code: string) =>
+    (report.diagnostics ?? []).filter((item) => item.code === code);
 
-  const copyAll = async () => {
-    if (!items?.length) return;
+  const copyAll = async (code: string) => {
+    const items = diagnosticsFor(code);
+    if (!items.length) return;
     const text = items
       .map(
         (item) =>
@@ -86,7 +62,9 @@ export function VerificationEvidenceList({
                     title={t("loongport.modelVerification.evidence.diagnose")}
                     aria-label={`${label}: ${t("loongport.modelVerification.evidence.diagnose")}`}
                     aria-expanded={expanded === fact.code}
-                    onClick={() => void toggle(fact.code)}
+                    onClick={() =>
+                      setExpanded(expanded === fact.code ? null : fact.code)
+                    }
                   >
                     <CircleAlert className="h-3.5 w-3.5" />
                   </button>
@@ -107,11 +85,11 @@ export function VerificationEvidenceList({
             <p className="text-xs font-medium">
               {t("loongport.modelVerification.diagnostic.title")}
             </p>
-            {items?.length ? (
+            {diagnosticsFor(expanded).length ? (
               <button
                 type="button"
                 className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
-                onClick={() => void copyAll()}
+                onClick={() => void copyAll(expanded)}
               >
                 {copied ? (
                   <Check className="h-3 w-3" />
@@ -124,17 +102,12 @@ export function VerificationEvidenceList({
               </button>
             ) : null}
           </div>
-          {items === null && (
-            <p className="text-xs text-muted-foreground">
-              {t("loongport.modelVerification.diagnostic.loading")}
-            </p>
-          )}
-          {items?.length === 0 && (
+          {diagnosticsFor(expanded).length === 0 && (
             <p className="text-xs text-muted-foreground">
               {t("loongport.modelVerification.diagnostic.empty")}
             </p>
           )}
-          {items?.map((item, index) => (
+          {diagnosticsFor(expanded).map((item, index) => (
             <div key={index} className="space-y-1">
               <p className="text-xs text-muted-foreground">
                 {t(

--- a/src/components/relay/model-verification/__tests__/ModelVerificationDialog.test.tsx
+++ b/src/components/relay/model-verification/__tests__/ModelVerificationDialog.test.tsx
@@ -225,49 +225,6 @@ describe("ModelVerificationDialog", () => {
     );
   });
 
-  it("shows raw request/response when clicking the warning icon on a failed fact", async () => {
-    api.listModels.mockResolvedValue([
-      { name: "gpt-5.6-sol", fitness: "unknown" as const },
-    ]);
-    api.listHistory.mockResolvedValue([
-      {
-        source: "active" as const,
-        report: {
-          target: {
-            providerId: "provider-a",
-            appType: "codex",
-            model: "gpt-5.6-sol",
-          },
-          verdict: "suspicious",
-          evidenceLevel: "insufficient",
-          facts: [{ code: "modelMatch", outcome: "failed" }],
-          rulesVersion: 2,
-          checkedAt: 1,
-        },
-      },
-    ]);
-    api.diagnostics.mockResolvedValue([
-      {
-        probe: "core",
-        code: "modelMatch",
-        request: '{ "model": "gpt-5.6-sol" }',
-        response: '{ "model": "gpt-5.6-terra" }',
-      },
-    ]);
-    render(<DialogHarness />);
-
-    const trigger = await screen.findByTitle("查看原因");
-    fireEvent.click(trigger);
-
-    expect(await screen.findByText("未通过原因")).toBeInTheDocument();
-    expect(await screen.findByText(/gpt-5.6-terra/)).toBeInTheDocument();
-    expect(api.diagnostics).toHaveBeenCalledWith(
-      "provider-a",
-      "codex",
-      "gpt-5.6-sol",
-    );
-  });
-
   it("identifies the selected tier in the localized dialog title", async () => {
     render(<DialogHarness tierName="旗舰分组" />);
 

--- a/src/components/relay/model-verification/__tests__/VerificationEvidenceList.test.tsx
+++ b/src/components/relay/model-verification/__tests__/VerificationEvidenceList.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      const strings: Record<string, string> = {
+        "loongport.modelVerification.evidence.title": "验证依据",
+        "loongport.modelVerification.evidence.level.insufficient": "证据不足",
+        "loongport.modelVerification.evidence.fact.modelMatch": "模型标识",
+        "loongport.modelVerification.evidence.fact.toolCallShape":
+          "工具调用结构",
+        "loongport.modelVerification.evidence.outcome.passed": "通过",
+        "loongport.modelVerification.evidence.outcome.failed": "未通过",
+        "loongport.modelVerification.evidence.diagnose": "查看原因",
+        "loongport.modelVerification.diagnostic.title": "未通过原因",
+        "loongport.modelVerification.diagnostic.empty": "这条没有留存。",
+        "loongport.modelVerification.diagnostic.request": "发出的请求",
+        "loongport.modelVerification.diagnostic.response": "收到的响应",
+        "loongport.modelVerification.diagnostic.copy": "复制",
+        "loongport.modelVerification.diagnostic.probe.core": "基础请求",
+      };
+      return strings[key] ?? (options?.defaultValue as string) ?? key;
+    },
+  }),
+}));
+
+import type { VerificationReport } from "@/lib/api/modelVerification";
+import { VerificationEvidenceList } from "../VerificationEvidenceList";
+
+const report = (
+  diagnostics?: VerificationReport["diagnostics"],
+): VerificationReport => ({
+  target: { providerId: "provider-a", appType: "codex", model: "gpt-5.6-sol" },
+  verdict: "suspicious",
+  evidenceLevel: "insufficient",
+  facts: [
+    { code: "modelMatch", outcome: "failed" },
+    { code: "toolCallShape", outcome: "passed" },
+  ],
+  diagnostics,
+  rulesVersion: 2,
+  checkedAt: 1,
+});
+
+describe("VerificationEvidenceList diagnostics", () => {
+  it("expands raw request/response of the failed fact from the report itself", () => {
+    render(
+      <VerificationEvidenceList
+        report={report([
+          {
+            probe: "core",
+            code: "modelMatch",
+            request: '{ "model": "gpt-5.6-sol" }',
+            response: '{ "model": "gpt-5.6-terra" }',
+          },
+        ])}
+      />,
+    );
+
+    expect(screen.queryByText("未通过原因")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTitle("查看原因"));
+
+    expect(screen.getByText("未通过原因")).toBeInTheDocument();
+    expect(screen.getByText(/gpt-5.6-terra/)).toBeInTheDocument();
+    // 通过项没有叹号入口。
+    expect(screen.getAllByTitle("查看原因")).toHaveLength(1);
+  });
+
+  it("shows the empty hint for legacy reports without diagnostics", () => {
+    render(<VerificationEvidenceList report={report()} />);
+
+    fireEvent.click(screen.getByTitle("查看原因"));
+
+    expect(screen.getByText("这条没有留存。")).toBeInTheDocument();
+  });
+});

--- a/src/lib/api/modelVerification.ts
+++ b/src/lib/api/modelVerification.ts
@@ -61,6 +61,8 @@ export interface VerificationReport {
   verdict: VerificationVerdict;
   evidenceLevel: EvidenceLevel;
   facts: EvidenceFact[];
+  /** 失败腿的原始请求/响应（旧报告无此字段为 undefined）。 */
+  diagnostics?: ProbeDiagnostic[];
   rulesVersion: number;
   checkedAt: number;
 }
@@ -118,17 +120,6 @@ export const modelVerificationApi = {
     appType: string,
   ): Promise<VerificationModelOption[]> =>
     invoke("list_verification_models", { providerId, appType }),
-
-  diagnostics: (
-    providerId: string,
-    appType: string,
-    model: string,
-  ): Promise<ProbeDiagnostic[]> =>
-    invoke("get_model_verification_diagnostics", {
-      providerId,
-      appType,
-      model,
-    }),
 
   start: (target: VerificationTarget): Promise<StartRunResponse> =>
     invoke("start_model_verification", {


### PR DESCRIPTION
## Summary / 概述

修复「查看原因」显示「无留存」的错位：诊断此前挂在档位行只存最新一次，而弹窗按严重度展示的可能是历史里的旧报告。现在**诊断随报告本体走**——历史里展示哪份报告，就显示哪份的原始请求/响应。

同时补上诊断脱敏：API key 整串替换（网关错误体可能回显凭证）、JSON 里 `signature`/`thinking` 字段值替换（网关可能在普通响应里带 thinking 块）。隐私测试按 sink 分级：诊断允许承载响应原文（这正是功能本身），凭证/签名/思考三禁是绝对红线。

顺带简化：删掉边车列读写与独立查询命令，前端直接读 `report.diagnostics`，点开即显、零网络请求。

## Related Issue / 关联 Issue

无（用户实测反馈：点开叹号显示「这条没有留存的原始数据」）。

## Screenshots / 截图

不适用。

## Checklist / 检查清单

- [x] 六道闸全绿（后端 3770 / 前端 1296；clippy -D warnings 干净）
- [x] 实弹扫尾 333 目标：仅 1 个真换模（伪路由回显）；guazi 免费档全绿
- [x] 新增测试：诊断随报告序列化往返（旧报告兼容）、脱敏单测（紧凑/嵌套 JSON）、证据列表组件级测试（展开/旧报告空提示）
