### PR TITLE
Revert "fix(easymode): 档位看板策略兜底文案对齐价格最低/响应最快"

### DIFF
--- a/src/components/easymode/EasyBoard.tsx
+++ b/src/components/easymode/EasyBoard.tsx
@@ -1,7 +1,7 @@
 /**
  * 首页省心视图：省心模式生效时替换该 app 的 provider 页。
  *
- * 用户只做三件事：选模型、选模式（自动/手动）；自动下选策略（价格最低/响应最快），
+ * 用户只做三件事：选模型、选模式（自动/手动）；自动下选策略（省钱/省时），
  * 手动下拖动档位卡排序。全部档位事实来自后端看板（唯源），这里只渲染。
  */
 import { useTranslation } from "react-i18next";
@@ -116,14 +116,14 @@ export function EasyBoard({ appId }: { appId: string }) {
               disabled={setStrategy.isPending}
               onClick={() => setStrategy.mutate({ strategy: "cheapest" })}
             >
-              {t("autoMode.strategy.cheapest", { defaultValue: "价格最低" })}
+              {t("autoMode.strategy.cheapest", { defaultValue: "省钱" })}
             </ChoiceButton>
             <ChoiceButton
               active={board.strategy === "fastest"}
               disabled={setStrategy.isPending}
               onClick={() => setStrategy.mutate({ strategy: "fastest" })}
             >
-              {t("autoMode.strategy.fastest", { defaultValue: "响应最快" })}
+              {t("autoMode.strategy.fastest", { defaultValue: "省时" })}
             </ChoiceButton>
           </div>
         ) : null}

--- a/tests/components/EasyBoard.test.tsx
+++ b/tests/components/EasyBoard.test.tsx
@@ -416,7 +416,7 @@ describe("EasyBoard", () => {
 
   it("点策略按钮落到 setStrategy mutation", () => {
     setupBoard(boardFixture());
-    fireEvent.click(screen.getByText("响应最快"));
+    fireEvent.click(screen.getByText("省时"));
     expect(setStrategyMock).toHaveBeenCalledWith({ strategy: "fastest" });
   });
 


### PR DESCRIPTION
Revert 89c4475c（PR #264）。

**原因：范围越界。** 2026-09-05 省钱/价格叙事下线的拍板范围是**线上内容面**（网站、README、公开内容仓）；软件本体不动。PR #264 对 EasyBoard 兜底文案与注释的对齐属于超出该范围的改动，按用户要求恢复原样。

**说明**：被 revert 的 3 行是 locale 缺 key 时才会用到的兜底字符串与一行注释，运行时界面（由语言包渲染）改动前后完全一致，无任何功能或用户可见变化；本次 revert 同样零行为差异。

**验证**：`vitest run tests/components/EasyBoard.test.tsx` 12/12 通过；`pnpm format:check` 通过。