### PR TITLE
fix(proxy): 首字/用时按成功尝试计时，失败尝试的耗时不再记进成功档

### DIFF
--- a/src-tauri/src/proxy/auto_mode_e2e_tests.rs
+++ b/src-tauri/src/proxy/auto_mode_e2e_tests.rs
@@ -22,6 +22,7 @@ use crate::database::Database;
 use crate::provider::Provider;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
 use axum::Json;
 use serde_json::{json, Value};
 use serial_test::serial;
@@ -31,13 +32,17 @@ use tempfile::TempDir;
 use tokio::sync::RwLock;
 
 /// 可编程 mock 上游：默认 200，可翻成 500 模拟故障；记录命中数与鉴权头。
-/// `foreign` 开关让 mock 回 OpenAI 形状（模拟换芯转发，供被动监控 E2E）。
+/// `foreign` 开关让 mock 回 OpenAI 形状（模拟换芯转发，供被动监控 E2E）；
+/// `stream` 开关回 Anthropic SSE 形状（供流式首字/用量链路 E2E）；
+/// `delay_ms` 在应答前 sleep（模拟「等了很久才失败」的档位，验证计时不被它污染）。
 #[derive(Clone)]
 struct MockUpstreamState {
     hits: Arc<AtomicUsize>,
     status: Arc<RwLock<u16>>,
     auth_header: Arc<RwLock<Option<String>>>,
     foreign: Arc<RwLock<bool>>,
+    stream: Arc<RwLock<bool>>,
+    delay_ms: Arc<std::sync::atomic::AtomicU64>,
     marker: &'static str,
 }
 
@@ -53,6 +58,8 @@ impl MockUpstream {
             status: Arc::new(RwLock::new(200)),
             auth_header: Arc::new(RwLock::new(None)),
             foreign: Arc::new(RwLock::new(false)),
+            stream: Arc::new(RwLock::new(false)),
+            delay_ms: Arc::new(std::sync::atomic::AtomicU64::new(0)),
             marker,
         };
         let app = axum::Router::new()
@@ -84,6 +91,16 @@ impl MockUpstream {
         *self.state.foreign.write().await = foreign;
     }
 
+    async fn set_stream(&self, stream: bool) {
+        *self.state.stream.write().await = stream;
+    }
+
+    fn set_delay_ms(&self, delay_ms: u64) {
+        self.state
+            .delay_ms
+            .store(delay_ms, std::sync::atomic::Ordering::SeqCst);
+    }
+
     async fn auth_header(&self) -> Option<String> {
         self.state.auth_header.read().await.clone()
     }
@@ -93,14 +110,52 @@ async fn handle_mock(
     State(state): State<MockUpstreamState>,
     headers: HeaderMap,
     _body: axum::body::Bytes,
-) -> (StatusCode, Json<Value>) {
+) -> axum::response::Response {
     state.hits.fetch_add(1, Ordering::SeqCst);
     *state.auth_header.write().await = headers
         .get("authorization")
         .and_then(|v| v.to_str().ok())
         .map(str::to_string);
+    let delay_ms = state.delay_ms.load(std::sync::atomic::Ordering::SeqCst);
+    if delay_ms > 0 {
+        tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+    }
     let status = *state.status.read().await;
     if status == 200 {
+        if *state.stream.read().await {
+            // Anthropic SSE 形状：message_start 立即到（首字锚点），usage 在
+            // message_start / message_delta 里（Claude 流式解析器的取数点）。
+            let sse = format!(
+                "event: message_start\ndata: {}\n\n\
+                 event: content_block_delta\ndata: {}\n\n\
+                 event: message_delta\ndata: {}\n\n\
+                 event: message_stop\ndata: {}\n\n",
+                json!({
+                    "type": "message_start",
+                    "message": {
+                        "id": "msg_mock",
+                        "model": "claude-e2e",
+                        "usage": { "input_tokens": 1 },
+                    }
+                }),
+                json!({
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": { "type": "text_delta", "text": state.marker },
+                }),
+                json!({
+                    "type": "message_delta",
+                    "delta": { "stop_reason": "end_turn" },
+                    "usage": { "output_tokens": 1 },
+                }),
+                json!({ "type": "message_stop" }),
+            );
+            return axum::http::Response::builder()
+                .status(StatusCode::OK)
+                .header("content-type", "text/event-stream")
+                .body(axum::body::Body::from(sse))
+                .expect("build sse response");
+        }
         if *state.foreign.read().await {
             // OpenAI chat.completions 形状出现在 Claude 线路 = 异源指纹（换芯转发）
             return (
@@ -113,7 +168,8 @@ async fn handle_mock(
                     }],
                     "usage": {},
                 })),
-            );
+            )
+                .into_response();
         }
         (
             StatusCode::OK,
@@ -127,6 +183,7 @@ async fn handle_mock(
                 "usage": { "input_tokens": 1, "output_tokens": 1 },
             })),
         )
+            .into_response()
     } else {
         (
             StatusCode::from_u16(status).expect("valid status"),
@@ -135,6 +192,7 @@ async fn handle_mock(
                 "error": { "type": "api_error", "message": "mock upstream failure" },
             })),
         )
+            .into_response()
     }
 }
 
@@ -337,6 +395,73 @@ async fn response_text(resp: reqwest::Response) -> String {
         .to_string()
 }
 
+/// 走真实代理端口的 Claude 流式请求（SSE）。
+async fn send_streaming_message(port: u16, session: &str) -> reqwest::Response {
+    reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("build client")
+        .post(format!("http://127.0.0.1:{port}/v1/messages"))
+        .header("x-api-key", "client-key-should-be-overridden")
+        .header("anthropic-version", "2023-06-01")
+        .header("x-claude-code-session-id", session)
+        .json(&json!({
+            "model": "claude-e2e",
+            "max_tokens": 16,
+            "stream": true,
+            "messages": [{ "role": "user", "content": "hi" }],
+        }))
+        .send()
+        .await
+        .expect("send request")
+}
+
+/// 等异步 usage 落库，取该档位最近一行的 (first_token_ms, latency_ms)。
+async fn await_logged_timing(fx: &E2eFixture, provider_id: &str) -> (u64, u64) {
+    for _ in 0..250 {
+        let row = {
+            let conn = fx.db.conn.lock().unwrap();
+            conn.query_row(
+                "SELECT first_token_ms, latency_ms FROM proxy_request_logs \
+                 WHERE provider_id = ?1 AND first_token_ms IS NOT NULL \
+                 ORDER BY rowid DESC LIMIT 1",
+                rusqlite::params![provider_id],
+                |r| Ok((r.get::<_, i64>(0)? as u64, r.get::<_, i64>(1)? as u64)),
+            )
+            .ok()
+        };
+        if let Some(timing) = row {
+            return timing;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    let dump = {
+        let conn = fx.db.conn.lock().unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT rowid, provider_id, first_token_ms, latency_ms, status_code \
+                      FROM proxy_request_logs ORDER BY rowid DESC LIMIT 5",
+            )
+            .unwrap();
+        let rows = stmt
+            .query_map([], |r| {
+                Ok(format!(
+                    "(id={}, provider={}, ttft={:?}, latency={:?}, status={})",
+                    r.get::<_, i64>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, Option<i64>>(2)?,
+                    r.get::<_, Option<i64>>(3)?,
+                    r.get::<_, i64>(4)?,
+                ))
+            })
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        rows.join(" | ")
+    };
+    panic!("usage row for {provider_id} never landed; recent rows: {dump}");
+}
+
 /// 闲置（无当前档位活跃会话）时，省心模式把流量交给最便宜档位。
 #[tokio::test]
 #[serial]
@@ -443,6 +568,48 @@ async fn easy_mode_fails_over_in_request_even_with_failover_toggle_off() {
     let marker = response_text(send_message(fx.port, "sess-e2e-implied-0001").await).await;
     assert_eq!(marker, "served-by-expensive");
     assert_eq!(fx.cheap.hits(), 1, "故障档位只应被探测一次");
+    fx.server.stop().await.expect("stop server");
+}
+
+/// 首字/用时归因只算成功档位自己的耗时：便宜档拖 500ms 才回 402、贵档接住
+/// 流式请求 —— 落库的 first_token_ms / latency_ms 归贵档，且不得含那 500ms。
+/// （修复前计时锚点是客户端请求进入时刻：失败尝试的耗时会记进成功档的
+/// 首字里，污染看板均值与「响应最快」排序。）
+#[tokio::test]
+#[serial]
+async fn first_token_ms_excludes_time_spent_on_failed_attempts() {
+    let fx = E2eFixture::new().await;
+    // 关掉流式超时（0=禁用），失败档位的 500ms 延迟不被超时改道
+    let mut config = fx.db.get_proxy_config_for_app("claude").await.unwrap();
+    config.non_streaming_timeout = 0;
+    config.streaming_first_byte_timeout = 0;
+    config.streaming_idle_timeout = 0;
+    fx.db.update_proxy_config_for_app(config).await.unwrap();
+
+    const FAILED_ATTEMPT_DELAY_MS: u64 = 500;
+    fx.cheap.set_delay_ms(FAILED_ATTEMPT_DELAY_MS);
+    fx.cheap.set_status(402).await;
+    fx.expensive.set_stream(true).await;
+
+    let resp = send_streaming_message(fx.port, "sess-e2e-ttft-00001").await;
+    assert_eq!(resp.status(), 200, "故障转移后必须成功");
+    let body = resp.text().await.expect("read sse body");
+    assert!(
+        body.contains("served-by-expensive"),
+        "流式响应必须来自接住请求的档位: {body}"
+    );
+    assert_eq!(fx.cheap.hits(), 1);
+    assert_eq!(fx.expensive.hits(), 1);
+
+    let (first_token_ms, latency_ms) = await_logged_timing(&fx, &fx.expensive_id).await;
+    assert!(
+        first_token_ms < FAILED_ATTEMPT_DELAY_MS,
+        "首字时长不得包含失败尝试的 {FAILED_ATTEMPT_DELAY_MS}ms：{first_token_ms}ms"
+    );
+    assert!(
+        latency_ms < FAILED_ATTEMPT_DELAY_MS,
+        "用时同口径按成功尝试计：{latency_ms}ms"
+    );
     fx.server.stop().await.expect("stop server");
 }
 

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -83,6 +83,10 @@ fn validate_codex_official_authorization(
 pub struct ForwardResult {
     pub response: ProxyResponse,
     pub provider: Provider,
+    /// 本次成功尝试的开始时刻（latency/first_token 归因锚点，
+    /// 见 [`RequestContext::attempt_started_at`]）。故障转移链上它晚于请求
+    /// 进入时刻 —— 两者之差就是前面失败尝试烧掉的时间，不归成功档位。
+    pub attempt_started_at: std::time::Instant,
     pub claude_api_format: Option<String>,
     /// 实际发往上游的模型名（路由接管/模型映射后的真值）。
     ///
@@ -519,6 +523,11 @@ impl RequestForwarder {
 
             attempted_providers += 1;
 
+            // 本次尝试的计时锚点：从「开始向这家发起请求」起算。同一家内部的
+            // 整流器/媒体降级重试不重置它（重试也是这家消费掉的时间），
+            // 换一家（下一轮循环）才换锚点。
+            let attempt_started_at = std::time::Instant::now();
+
             // 更新状态中的当前 Provider 信息（per-attempt 维度的标识）
             //
             // total_requests / last_request_at / active_connections 已由
@@ -583,6 +592,7 @@ impl RequestForwarder {
                     return Ok(ForwardResult {
                         response,
                         provider: provider.clone(),
+                        attempt_started_at,
                         claude_api_format,
                         outbound_model,
                         connection_guard: None,
@@ -676,6 +686,7 @@ impl RequestForwarder {
                                     return Ok(ForwardResult {
                                         response,
                                         provider: provider.clone(),
+                                        attempt_started_at,
                                         claude_api_format,
                                         outbound_model,
                                         connection_guard: None,
@@ -815,6 +826,7 @@ impl RequestForwarder {
                                         return Ok(ForwardResult {
                                             response,
                                             provider: provider.clone(),
+                                            attempt_started_at,
                                             claude_api_format,
                                             outbound_model,
                                             connection_guard: None,
@@ -966,6 +978,7 @@ impl RequestForwarder {
                                     return Ok(ForwardResult {
                                         response,
                                         provider: provider.clone(),
+                                        attempt_started_at,
                                         claude_api_format,
                                         outbound_model,
                                         connection_guard: None,

--- a/src-tauri/src/proxy/handler_context.rs
+++ b/src-tauri/src/proxy/handler_context.rs
@@ -33,8 +33,16 @@ pub struct StreamingTimeoutConfig {
 /// - 日志标签
 /// - Session ID（用于日志关联）
 pub struct RequestContext {
-    /// 请求开始时间
+    /// 请求开始时间（客户端请求进入代理的时刻）
     pub start_time: Instant,
+    /// 最终成功尝试的开始时刻 —— latency/first_token 归因的锚点。
+    ///
+    /// 故障转移链上前面失败尝试的耗时属于「这家坏了」，不该算进接住请求的
+    /// 那家：首字/用时统计以这里为起点。初始等于 [`Self::start_time`]，
+    /// forward 成功后由 handler 回填为实际服务档位那次尝试的起点
+    /// （[`ForwardResult::attempt_started_at`](crate::proxy::forwarder::ForwardResult)）。
+    /// 整链耗时（含全部失败尝试，用户实际等待时长）用 [`Self::request_latency_ms`]。
+    pub attempt_started_at: Instant,
     /// 应用级代理配置（per-app，包含重试次数和超时配置）
     pub app_config: AppProxyConfig,
     /// 本次请求的故障转移行为（请求内换档、重试、超时）是否启用：显式
@@ -172,6 +180,7 @@ impl RequestContext {
 
         Ok(Self {
             start_time,
+            attempt_started_at: start_time,
             app_config,
             failover_active,
             provider,
@@ -264,9 +273,19 @@ impl RequestContext {
         self.providers.clone()
     }
 
-    /// 计算请求延迟（毫秒）
+    /// 归因耗时（毫秒）：从最终服务请求的那次尝试开始计。
+    ///
+    /// 故障转移时前面失败尝试的耗时不计入 —— 那段时间属于坏掉的档位，
+    /// 记到接住请求的档位头上会污染「首字/用时」均值与「响应最快」排序。
     #[inline]
     pub fn latency_ms(&self) -> u64 {
+        self.attempt_started_at.elapsed().as_millis() as u64
+    }
+
+    /// 整链耗时（毫秒）：从客户端请求进入代理开始计，含全部失败尝试。
+    /// 失败请求的错误日志用它 —— 那行要回答的是「用户等了多久」，不是「谁接住了」。
+    #[inline]
+    pub fn request_latency_ms(&self) -> u64 {
         self.start_time.elapsed().as_millis() as u64
     }
 

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -225,6 +225,7 @@ async fn handle_messages_for_app(
 
     let connection_guard = result.connection_guard.take();
     ctx.outbound_model = result.outbound_model.take();
+    ctx.attempt_started_at = result.attempt_started_at;
     ctx.provider = result.provider;
     let api_format = result
         .claude_api_format
@@ -462,7 +463,7 @@ async fn handle_claude_transform(
                 .clone()
                 .unwrap_or_else(|| ctx.request_model.clone());
             let status_code = status.as_u16();
-            let start_time = ctx.start_time;
+            let start_time = ctx.attempt_started_at;
             let session_id = ctx.session_id.clone();
             // 用 ctx 的 app_type：Claude Desktop 网关也走此转换路径，硬编码
             // "claude" 会把 claude-desktop 的行错记到 claude 名下
@@ -811,6 +812,7 @@ pub async fn handle_chat_completions(
 
     let connection_guard = result.connection_guard.take();
     ctx.outbound_model = result.outbound_model.take();
+    ctx.attempt_started_at = result.attempt_started_at;
     ctx.provider = result.provider;
     let response = result.response;
 
@@ -906,6 +908,7 @@ async fn handle_responses_for_app(
 
     let connection_guard = result.connection_guard.take();
     ctx.outbound_model = result.outbound_model.take();
+    ctx.attempt_started_at = result.attempt_started_at;
     ctx.provider = result.provider;
     let response = result.response;
 
@@ -1022,6 +1025,7 @@ pub async fn handle_alpha_search(
 
     let connection_guard = result.connection_guard.take();
     ctx.outbound_model = result.outbound_model.take();
+    ctx.attempt_started_at = result.attempt_started_at;
     ctx.provider = result.provider;
 
     process_response(
@@ -1105,6 +1109,7 @@ async fn handle_responses_compact_for_app(
 
     let connection_guard = result.connection_guard.take();
     ctx.outbound_model = result.outbound_model.take();
+    ctx.attempt_started_at = result.attempt_started_at;
     ctx.provider = result.provider;
     let response = result.response;
 
@@ -1336,7 +1341,7 @@ async fn handle_codex_chat_to_responses_transform(
                 .clone()
                 .unwrap_or_else(|| ctx.request_model.clone());
             let app_type_str = ctx.app_type_str;
-            let start_time = ctx.start_time;
+            let start_time = ctx.attempt_started_at;
             let session_id = ctx.session_id.clone();
 
             Some(SseUsageCollector::new(
@@ -1715,7 +1720,7 @@ fn build_codex_anthropic_sse_response(
             .clone()
             .unwrap_or_else(|| ctx.request_model.clone());
         let app_type_str = ctx.app_type_str;
-        let start_time = ctx.start_time;
+        let start_time = ctx.attempt_started_at;
         let session_id = ctx.session_id.clone();
 
         Some(SseUsageCollector::new(
@@ -2116,6 +2121,7 @@ pub async fn handle_gemini(
 
     let connection_guard = result.connection_guard.take();
     ctx.outbound_model = result.outbound_model.take();
+    ctx.attempt_started_at = result.attempt_started_at;
     ctx.provider = result.provider;
     let response = result.response;
 
@@ -2764,7 +2770,8 @@ fn log_forward_error(
         ctx.request_model.clone(),
         status_code,
         error_message,
-        ctx.latency_ms(),
+        // 错误行报整链耗时（用户等了多久），失败尝试没有「成功尝试」可归因
+        ctx.request_latency_ms(),
         is_streaming,
         Some(ctx.session_id.clone()),
         None,

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -504,7 +504,7 @@ pub(crate) fn create_usage_collector(
     // claude-desktop 的行错记到 claude 名下，导致供应商计价覆盖解析不到。
     let app_type_str = ctx.app_type_str;
     let tag = ctx.tag;
-    let start_time = ctx.start_time;
+    let start_time = ctx.attempt_started_at;
     let stream_parser = parser_config.stream_parser;
     let model_extractor = parser_config.model_extractor;
     let session_id = ctx.session_id.clone();


### PR DESCRIPTION
## Summary / 概述

省心模式故障转移链上，**前面失败尝试的耗时被全部计入接住请求的档位**的首字/用时：
计时锚点是「客户端请求进入代理」的时刻（`RequestContext::start_time`），重试循环从不重置，而 usage 落库只记最终成功的那一行（失败尝试不落库）。

后果：被故障转移「连累」的档位显得慢，肇事的档位没留任何污点；看板首字均值、首字走势折线、「响应最快」策略排序全部被带偏（排序会惩罚接盘档、奖励肇事档，方向正好反了）。

修法（按尝试计时，计时语义的根）：

- `RequestContext` 新增 `attempt_started_at`（成功尝试锚点），`latency_ms()` 改读它 —— 五个成功归因点（各 app 流式/非流式 usage 收集器）一次修齐
- `ForwardResult` 携带锚点，handler 在回填 `provider` 的同一处回填；同一家内部的整流器/媒体降级重试不重置（重试也是这家消费掉的时间），换一家才换锚点
- 失败请求的错误日志改用新方法 `request_latency_ms()`（整链耗时）：那一行回答的是「用户等了多久」，原语义保持不变
- 非流式请求 `first_token_ms` 不落值的既有边界不变（流式探针才测速）

## Related Issue / 关联 Issue

用户实测反馈（无 issue）

## Screenshots / 截图

不涉及 UI。

## Checklist / 检查清单

- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` / `cargo test` 全绿（16 套件）
- [x] 新增 e2e 回归闸 `first_token_ms_excludes_time_spent_on_failed_attempts`（流式 mock + 500ms 才 402 的失败档）：红绿对照实测——修复前成功档首字 **513ms**（含失败档 500ms），修复后 <500ms
- [ ] 前端无改动（typecheck/format 由 CI 兜底）
