### PR TITLE
fix(proxy): 致命错误（401/402/403）故障转移升级为账号级跳过

### DIFF
--- a/src-tauri/src/commands/auto_mode.rs
+++ b/src-tauri/src/commands/auto_mode.rs
@@ -463,7 +463,7 @@ pub(crate) async fn tier_board_impl(state: &AppState, app_type: &str) -> Result<
     let provider_ids: Vec<String> = ranked.iter().map(|p| p.id.clone()).collect();
     let breaker_states = state
         .proxy_service
-        .provider_breaker_states(app_type, &provider_ids)
+        .provider_breaker_states(app_type, &ranked)
         .await;
 
     let balances = fetch_site_balances(app_type, &ranked).await;

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -87,6 +87,28 @@ impl Provider {
             || self.claude_base_url_contains("chatgpt.com/backend-api/codex")
     }
 
+    /// 账号级故障域：同站同账号的托管档共享同一份凭证与余额 —— 一家吃到
+    /// 致命错误（401/402），同账号其他分组也过不去，故障转移该整个账号跳过。
+    ///
+    /// 键 = `website_url`（provision 写入的站点 origin）+ 账号 id
+    /// （[`ProviderMeta::loongport_account_id`]，vendor 档用字符串形态的
+    /// [`ProviderMeta::loongport_vendor_account`]）。`None` = 非托管档
+    /// （用户手工配置）或账号身份缺失：没有账号维度，档位各自独立，
+    /// 致命熔断只作用单档（既有行为）。
+    pub fn failover_account_key(&self) -> Option<String> {
+        let meta = self.meta.as_ref()?;
+        let origin = self.website_url.as_deref()?;
+        let account = match (
+            meta.loongport_account_id,
+            meta.loongport_vendor_account.as_deref(),
+        ) {
+            (Some(id), _) => id.to_string(),
+            (None, Some(vendor)) => vendor.to_string(),
+            (None, None) => return None,
+        };
+        Some(format!("{origin}/{account}"))
+    }
+
     /// Whether the provider form's "auth field" was explicitly set to
     /// ANTHROPIC_API_KEY. The form only persists `meta.apiKeyField` for the
     /// non-default choice, so `None` means the default ANTHROPIC_AUTH_TOKEN.
@@ -1076,6 +1098,69 @@ mod tests {
     };
     use serde_json::json;
     use std::collections::HashMap;
+
+    /// 账号级故障域：同站同账号同键、站点或账号任一不同则不同键；
+    /// vendor 档用字符串账号；手工档/缺账号身份 → None（无账号维度）。
+    #[test]
+    fn failover_account_key_scopes_site_and_account() {
+        let tier = |site: Option<&str>, account: Option<i64>, vendor: Option<&str>| {
+            let mut provider = Provider::with_id(
+                "t".to_string(),
+                "t".to_string(),
+                json!({}),
+                site.map(str::to_string),
+            );
+            provider.meta = Some(ProviderMeta {
+                loongport_account_id: account,
+                loongport_vendor_account: vendor.map(str::to_string),
+                ..ProviderMeta::default()
+            });
+            provider
+        };
+
+        let a1 = tier(Some("https://a.example"), Some(1), None);
+        let a2 = tier(Some("https://a.example"), Some(1), None);
+        assert_eq!(
+            a1.failover_account_key(),
+            a2.failover_account_key(),
+            "同站同账号 = 同一故障域"
+        );
+
+        let other_account = tier(Some("https://a.example"), Some(2), None);
+        assert_ne!(
+            a1.failover_account_key(),
+            other_account.failover_account_key(),
+            "同站不同账号各自独立"
+        );
+
+        let other_site = tier(Some("https://b.example"), Some(1), None);
+        assert_ne!(
+            a1.failover_account_key(),
+            other_site.failover_account_key(),
+            "不同站点各自独立"
+        );
+
+        // vendor 档（DeepSeek 等）：账号 id 是字符串形态
+        let vendor = tier(Some("https://vendor.example"), None, Some("uuid-1"));
+        assert_eq!(
+            vendor.failover_account_key().as_deref(),
+            Some("https://vendor.example/uuid-1")
+        );
+
+        // 手工档（无 meta / 无站点 / 无账号身份）：没有账号维度，档位各自独立
+        let manual = Provider::with_id("m".to_string(), "m".to_string(), json!({}), None);
+        assert_eq!(manual.failover_account_key(), None);
+        assert_eq!(
+            tier(None, Some(1), None).failover_account_key(),
+            None,
+            "缺站点 origin"
+        );
+        assert_eq!(
+            tier(Some("https://a.example"), None, None).failover_account_key(),
+            None,
+            "缺账号身份"
+        );
+    }
 
     #[test]
     fn provider_meta_serializes_pricing_model_source() {

--- a/src-tauri/src/proxy/auto_mode_e2e_tests.rs
+++ b/src-tauri/src/proxy/auto_mode_e2e_tests.rs
@@ -613,6 +613,95 @@ async fn first_token_ms_excludes_time_spent_on_failed_attempts() {
     fx.server.stop().await.expect("stop server");
 }
 
+/// 致命失败（402 余额不足）按账号跳过，不逐组撞墙：同站同账号两档
+/// （a1 最便宜 ×0.5、a2 居中 ×1.0）+ 另一账号一档（b 最贵 ×2.0）。
+/// a1 吃 402 后：本请求内 a2 被跳过（余额是账号级事实，a2 必然同样 402）；
+/// 后续请求 a1/a2 都被账号级熔断排除，流量直达 b。
+#[tokio::test]
+#[serial]
+async fn fatal_402_skips_sibling_tiers_of_the_same_account() {
+    let _home = TempHome::new();
+    let db = Arc::new(Database::memory().unwrap());
+
+    let a1_mock = MockUpstream::spawn("served-by-a1").await;
+    let a2_mock = MockUpstream::spawn("served-by-a2").await;
+    let b_mock = MockUpstream::spawn("served-by-b").await;
+
+    // 托管档形状对齐 provision 建档：website_url=站点 origin + meta 账号身份
+    let account_tier = |mock: &MockUpstream, site: &str, account: i64, group: i64| {
+        let id = crate::relay::provision::provider_id_for(site, Some(account), group);
+        let mut provider = Provider::with_id(
+            id,
+            format!("{site} · {group}"),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": mock.base_url(),
+                    "ANTHROPIC_AUTH_TOKEN": "tok",
+                }
+            }),
+            Some(site.to_string()),
+        );
+        provider.meta = Some(crate::provider::ProviderMeta {
+            loongport_account_id: Some(account),
+            ..Default::default()
+        });
+        provider
+    };
+    let a1 = account_tier(&a1_mock, "https://acc.example", 1, 11);
+    let a2 = account_tier(&a2_mock, "https://acc.example", 1, 22);
+    let b = account_tier(&b_mock, "https://other.example", 2, 33);
+    for provider in [&a1, &a2, &b] {
+        db.save_provider("claude", provider).unwrap();
+    }
+    db.set_tier_rate_multiplier("claude", &a1.id, Some(0.5))
+        .unwrap();
+    db.set_tier_rate_multiplier("claude", &a2.id, Some(1.0))
+        .unwrap();
+    db.set_tier_rate_multiplier("claude", &b.id, Some(2.0))
+        .unwrap();
+
+    let mut config = db.get_proxy_config_for_app("claude").await.unwrap();
+    config.enabled = true;
+    config.auto_failover_enabled = true;
+    config.max_retries = 3;
+    db.update_proxy_config_for_app(config).await.unwrap();
+    auto_strategy::set_enabled(&db, "claude", true).unwrap();
+
+    let verification = Arc::new(
+        crate::relay::model_verification::coordinator::ModelVerificationCoordinator::new(
+            db.clone(),
+        ),
+    );
+    let server = ProxyServer::new(
+        ProxyConfig {
+            listen_port: 0,
+            ..Default::default()
+        },
+        db.clone(),
+        None,
+        verification.passive_ingress(),
+    );
+    let info = server.start().await.expect("start proxy server");
+
+    a1_mock.set_status(402).await;
+
+    // 第一条请求：a1 → 402（致命）→ a2 同账号被跳过 → b 接住
+    let marker = response_text(send_message(info.port, "sess-e2e-acct-0001").await).await;
+    assert_eq!(marker, "served-by-b");
+    assert_eq!(a1_mock.hits(), 1);
+    assert_eq!(a2_mock.hits(), 0, "请求内不得再撞同账号的兄弟档位");
+    assert_eq!(b_mock.hits(), 1);
+
+    // 第二条请求：账号级熔断跨请求排除 a1/a2，流量直达 b
+    let marker = response_text(send_message(info.port, "sess-e2e-acct-0002").await).await;
+    assert_eq!(marker, "served-by-b");
+    assert_eq!(a1_mock.hits(), 1, "肇事档位被自身熔断排除");
+    assert_eq!(a2_mock.hits(), 0, "兄弟档位被账号级熔断排除");
+    assert_eq!(b_mock.hits(), 2);
+
+    server.stop().await.expect("stop server");
+}
+
 /// 4. 被动模型监控：换芯流量（Claude 线路回 OpenAI 形状）→ 异源指纹 Anomaly
 ///    落库 + history(source=passive) + 档位看板点亮；干净档位零报告；
 ///    转发本身不受观察影响（客户端仍拿到 200 与原样响应体）。

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -470,8 +470,21 @@ impl RequestForwarder {
         // 单 Provider 场景下跳过熔断器检查（故障转移关闭时）
         let bypass_circuit_breaker = providers.len() == 1;
 
+        // 致命失败（凭证/余额级）按账号拉黑：同站同账号的其他分组共享同一份
+        // 凭证与余额，接着试只会再吃一次 401/402。跨请求由账号级熔断器接管
+        //（record_fatal_result 同步打开），这里只管本请求内的候选跳跃。
+        let mut banned_accounts: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+
         // 依次尝试每个供应商
         for provider in providers.iter() {
+            // 同账号已被致命失败拉黑：跳过（不占尝试次数，也不动熔断器）
+            if provider
+                .failover_account_key()
+                .is_some_and(|account| banned_accounts.contains(&account))
+            {
+                continue;
+            }
             // 整流器重试标记：每个 provider 独立持有，避免标记跨 provider 短路故障转移
             // —— 首家 provider 整流后被 5xx/timeout 击落时，下家仍能用整流后的请求体走整流流程
             let mut rectifier_retried = false;
@@ -1068,6 +1081,16 @@ impl RequestForwarder {
                                     .field("app", app_type_str)
                                     .field("provider_id", provider.id.clone()),
                             );
+
+                            // 致命失败按账号拉黑：请求内不再尝试同账号的其他分组
+                            if fatal {
+                                if let Some(account) = provider.failover_account_key() {
+                                    log::warn!(
+                                        "[{app_type_str}] 凭证/余额级失败，本请求跳过同账号其余档位: {account}"
+                                    );
+                                    banned_accounts.insert(account);
+                                }
+                            }
 
                             {
                                 let mut status = self.status.write().await;

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -20,6 +20,17 @@ pub(crate) fn provider_supports_failover(app_type: &str, provider: &Provider) ->
         || !crate::proxy::providers::is_codex_official_provider(provider)
 }
 
+/// 账号级熔断键：与档位键（`app_type:provider_id`）同表不同命名空间，
+/// `account:` 段保证不与任何 provider id 撞键。
+///
+/// app 维度与档位熔断一致（跨 app 不联动）：熔断器配置按 app 读取，
+/// 且同站同账号在不同 app 的档位走不同链路，跨 app 连坐会放大误伤。
+fn account_circuit_key(app_type: &str, provider: &Provider) -> Option<String> {
+    provider
+        .failover_account_key()
+        .map(|key| format!("{app_type}:account:{key}"))
+}
+
 /// 供应商路由器
 pub struct ProviderRouter {
     /// 数据库连接
@@ -129,10 +140,7 @@ impl ProviderRouter {
                     }
                     total_providers += 1;
 
-                    let circuit_key = format!("{app_type}:{}", provider.id);
-                    let breaker = self.get_or_create_circuit_breaker(&circuit_key).await;
-
-                    if breaker.is_available().await {
+                    if self.tier_and_account_available(app_type, &provider).await {
                         result.push(provider);
                     } else {
                         circuit_open_count += 1;
@@ -170,6 +178,9 @@ impl ProviderRouter {
     }
 
     /// 按熔断器可用性过滤候选，累计放行结果与熔断计数。
+    ///
+    /// 档位熔断与账号级熔断都可用才放行：致命错误（凭证/余额）按账号升级
+    /// 后，同账号其他分组即使自身熔断器是 Closed 也进不了候选。
     async fn filter_by_circuit_breaker(
         &self,
         app_type: &str,
@@ -178,15 +189,28 @@ impl ProviderRouter {
         circuit_open_count: &mut usize,
     ) {
         for provider in candidates {
-            let circuit_key = format!("{app_type}:{}", provider.id);
-            let breaker = self.get_or_create_circuit_breaker(&circuit_key).await;
-
-            if breaker.is_available().await {
+            if self.tier_and_account_available(app_type, &provider).await {
                 result.push(provider);
             } else {
                 *circuit_open_count += 1;
             }
         }
+    }
+
+    /// 档位与其所属账号的熔断器是否都可用（选路阶段判断，不占探测名额）。
+    async fn tier_and_account_available(&self, app_type: &str, provider: &Provider) -> bool {
+        let circuit_key = format!("{app_type}:{}", provider.id);
+        let breaker = self.get_or_create_circuit_breaker(&circuit_key).await;
+        if !breaker.is_available().await {
+            return false;
+        }
+        if let Some(account_key) = account_circuit_key(app_type, provider) {
+            let account_breaker = self.get_or_create_circuit_breaker(&account_key).await;
+            if !account_breaker.is_available().await {
+                return false;
+            }
+        }
+        true
     }
 
     /// 请求执行前获取熔断器“放行许可”
@@ -224,6 +248,23 @@ impl ProviderRouter {
 
         if success {
             breaker.record_success(used_half_open_permit).await;
+            // 账号级联动（成功解封）：账号熔断只由致命失败打开，也只有成功
+            // 能闭合它 —— 普通失败不碰账号维度。半开探测成功攒够阈值自然回落
+            // Closed，与档位熔断同一套恢复语义。
+            if let Some(provider) = self
+                .db
+                .get_provider_by_id(provider_id, app_type)
+                .ok()
+                .flatten()
+            {
+                if let Some(account_key) = account_circuit_key(app_type, &provider) {
+                    let breakers = self.circuit_breakers.read().await;
+                    // 只记录已存在的账号熔断器：没打开过就不为记账凭空建条目
+                    if let Some(account_breaker) = breakers.get(&account_key) {
+                        account_breaker.record_success(false).await;
+                    }
+                }
+            }
         } else {
             breaker.record_failure(used_half_open_permit).await;
         }
@@ -248,6 +289,10 @@ impl ProviderRouter {
     /// 区别只在熔断器：致命失败一次即 Open 且用长冷却
     /// （[`CircuitBreaker::record_fatal_failure`](crate::proxy::circuit_breaker::CircuitBreaker::record_fatal_failure)）。
     /// 什么时候算「致命」由调用方分类（forwarder 按上游状态码 401/402/403）。
+    ///
+    /// 致命 ⇒ 账号级升级：凭证与余额是账号级事实，同站同账号的其他分组
+    /// 必然同样 401/402 —— 账号熔断打开后，整个账号的档位在选路阶段被
+    /// 排除（[`Self::filter_by_circuit_breaker`]），不再逐组撞墙。
     pub async fn record_fatal_result(
         &self,
         provider_id: &str,
@@ -266,7 +311,20 @@ impl ProviderRouter {
         let breaker = self.get_or_create_circuit_breaker(&circuit_key).await;
         breaker.record_fatal_failure(used_half_open_permit).await;
 
-        // 3. 更新数据库健康状态（与普通失败同一张表）
+        // 3. 账号级熔断同步打开（致命一次即开，长冷却）
+        if let Some(provider) = self
+            .db
+            .get_provider_by_id(provider_id, app_type)
+            .ok()
+            .flatten()
+        {
+            if let Some(account_key) = account_circuit_key(app_type, &provider) {
+                let account_breaker = self.get_or_create_circuit_breaker(&account_key).await;
+                account_breaker.record_fatal_failure(false).await;
+            }
+        }
+
+        // 4. 更新数据库健康状态（与普通失败同一张表）
         self.db
             .update_provider_health_with_threshold(
                 provider_id,
@@ -290,26 +348,57 @@ impl ProviderRouter {
 
     /// 批量读熔断器快照（看板「熔断/自动重试倒计时」用）。Closed（含从未
     /// 记录过结果的）不进 map —— 只上报当前不正常的。
+    ///
+    /// 档位自身的熔断优先；档位自身 Closed 但**账号级熔断**打开时上报账号
+    /// 快照 —— 致命错误按账号升级后，同账号其他分组确实整段不可用，看板
+    /// 必须如实显示，否则「这家好好的为什么不接流量」无从解释。
     pub async fn breaker_states(
         &self,
         app_type: &str,
-        provider_ids: &[String],
+        providers: &[Provider],
     ) -> HashMap<String, crate::proxy::circuit_breaker::BreakerSnapshot> {
         let mut result = HashMap::new();
-        for provider_id in provider_ids {
-            let circuit_key = format!("{app_type}:{provider_id}");
+        for provider in providers {
+            let circuit_key = format!("{app_type}:{}", provider.id);
             let breaker = self.get_or_create_circuit_breaker(&circuit_key).await;
-            if let Some(snapshot) = breaker.snapshot().await {
-                result.insert(provider_id.clone(), snapshot);
+            let mut snapshot = breaker.snapshot().await;
+            if snapshot.is_none() {
+                if let Some(account_key) = account_circuit_key(app_type, provider) {
+                    // 只读既有条目：账号从未熔断过就不为看板凭空建熔断器
+                    let account_breaker = {
+                        let breakers = self.circuit_breakers.read().await;
+                        breakers.get(&account_key).cloned()
+                    };
+                    if let Some(account_breaker) = account_breaker {
+                        snapshot = account_breaker.snapshot().await;
+                    }
+                }
+            }
+            if let Some(snapshot) = snapshot {
+                result.insert(provider.id.clone(), snapshot);
             }
         }
         result
     }
 
     /// 重置指定供应商的熔断器
+    ///
+    /// 账号级连带重置：余额/凭证是账号级事实，用户点「重新启用」（通常已
+    /// 充值/换好凭证）就该放开整个账号 —— 只重置单档会让同账号其他档位仍
+    /// 被账号熔断挡着，看起来像「点了没生效」。
     pub async fn reset_provider_breaker(&self, provider_id: &str, app_type: &str) {
         let circuit_key = format!("{app_type}:{provider_id}");
         self.reset_circuit_breaker(&circuit_key).await;
+        if let Some(provider) = self
+            .db
+            .get_provider_by_id(provider_id, app_type)
+            .ok()
+            .flatten()
+        {
+            if let Some(account_key) = account_circuit_key(app_type, &provider) {
+                self.reset_circuit_breaker(&account_key).await;
+            }
+        }
     }
 
     /// 仅释放 HalfOpen permit，不影响健康统计（neutral 接口）
@@ -502,9 +591,7 @@ mod tests {
             .await
             .unwrap();
 
-        let states = router
-            .breaker_states("claude", &["dead".to_string(), "fine".to_string()])
-            .await;
+        let states = router.breaker_states("claude", &[dead, fine]).await;
         let snapshot = states.get("dead").expect("致命打开的熔断器必须上报");
         assert!(!snapshot.half_open);
         let remaining = snapshot.reopen_in_secs.expect("Open 带倒计时");
@@ -513,6 +600,136 @@ mod tests {
             "长冷却 1800：{remaining}"
         );
         assert!(!states.contains_key("fine"), "正常（Closed）熔断器不上报");
+    }
+
+    /// 托管档（中转站 tier）：`website_url`=站点 origin、meta 带账号身份 ——
+    /// 形状对齐 provision 建档路径（commands/relay.rs 落库字段）。
+    fn managed_tier(site: &str, account: i64, group: i64) -> Provider {
+        let id = crate::relay::provision::provider_id_for(site, Some(account), group);
+        let mut provider = Provider::with_id(
+            id,
+            format!("{site} · group {group}"),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": format!("{site}/v1"),
+                    "ANTHROPIC_AUTH_TOKEN": "tok",
+                }
+            }),
+            Some(site.to_string()),
+        );
+        provider.meta = Some(ProviderMeta {
+            loongport_account_id: Some(account),
+            ..ProviderMeta::default()
+        });
+        provider
+    }
+
+    /// 致命失败（凭证/余额级）按账号升级：同站同账号的其他分组在选路阶段被
+    /// 账号级熔断排除 —— 余额是账号级事实，逐组撞 402 只是浪费用户请求。
+    #[tokio::test]
+    #[serial]
+    async fn fatal_failure_excludes_sibling_tiers_of_the_same_account() {
+        let _home = TempHome::new();
+        let db = Arc::new(Database::memory().unwrap());
+
+        let a1 = managed_tier("https://a.example", 1, 11);
+        let a2 = managed_tier("https://a.example", 1, 22);
+        let b = managed_tier("https://b.example", 2, 33);
+        for provider in [&a1, &a2, &b] {
+            db.save_provider("claude", provider).unwrap();
+        }
+        crate::proxy::auto_strategy::set_enabled(&db, "claude", true).unwrap();
+
+        let router = ProviderRouter::new(db.clone());
+        assert_eq!(
+            router.select_providers("claude").await.unwrap().len(),
+            3,
+            "基线：无熔断时全部档位都在候选"
+        );
+
+        router
+            .record_fatal_result(&a1.id, "claude", false, Some("402".to_string()))
+            .await
+            .unwrap();
+
+        let selected: Vec<String> = router
+            .select_providers("claude")
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|provider| provider.id)
+            .collect();
+        assert!(!selected.contains(&a1.id), "肇事档位被自身熔断排除");
+        assert!(
+            !selected.contains(&a2.id),
+            "同账号兄弟档位被账号级熔断排除（自身熔断器还是 Closed）"
+        );
+        assert!(selected.contains(&b.id), "其他账号不受连坐");
+    }
+
+    /// 「重新启用」连带放开整个账号：用户充值后点重置，同账号其余档位必须
+    /// 一起回来 —— 只重置单档会让账号熔断继续挡着兄弟档位，看起来像没生效。
+    #[tokio::test]
+    #[serial]
+    async fn reset_provider_breaker_releases_the_whole_account() {
+        let _home = TempHome::new();
+        let db = Arc::new(Database::memory().unwrap());
+
+        let a1 = managed_tier("https://a.example", 1, 11);
+        let a2 = managed_tier("https://a.example", 1, 22);
+        for provider in [&a1, &a2] {
+            db.save_provider("claude", provider).unwrap();
+        }
+        crate::proxy::auto_strategy::set_enabled(&db, "claude", true).unwrap();
+
+        let router = ProviderRouter::new(db.clone());
+        router
+            .record_fatal_result(&a1.id, "claude", false, Some("402".to_string()))
+            .await
+            .unwrap();
+        router.reset_provider_breaker(&a1.id, "claude").await;
+
+        assert_eq!(
+            router.select_providers("claude").await.unwrap().len(),
+            2,
+            "重置必须连带放开账号级熔断"
+        );
+    }
+
+    /// 看板如实显示账号级熔断：档位自身 Closed 但账号熔断打开时，兄弟档位
+    /// 上报账号快照（Open + 长冷却），不能显示成「健康」。
+    #[tokio::test]
+    #[serial]
+    async fn breaker_states_surface_account_open_on_sibling_tiers() {
+        let _home = TempHome::new();
+        let db = Arc::new(Database::memory().unwrap());
+
+        let a1 = managed_tier("https://a.example", 1, 11);
+        let a2 = managed_tier("https://a.example", 1, 22);
+        let b = managed_tier("https://b.example", 2, 33);
+        for provider in [&a1, &a2, &b] {
+            db.save_provider("claude", provider).unwrap();
+        }
+
+        let router = ProviderRouter::new(db.clone());
+        router
+            .record_fatal_result(&a1.id, "claude", false, Some("402".to_string()))
+            .await
+            .unwrap();
+
+        let (a1_id, a2_id, b_id) = (a1.id.clone(), a2.id.clone(), b.id.clone());
+        let states = router.breaker_states("claude", &[a1, a2, b]).await;
+        assert!(states.contains_key(&a1_id), "肇事档位：自身熔断 Open");
+        let sibling = states
+            .get(&a2_id)
+            .expect("兄弟档位必须上报账号级熔断，不能显示成健康");
+        assert!(!sibling.half_open);
+        let remaining = sibling.reopen_in_secs.expect("Open 带倒计时");
+        assert!(
+            remaining > 1790 && remaining <= 1800,
+            "账号级致命长冷却 1800：{remaining}"
+        );
+        assert!(!states.contains_key(&b_id), "其他账号不上报");
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -420,11 +420,11 @@ impl ProxyServer {
     pub async fn provider_breaker_states(
         &self,
         app_type: &str,
-        provider_ids: &[String],
+        providers: &[crate::provider::Provider],
     ) -> std::collections::HashMap<String, crate::proxy::circuit_breaker::BreakerSnapshot> {
         self.state
             .provider_router
-            .breaker_states(app_type, provider_ids)
+            .breaker_states(app_type, providers)
             .await
     }
 }

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -4118,11 +4118,11 @@ impl ProxyService {
     pub async fn provider_breaker_states(
         &self,
         app_type: &str,
-        provider_ids: &[String],
+        providers: &[crate::provider::Provider],
     ) -> std::collections::HashMap<String, crate::proxy::circuit_breaker::BreakerSnapshot> {
         let mut result = std::collections::HashMap::new();
         if let Some(server) = self.server.read().await.as_ref() {
-            result = server.provider_breaker_states(app_type, provider_ids).await;
+            result = server.provider_breaker_states(app_type, providers).await;
         }
         result
     }


### PR DESCRIPTION
## Summary / 概述

省心模式故障转移的粒度问题：**凭证/余额级错误（401/402/403）此前只熔断单个档位** —— 但凭证与余额是账号级事实，同站同账号的分组共享同一份：一家 402，兄弟分组必然同样 402。请求内下一候选若是同账号下一分组会接着撞，跨请求也要逐组各撞一次才各自熔断。

> 429/5xx/超时等瞬态错误的现有行为**保持不变**（普通失败计数、只记本档、同站其他分组不受连坐）——那部分粒度本来就对。

修法（致命错误升级为账号+站点级，sub2api 原设计即账号级屏蔽，此处补齐）：

- `Provider::failover_account_key()`：账号故障域 = 站点 origin（provision 写入的 `websiteUrl`）+ 账号 id（`meta.loongportAccountId`，vendor 档为字符串形态）；手工档无账号维度，维持单档语义
- **致命 ⇒ 账号升级收在致命原语里**：`record_fatal_result` 同步打开账号级熔断器（同表 `account:` 命名空间，一次即开 1800s 长冷却）；`record_result` 成功联动解封（半开探测成功攒阈值回落 Closed；普通失败不碰账号维度）—— 升级语义跟着原语走，现有与未来调用方自动获得
- 选路两条路径（自动模式排序过滤 + 故障转移队列）统一双层判断：档位与账号熔断都可用才进候选；转发循环请求内拉黑同账号剩余候选（不占 `max_attempts` 次数、不动熔断器）
- 看板如实显示：档位自身 Closed 但账号熔断打开时，兄弟档位上报账号快照（Open + 长冷却），不会显示成「健康却不接流量」；「重新启用」连带放开整个账号（用户充值后一键恢复）
- 403 body 命中站点侧标记（「余额不足/上游」）的既有降级（当瞬态处理，不熔断）**不变**

## Related Issue / 关联 Issue

用户实测反馈（无 issue）；与 #278 同一批反馈的另两条之一

## Screenshots / 截图

不涉及 UI 布局变化（看板熔断徽章复用既有展示，仅数据源加账号级折叠）。

## Checklist / 检查清单

- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` / `cargo test` 全绿（16 套件）
- [x] 账号键单测 + 路由三条（选路排除兄弟档/重置级联放开整个账号/看板折叠账号快照）+ e2e（402 后请求内不撞兄弟档、跨请求账号级排除、流量直达其他账号）
- [x] 红绿对照：`failover_account_key` 置 None（关掉账号维度）时新测试全部按预期变红
- [ ] 前端无改动
