### PR TITLE
fix(easymode): 看板「当前」徽章跟实际在用档位走，不再静态

### DIFF
--- a/src/components/easymode/EasyBoard.tsx
+++ b/src/components/easymode/EasyBoard.tsx
@@ -24,13 +24,20 @@ import { TierList } from "./TierList";
 export function EasyBoard({ appId }: { appId: string }) {
   const { t } = useTranslation();
   const { data: board, isLoading } = useTierBoard(appId);
-  const { isRunning, startProxyServer } = useProxyStatus();
-  const { data: status } = useAutoModeStatus(appId);
+  const { status, isRunning, startProxyServer } = useProxyStatus();
+  const { data: autoStatus } = useAutoModeStatus(appId);
   const setModel = useSetAutoModeModel();
   const setStrategy = useSetAutoModeStrategy();
   const setMode = useSetEasyModeMode();
   const setOrder = useSetEasyModeManualOrder();
   const resetBreaker = useResetCircuitBreaker();
+
+  // 实际在用档位：后端每次成功转发实时写内存、经代理状态 2s 轮询透出
+  // （自主视图供应商卡的绿边用同一信号）。「当前」徽章跟它走，路由没跑/
+  // 尚无流量时回退看板的持久化 isCurrent。
+  const activeProviderId = status?.active_targets?.find(
+    (target) => target.app_type === appId,
+  )?.provider_id;
 
   // 熔断/降级档位：右上角「重试全部」逐个清健康+熔断（单卡上另有单独按钮）
   const failedTiers = (board?.tiers ?? []).filter(
@@ -165,13 +172,14 @@ export function EasyBoard({ appId }: { appId: string }) {
           tiers={board.tiers}
           manual={manual}
           appType={appId}
+          activeProviderId={activeProviderId}
           onReorder={(orderedIds) =>
             setOrder.mutate({ appType: appId, orderedIds })
           }
         />
       )}
 
-      {!status?.cliInstalled ? (
+      {!autoStatus?.cliInstalled ? (
         <p className="text-xs text-amber-600 dark:text-amber-400">
           {t("autoMode.cliMissingHint", {
             defaultValue: "该 CLI 未安装，接管不会生效",

--- a/src/components/easymode/TierList.tsx
+++ b/src/components/easymode/TierList.tsx
@@ -43,11 +43,14 @@ export function TierList({
   tiers,
   manual,
   appType,
+  activeProviderId,
   onReorder,
 }: {
   tiers: TierBoardTier[];
   manual: boolean;
   appType: string;
+  /** 实际在用档位（代理实时信号）；缺省回退各档的持久化 isCurrent */
+  activeProviderId?: string;
   onReorder: (orderedIds: string[]) => void;
 }) {
   const sensors = useSensors(
@@ -71,7 +74,12 @@ export function TierList({
     return (
       <div className="space-y-2">
         {tiers.map((tier) => (
-          <TierCard key={tier.providerId} tier={tier} appType={appType} />
+          <TierCard
+            key={tier.providerId}
+            tier={tier}
+            appType={appType}
+            activeProviderId={activeProviderId}
+          />
         ))}
       </div>
     );
@@ -90,6 +98,7 @@ export function TierList({
               key={tier.providerId}
               tier={tier}
               appType={appType}
+              activeProviderId={activeProviderId}
             />
           ))}
         </div>
@@ -101,9 +110,11 @@ export function TierList({
 function SortableTierCard({
   tier,
   appType,
+  activeProviderId,
 }: {
   tier: TierBoardTier;
   appType: string;
+  activeProviderId?: string;
 }) {
   const {
     attributes,
@@ -122,6 +133,7 @@ function SortableTierCard({
       <TierCard
         tier={tier}
         appType={appType}
+        activeProviderId={activeProviderId}
         dragHandleProps={{ attributes, listeners }}
       />
     </div>
@@ -136,10 +148,12 @@ function SortableTierCard({
 function TierCard({
   tier,
   appType,
+  activeProviderId,
   dragHandleProps,
 }: {
   tier: TierBoardTier;
   appType: string;
+  activeProviderId?: string;
   dragHandleProps?: {
     attributes?: DraggableAttributes;
     listeners?: SyntheticListenerMap;
@@ -151,6 +165,12 @@ function TierCard({
     tier.isHealthy === false ||
     tier.breakerState != null ||
     (tier.consecutiveFailures ?? 0) > 0;
+  // 「当前」跟实际在用档位走（代理实时信号）；没有实时信号（路由没跑）时
+  // 回退持久化指针 —— 持久化指针本身只随显式切换/故障转移成功移动，盯屏
+  // 看板 30s 才重取，静态观感就来自它
+  const isCurrentTier = activeProviderId
+    ? tier.providerId === activeProviderId
+    : tier.isCurrent;
   return (
     <div className="flex items-center gap-3 rounded-lg border bg-card p-3">
       {dragHandleProps ? (
@@ -172,7 +192,7 @@ function TierCard({
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <span className="truncate text-sm font-medium">{tier.name}</span>
-          {tier.isCurrent ? (
+          {isCurrentTier ? (
             <Badge
               variant="outline"
               className="border-emerald-500/60 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
@@ -180,7 +200,7 @@ function TierCard({
               {t("autoMode.board.current", { defaultValue: "当前" })}
             </Badge>
           ) : null}
-          {tier.isCurrent && tier.affinityRemainingSecs != null ? (
+          {isCurrentTier && tier.affinityRemainingSecs != null ? (
             <Badge
               variant="outline"
               title={t("autoMode.board.affinityTitle", {

--- a/src/lib/query/autoMode.ts
+++ b/src/lib/query/autoMode.ts
@@ -16,6 +16,9 @@ import {
   type ProxyAppId,
 } from "@/config/appConfig";
 import { useProxyStatus } from "@/hooks/useProxyStatus";
+import { useTauriEvent } from "@/hooks/useTauriEvent";
+import { PROVIDER_SWITCHED } from "@/lib/api/events";
+import type { ProviderSwitchEvent } from "@/lib/api/providers";
 
 /**
  * 某应用的省心模式状态（enabled 是按 app 的，strategy 是全局的）
@@ -445,6 +448,15 @@ export function useSetFailoverAll() {
  * 余额链含站点查询，给个短 staleTime 避免频繁切 app 时反复打站点。
  */
 export function useTierBoard(appType: string, enabled = true) {
+  const queryClient = useQueryClient();
+  // 切档事件即时失效看板：否则「当前」徽章、粘性倒计时要等 30s stale
+  // 或窗口聚焦才刷新，盯屏时看起来是静态的。事件名唯源 events.ts（双侧闸守）。
+  useTauriEvent<ProviderSwitchEvent>(PROVIDER_SWITCHED, (payload) => {
+    if (payload?.appType !== appType) return;
+    void queryClient.invalidateQueries({
+      queryKey: ["easyModeTierBoard", appType],
+    });
+  });
   return useQuery({
     queryKey: ["easyModeTierBoard", appType],
     queryFn: () => autoModeApi.getTierBoard(appType),

--- a/tests/components/EasyBoard.test.tsx
+++ b/tests/components/EasyBoard.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import {
   describe,
   expect,
@@ -511,5 +517,51 @@ describe("EasyBoard", () => {
     }));
     setupBoard(boardFixture({ tiers }));
     expect(screen.getAllByTitle("需要复核")).toHaveLength(2);
+  });
+
+  it("「当前」徽章跟实时在用档位走（active_targets），不卡在持久化指针上", () => {
+    // 看板 isCurrent 仍指 tier-b（贵档，持久化指针），但实际流量在 tier-a ——
+    // 徽章必须跟实际在用走，否则省心选路后盯屏看它不动（用户反馈的静态徽章）
+    proxyStatusMock.mockReturnValue({
+      isRunning: true,
+      startProxyServer: vi.fn().mockResolvedValue(undefined),
+      status: {
+        running: true,
+        active_targets: [
+          {
+            app_type: "claude",
+            provider_id: "tier-a",
+            provider_name: "便宜档",
+          },
+        ],
+      },
+    });
+    setupBoard(boardFixture());
+
+    expect(screen.getAllByText("当前")).toHaveLength(1);
+    const cheapRow = screen
+      .getByText("便宜档")
+      .closest("div.rounded-lg") as HTMLElement | null;
+    const expensiveRow = screen
+      .getByText("贵档")
+      .closest("div.rounded-lg") as HTMLElement | null;
+    expect(cheapRow).not.toBeNull();
+    expect(expensiveRow).not.toBeNull();
+    expect(within(cheapRow!).getByText("当前")).toBeDefined();
+    expect(within(expensiveRow!).queryByText("当前")).toBeNull();
+    // 实时当前档没有粘性数据（后端只给指针当前档填 affinity）→ 不硬凑粘性徽章
+    expect(screen.queryByText(/粘性/)).toBeNull();
+  });
+
+  it("无实时信号（路由未跑/尚无流量）时回退持久化 isCurrent", () => {
+    proxyStatusMock.mockReturnValue({
+      isRunning: true,
+      startProxyServer: vi.fn().mockResolvedValue(undefined),
+      status: { running: true, active_targets: [] },
+    });
+    setupBoard(boardFixture());
+    // 回退后与既有行为一致：当前在 tier-b、粘性徽章跟着 tier-b
+    expect(screen.getAllByText("当前")).toHaveLength(1);
+    expect(screen.getByText("粘性 · 12 分钟")).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary / 概述

省心模式看板的「当前」徽章是静态的：它绑的是持久化逻辑指针（settings 的 `current_provider_<app>` 回退 `providers.is_current`），只随显式切换/故障转移成功移动；看板查询又是 30s stale + 窗口聚焦刷新、不订阅切档事件 —— 用户盯着页面时，省心选路实际换了档、徽章不动。

修法（复用现成实时信号，不新增状态源）：

- 徽章（含粘性徽章门控）改绑 `get_proxy_status.active_targets`：后端每次成功转发实时写内存、2s 轮询透出 —— **自主视图供应商卡的「实际在用」绿边用的就是同一份信号**；路由没跑/尚无流量（`active_targets` 空）时回退持久化 `isCurrent`，与原行为一致
- `useTierBoard` 订阅 `PROVIDER_SWITCHED` 事件即时失效看板（事件名唯源 `events.ts`，Rust/前端一致性闸在守）：徽章本体随 2s 轮询动，事件保证切档后粘性/亲和等指针关联数据不滞后

> 与 #278/#279 同一批用户反馈的第三条。事实 owner 是代理内存态，前端只做展示映射（符合「前端只展示后端定义的业务事实」）。

## Related Issue / 关联 Issue

用户实测反馈（无 issue）

## Screenshots / 截图

无布局变化（同一徽章，数据源换绑）。

## Checklist / 检查清单

- [x] `pnpm typecheck` / `pnpm format:check` / `vitest run` 全绿（189 文件 1298 测试）
- [x] 新增两条组件测试：实时信号优先（徽章跟实际在用档、不硬凑粘性）、无实时信号回退持久化行为
- [ ] 后端无改动
