### PR TITLE
feat(crowd): k-匿门槛临时放开为 1/1（冷启动期，恢复条件入档）

### DIFF
--- a/crowd-metrics/README.md
+++ b/crowd-metrics/README.md
@@ -18,8 +18,10 @@
 
 - **只有聚合指标**：站点 host、请求数、错误数、TTFT 直方图、token 计数、微美元花费。
   没有提示词、密钥、账号、时间戳级明细。
-- **k-匿名**：任何发布的聚合 ≥ 3 个独立来源（`MIN_SOURCES`）；来源是客户端**每日轮换**
-  的随机 id，不是持久安装标识。
+- **k-匿名**：任何发布的聚合需 ≥ `MIN_SOURCES` 个独立来源（来源是客户端**每日轮换**
+  的随机 id，不是持久安装标识）。⚠️ **2026-09-06 起门槛临时放开为 1/1**
+  （参与用户还少，3×2 让实测页必然空白；单源数据实质是单个用户的使用画像，
+  属有意识的临时让步）——恢复条件与随改清单见 `src/aggregate.ts` 常量注释。
 - **接收端不记 IP**：限流只存 IP 的 SHA-256（`upload_ip_hour`），保留 2 天。
 - 原始桶保留 30 天后删除；KV 里只有 k-匿名后的快照。
 
@@ -55,7 +57,7 @@ deploy.sh 会：拒绝占位 id → 重放 `schema.sql`（幂等）→ `wrangler
 npx wrangler deploy --name loongport-metrics-dev   # 独立名字，不碰生产
 ./verify.sh https://loongport-metrics-dev.<account-subdomain>.workers.dev
 
-# POST 冒烟（写入的是 staging 的 D1，且单来源永远过不了 k-匿名，不会出现在快照里）：
+# POST 冒烟（写入的是 staging 的 D1；门槛临时 1/1 期间单来源也会进快照，恢复 3/2 后不会）：
 curl -X POST https://…/v1/ingest -H 'content-type: application/json' -d '{
   "version": 1,
   "sourceId": "00112233445566778899aabbccddeeff",

--- a/crowd-metrics/src/aggregate.test.ts
+++ b/crowd-metrics/src/aggregate.test.ts
@@ -53,14 +53,20 @@ describe("k-匿名与网络多样性门槛（L1）", () => {
     expect(snap.sites).toEqual({});
   });
 
-  it("来源够但都在同一个 ASN：不发布（一个出口刷不动）", () => {
+  it("来源够但都在同一个 ASN：不发布（一个出口刷不动）——临时门槛 1/1 下改判发布", () => {
+    // 2026-09-06 起门槛临时放开为 1/1（见 aggregate.ts 常量注释），单 ASN
+    // 也发布；恢复 3/2 时此断言自动回到「不发布」，不需要改这条测试。
     const rows = Array.from({ length: 4 }, (_, i) => ({
       ...makeRaw(),
       source: `src-${i}`,
       asn: 4134,
     }));
     const snap = buildSnapshot(rows, NOW);
-    expect(snap.sites).toEqual({});
+    if (MIN_ASN <= 1) {
+      expect(snap.sites["example.com"]).toBeDefined();
+    } else {
+      expect(snap.sites).toEqual({});
+    }
   });
 
   it("横跨 ≥MIN_ASN 个 ASN 时发布，sources 如实计数", () => {
@@ -76,8 +82,10 @@ describe("k-匿名与网络多样性门槛（L1）", () => {
   });
 
   it("两个窗口都没过门槛时站点不出现；仅 w7 过门槛时 w24 为 null", () => {
+    // 用常量相对构造（门槛临时放开/恢复都不用改这里）：
+    // w24 窗口内 MIN_SOURCES - 1 个源 + 一个 30h 前的旧源（只进 w7）。
     const rows = [
-      ...sources(2),
+      ...sources(MIN_SOURCES - 1),
       makeRaw({
         source: "old",
         asn: 4837,
@@ -88,7 +96,7 @@ describe("k-匿名与网络多样性门槛（L1）", () => {
     const site = snap.sites["example.com"];
     expect(site).toBeDefined();
     expect(site.w24).toBeNull();
-    expect(site.w7?.sources).toBe(3);
+    expect(site.w7?.sources).toBe(MIN_SOURCES);
   });
 });
 
@@ -206,9 +214,10 @@ describe("分布直方图与口径", () => {
   });
 
   it("时段槽按 UTC 小时落位，槽内来源不过门槛则置零", () => {
+    // 常量相对构造：槽 3 过门槛、槽 5 差一个（门槛临时放开/恢复都不用改）
     const rows = [
-      ...sources(3, { hour: "2026-08-26T03Z" }),
-      ...sources(2, { hour: "2026-08-26T05Z" }),
+      ...sources(MIN_SOURCES, { hour: "2026-08-26T03Z" }),
+      ...sources(MIN_SOURCES - 1, { hour: "2026-08-26T05Z" }),
     ];
     const snap = buildSnapshot(rows, NOW);
     const hours = snap.sites["example.com"]?.hours;
@@ -238,8 +247,8 @@ describe("分布直方图与口径", () => {
     expect(TTFT_BIN_EDGES_MS[0]).toBe(200);
   });
 
-  it("门槛常量钉住：MIN_SOURCES=3、MIN_ASN=2（调阈值要连着测试改）", () => {
-    expect(MIN_SOURCES).toBe(3);
-    expect(MIN_ASN).toBe(2);
+  it("门槛常量钉住：MIN_SOURCES=1、MIN_ASN=1（2026-09-06 临时放开，恢复 3/2 时连着常量注释与 README 一起改）", () => {
+    expect(MIN_SOURCES).toBe(1);
+    expect(MIN_ASN).toBe(1);
   });
 });

--- a/crowd-metrics/src/aggregate.ts
+++ b/crowd-metrics/src/aggregate.ts
@@ -25,10 +25,22 @@ import { binMidpoint, quantileFromBins, TTFT_BIN_COUNT } from "./bins";
 import { hourToEpochSec } from "./validate";
 import type { HourSlot, SiteStats, Snapshot, WindowStats } from "./types";
 
-/** k-匿名门槛：少于这么多受信独立来源的聚合不发布。 */
-export const MIN_SOURCES = 3;
-/** 网络多样性门槛：受信来源横跨的最少 ASN 数。 */
-export const MIN_ASN = 2;
+/**
+ * k-匿名门槛：少于这么多受信独立来源的聚合不发布。
+ * 网络多样性门槛：受信来源横跨的最少 ASN 数。
+ *
+ * ⚠️ **2026-09-06 起临时放开为 1/1**（用户拍板）：参与上传的用户还很少，
+ * 3 源 × 2 ASN 让实测页几乎必然空白。这是一次有意识的隐私让步——单源
+ * 站点的公开数据实质上就是该用户一人的使用画像。cohort（需 ≥2 源）与
+ * 极值裁剪（需 ≥5 源）在单源下天然不触发，防线代码保持原样。
+ *
+ * **恢复条件**：快照里稳定出现 ≥3 独立源的站点（或日均独立源 ≥5）时
+ * 改回 `MIN_SOURCES = 3 / MIN_ASN = 2`，并同步恢复：
+ * aggregate.test.ts 的钉值测试与「同一 ASN」测试、README 的门槛描述、
+ * 主仓 crowd/mod.rs 口径节的 k-匿描述。
+ */
+export const MIN_SOURCES = 1;
+export const MIN_ASN = 1;
 /** 触发极值源裁剪的最少来源数（≥5 才裁：保 3 个来源也过 k-匿名）。 */
 export const TRIM_THRESHOLD = 5;
 /** cohort 剔除的联合快慢因子（快于同行 3 倍）。 */


### PR DESCRIPTION
## Summary / 概述

实测页（loongport.dev/status 与 app 内广场）在参与上传的用户变多之前几乎必然空白：发布门槛是 **3 独立源 × 2 ASN**，冷启动阶段凑不齐，页面永远没有站点数据。

用户拍板：**临时放开为 1/1**（`MIN_SOURCES=1 / MIN_ASN=1`）。这是一次有意识的隐私让步——单源站点的公开数据实质上是该用户一人的使用画像；等参与的人多了再恢复。

- 恢复条件与随改清单写在 `aggregate.ts` 常量注释（快照稳定出现 ≥3 独立源的站点时改回 3/2）：钉值测试、同 ASN 测试断言、README 门槛描述、主仓 `crowd/mod.rs` 口径节
- cohort 剔除（需 ≥2 源）与极值裁剪（需 ≥5 源）在单源下天然不触发，防线代码原样保留
- 三处测试改为**相对常量**构造（`MIN_SOURCES - 1` 之类），恢复门槛时测试自动继续成立；钉值测试与同 ASN 测试显式标注「临时放开」，恢复时按注释一起改回
- 合并后需部署 Worker 生效（`deploy.sh`，另行执行）

## Related Issue / 关联 Issue

用户请求（无 issue）：短期放开样本不足不展示的限制，人多了再补回来

## Screenshots / 截图

不涉及 UI 结构。

## Checklist / 检查清单

- [x] `pnpm check`（crowd-metrics：typecheck + vitest 59 测试）全绿
- [x] 恢复路径有钉：常量注释 + 钉值测试 + 记忆档
- [ ] Rust / 前端无改动
