### PR TITLE
perf(easymode): 看板余额改后端 SWR，打开不再被最慢站点的余额链钉死

### DIFF
--- a/src-tauri/src/commands/auto_mode.rs
+++ b/src-tauri/src/commands/auto_mode.rs
@@ -428,13 +428,19 @@ pub struct TierBoardModelOption {
 #[tauri::command]
 pub async fn easy_mode_tier_board(
     state: tauri::State<'_, AppState>,
+    app_handle: tauri::AppHandle,
     app_type: String,
 ) -> Result<TierBoard, String> {
-    tier_board_impl(&state, &app_type).await
+    tier_board_impl(&state, &app_type, Some(app_handle)).await
 }
 
-/// 看板核心（真实 smoke 直接调它，不走 tauri State）。
-pub(crate) async fn tier_board_impl(state: &AppState, app_type: &str) -> Result<TierBoard, String> {
+/// 看板核心（真实 smoke 直接调它，不走 tauri State）。`app_handle` 只用于
+/// 余额后台刷新完成后发补值事件，headless 传 `None`。
+pub(crate) async fn tier_board_impl(
+    state: &AppState,
+    app_type: &str,
+    app_handle: Option<tauri::AppHandle>,
+) -> Result<TierBoard, String> {
     require_auto_mode_app(app_type)?;
     let db = &state.db;
     let providers = db.get_all_providers(app_type).map_err(|e| e.to_string())?;
@@ -466,7 +472,25 @@ pub(crate) async fn tier_board_impl(state: &AppState, app_type: &str) -> Result<
         .provider_breaker_states(app_type, &ranked)
         .await;
 
-    let balances = fetch_site_balances(app_type, &ranked).await;
+    // 余额走缓存（SWR）：看板保持纯本地毫秒级返回，stale 站点由后台单飞
+    // 刷新（sk 直查 + 预算超时）补值，完成后发事件让前端重取。此前这里是
+    // 同步网络扇出 —— 20-30 家里一家超时型挂掉，整板就等它 30-90s，且冷
+    // 启动/窗口聚焦每次重演（用户反馈「每次打开软件省心模式卡好久」）。
+    let (tier_origins, site_keys) = tier_site_keys(app_type, &ranked);
+    let cached = crate::relay::balance::cached_site_balances(db);
+    let balances: std::collections::HashMap<String, Option<f64>> = tier_origins
+        .iter()
+        .map(|(tier_id, origin)| {
+            (
+                tier_id.clone(),
+                cached
+                    .get(origin)
+                    .map(|(balance, _)| *balance)
+                    .unwrap_or(None),
+            )
+        })
+        .collect();
+    crate::relay::balance::spawn_stale_refresh(state.db.clone(), app_handle, site_keys);
 
     // 健康快照（缺行时 DAO 合成默认健康行，见 get_provider_health 的契约）
     let mut health: std::collections::HashMap<String, crate::proxy::types::ProviderHealth> =
@@ -511,7 +535,7 @@ pub(crate) async fn tier_board_impl(state: &AppState, app_type: &str) -> Result<
             ),
             rate_multiplier: multipliers.get(&p.id).copied(),
             avg_first_token_ms: ttft.get(&p.id).copied(),
-            balance_usd: balances.get(&p.id).copied(),
+            balance_usd: balances.get(&p.id).copied().flatten(),
             verification_verdict: verification_verdict(&p.id),
             is_healthy: health.get(&p.id).map(|h| h.is_healthy),
             consecutive_failures: health.get(&p.id).map(|h| h.consecutive_failures),
@@ -590,29 +614,29 @@ pub(crate) async fn tier_board_impl(state: &AppState, app_type: &str) -> Result<
     })
 }
 
-/// 站点钱包余额：按「站点 origin」去重，每个 origin 用第一把 sk 查一次，回填到
-/// 该站的全部档位上。两路按序试：先 sub2api 的 `GET /v1/usage`（sub2api 站短路，
-/// 不多花请求）；问不出（典型 newapi：该端点 404）再回落 one-api 系 billing 双端
-/// 点（见 [`crate::relay::api::billing_balance_with_api_key`] 的口径与限制）。
-/// 两路都拿不到 → 该站各档 `None`。只对 https 端点发起（http/本地/无 sk 自然
-/// 跳过，单元测试零网络）。
-async fn fetch_site_balances(
+/// 档位 → 站点余额查询材料的解析（纯本地，无网络）：
+/// - `tier_origins`：档位 id → 站点 origin（https 端点才参与，http/本地/无 sk
+///   自然跳过 —— 单元测试零网络）；
+/// - `site_keys`：origin → 该站第一把 sk（同站多档共用一份站点余额）。
+///
+/// 网络查询本身在 [`crate::relay::balance::spawn_stale_refresh`]（后台 SWR）。
+fn tier_site_keys(
     app_type: &str,
     tiers: &[crate::provider::Provider],
-) -> std::collections::HashMap<String, f64> {
+) -> (
+    std::collections::HashMap<String, String>,
+    std::collections::HashMap<String, String>,
+) {
     use crate::app_config::AppType;
+    let mut tier_origins = std::collections::HashMap::new();
+    let mut site_keys = std::collections::HashMap::new();
     let app = match AppType::from_str(app_type) {
         Ok(app) => app,
-        Err(_) => return std::collections::HashMap::new(),
+        Err(_) => return (tier_origins, site_keys),
     };
     let Some(adapter) = crate::proxy::providers::get_adapter(&app) else {
-        return std::collections::HashMap::new();
+        return (tier_origins, site_keys);
     };
-
-    let mut tier_origin: std::collections::HashMap<String, String> =
-        std::collections::HashMap::new();
-    let mut origin_key: std::collections::HashMap<String, String> =
-        std::collections::HashMap::new();
     for tier in tiers {
         let (base, auth) = match (adapter.extract_base_url(tier), adapter.extract_auth(tier)) {
             (Ok(base), Some(auth)) => (base, auth),
@@ -624,42 +648,10 @@ async fn fetch_site_balances(
         if !origin.starts_with("https://") {
             continue;
         }
-        tier_origin.insert(tier.id.clone(), origin.clone());
-        origin_key.entry(origin).or_insert(auth.api_key);
+        tier_origins.insert(tier.id.clone(), origin.clone());
+        site_keys.entry(origin).or_insert(auth.api_key);
     }
-
-    let mut balances = std::collections::HashMap::new();
-    let queries: Vec<_> = origin_key
-        .into_iter()
-        .map(|(origin, key)| async move {
-            let sub2api_wallet = crate::relay::api::usage_with_api_key(&origin, &key)
-                .await
-                .ok()
-                .and_then(|usage| {
-                    usage
-                        .data
-                        .and_then(|items| items.first().and_then(|item| item.remaining))
-                });
-            let balance = match sub2api_wallet {
-                Some(balance) => Some(balance),
-                None => crate::relay::api::billing_balance_with_api_key(&origin, &key)
-                    .await
-                    .ok()
-                    .flatten(),
-            };
-            (origin, balance)
-        })
-        .collect();
-    for (origin, balance) in futures::future::join_all(queries).await {
-        if let Some(balance) = balance {
-            for (tier_id, tier_origin) in &tier_origin {
-                if tier_origin == &origin {
-                    balances.insert(tier_id.clone(), balance);
-                }
-            }
-        }
-    }
-    balances
+    (tier_origins, site_keys)
 }
 
 /// 模型单价（每百万 token 输入+输出之和，美元）；价表未收录 → `None`。
@@ -701,6 +693,49 @@ mod tests {
         assert!(require_auto_mode_app("pi").is_err());
     }
 
+    /// 看板余额走缓存（SWR）：种子缓存原样上板；缓存 TTL 内不触发任何刷新
+    /// （零网络、看板命令毫秒级返回）。
+    #[tokio::test]
+    #[serial]
+    async fn tier_board_reads_balances_from_cache_without_network() {
+        let _home = test_home();
+        let db = Arc::new(Database::memory().unwrap());
+        let state = AppState::new(db.clone());
+
+        let id = crate::relay::provision::provider_id_for("https://cache.example", Some(1), 1);
+        let tier = crate::provider::Provider::with_id(
+            id.clone(),
+            "缓存档".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "https://cache.example",
+                    "ANTHROPIC_AUTH_TOKEN": "sk-test-not-a-real-key",
+                }
+            }),
+            None,
+        );
+        db.save_provider("claude", &tier).unwrap();
+
+        // 无缓存：余额 None（显示 —）
+        let board = tier_board_impl(&state, "claude", None).await.unwrap();
+        assert_eq!(board.tiers[0].balance_usd, None, "缓存未命中 → —");
+
+        // 种子缓存（TTL 内）→ 上板；后台刷新因缓存新鲜而不触发（本测试零网络）
+        let now = chrono::Utc::now().timestamp();
+        crate::relay::balance::upsert_site_balance(
+            &db,
+            "https://cache.example",
+            (Some(12.34), now),
+        )
+        .unwrap();
+        let board = tier_board_impl(&state, "claude", None).await.unwrap();
+        assert_eq!(
+            board.tiers[0].balance_usd,
+            Some(12.34),
+            "缓存值必须原样上板"
+        );
+    }
+
     /// 看板聚合：顺序=选路序、倍率/单价/耗时/命中齐全；手动模式反映手动序。
     /// 余额链对 http 端点零网络（真实站点路径由 ignored 的真实 smoke 覆盖）。
     #[tokio::test]
@@ -732,7 +767,7 @@ mod tests {
             .unwrap();
         db.set_current_provider("claude", &expensive).unwrap();
 
-        let board = tier_board_impl(&state, "claude").await.unwrap();
+        let board = tier_board_impl(&state, "claude", None).await.unwrap();
         assert_eq!(board.mode, "auto");
         assert_eq!(board.strategy, "cheapest");
         assert_eq!(board.tiers.len(), 2);
@@ -772,7 +807,7 @@ mod tests {
             &verification_report(&expensive, "m-x", Verdict::Trusted),
         )
         .unwrap();
-        let board = tier_board_impl(&state, "claude").await.unwrap();
+        let board = tier_board_impl(&state, "claude", None).await.unwrap();
         let by_id = |id: &str| board.tiers.iter().find(|t| t.provider_id == id).unwrap();
         assert_eq!(
             by_id(&cheap).verification_verdict.as_deref(),
@@ -799,7 +834,7 @@ mod tests {
             &[expensive.clone(), cheap.clone()],
         )
         .unwrap();
-        let board = tier_board_impl(&state, "claude").await.unwrap();
+        let board = tier_board_impl(&state, "claude", None).await.unwrap();
         assert_eq!(board.mode, "manual");
         assert_eq!(board.tiers[0].provider_id, expensive, "手动序优先");
     }
@@ -835,7 +870,7 @@ mod tests {
         // 当前档位（贵）30 分钟内有流量 → 选路会亲和置顶；看板必须保持纯价格序
         seed_board_activity(&db, "claude", &expensive);
 
-        let board = tier_board_impl(&state, "claude").await.unwrap();
+        let board = tier_board_impl(&state, "claude", None).await.unwrap();
         assert_eq!(
             board.tiers[0].provider_id, cheap,
             "看板第一张是最便宜的，不被亲和置顶顶走"
@@ -877,7 +912,7 @@ mod tests {
         .await
         .unwrap();
 
-        let board = tier_board_impl(&state, "claude").await.unwrap();
+        let board = tier_board_impl(&state, "claude", None).await.unwrap();
         let by_id = |id: &str| board.tiers.iter().find(|t| t.provider_id == id).unwrap();
         assert_eq!(by_id(&dead).is_healthy, Some(false));
         assert_eq!(by_id(&dead).consecutive_failures, Some(1));
@@ -948,7 +983,7 @@ mod tests {
             -60,
         );
 
-        let board = tier_board_impl(&state, "claude").await.unwrap();
+        let board = tier_board_impl(&state, "claude", None).await.unwrap();
         let by_id = |id: &str| board.tiers.iter().find(|t| t.provider_id == id).unwrap();
         let remaining = by_id(&current)
             .affinity_remaining_secs
@@ -1057,7 +1092,7 @@ mod tests {
         );
         // cold 档没有任何行
 
-        let board = tier_board_impl(&state, "claude").await.unwrap();
+        let board = tier_board_impl(&state, "claude", None).await.unwrap();
         let by_id = |id: &str| board.tiers.iter().find(|t| t.provider_id == id).unwrap();
         let busy_tier = by_id(&busy);
         assert_eq!(busy_tier.today_cost_usd, Some(0.75), "昨日的 $9 不计入");
@@ -1108,7 +1143,7 @@ mod tests {
             .unwrap();
         }
 
-        let board = tier_board_impl(&state, "codex").await.unwrap();
+        let board = tier_board_impl(&state, "codex", None).await.unwrap();
         let by_model = |model: &str| {
             board
                 .model_options
@@ -1206,7 +1241,7 @@ mod tests {
             -8 * 3600,
         );
 
-        let board = tier_board_impl(&state, "claude").await.unwrap();
+        let board = tier_board_impl(&state, "claude", None).await.unwrap();
         let by_id = |id: &str| board.tiers.iter().find(|t| t.provider_id == id).unwrap();
         let activity = by_id(&busy)
             .recent_activity

--- a/src-tauri/src/database/loongport_schema.rs
+++ b/src-tauri/src/database/loongport_schema.rs
@@ -48,7 +48,7 @@ use crate::error::AppError;
 /// LoongPort 自己的 schema 版本。加迁移时 +1。
 ///
 /// **与 `SCHEMA_VERSION`（上游那个）无关**，两者各自独立计数。
-pub(crate) const LOONGPORT_SCHEMA_VERSION: i32 = 18;
+pub(crate) const LOONGPORT_SCHEMA_VERSION: i32 = 19;
 
 /// 存版本号的表。**只有一行**（`id = 1`）。
 ///
@@ -286,6 +286,11 @@ pub(crate) fn apply(conn: &Connection) -> Result<(), AppError> {
                     })?;
                 }
                 set_version(conn, 18)?;
+            }
+            18 => {
+                log::info!("LoongPort 数据迁移 v18 → v19（站点余额缓存表）");
+                crate::relay::balance::create_site_balance_cache_table(conn)?;
+                set_version(conn, 19)?;
             }
             other => {
                 return Err(AppError::Database(format!(
@@ -973,6 +978,32 @@ mod tests {
             )
             .unwrap();
         assert_eq!(not_null, 0);
+    }
+
+    /// ⭐ v18→v19 建站点余额缓存表（看板 SWR）：停在 v18 的老库升级后必须有表且可写。
+    #[test]
+    fn v18_to_v19_creates_the_site_balance_cache_table() {
+        let conn = mem();
+        ensure_version_table(&conn).expect("建版本表");
+        set_version(&conn, 18).expect("设为 v18");
+        assert!(
+            !Database::table_exists(&conn, "site_balance_cache").expect("查表"),
+            "前提：升级前本表不存在"
+        );
+
+        apply(&conn).expect("迁移到 v19");
+
+        assert!(
+            Database::table_exists(&conn, "site_balance_cache").expect("查表"),
+            "v18 → v19 必须建出站点余额缓存表"
+        );
+        conn.execute(
+            "INSERT INTO site_balance_cache (site_origin, balance_usd, fetched_at)
+             VALUES ('https://a.example', 1.5, 0)",
+            [],
+        )
+        .expect("迁移后必须可写");
+        assert_eq!(current_version(&conn).unwrap(), LOONGPORT_SCHEMA_VERSION);
     }
 
     /// ⭐ v13→v14 建中转站余额快照表：停在 v13 的老库升级后必须有表且可写。

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -48,6 +48,7 @@ impl Database {
 
         crate::relay::model_verification::store::create_results_table(conn)?;
         crate::relay::model_verification::history::create_table(conn)?;
+        crate::relay::balance::create_site_balance_cache_table(conn)?;
 
         // 2. Provider Endpoints 表
         conn.execute(

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -61,6 +61,10 @@ pub const ONBOARDING_REGISTER_COMPLETED: &str = "onboarding-register-completed";
 /// payload `{ promoCode, amountUsd }`。
 pub const ONBOARDING_STAR_REWARD_OFFER: &str = "onboarding-star-reward-offer";
 
+/// 看板站点余额后台刷新完成（`useTierBoard` 监听，失效看板查询补上新值）。
+/// 站点余额跨 app 共享，不带 payload —— 监听方把所有 app 的看板一起失效。
+pub const SITE_BALANCES_UPDATED: &str = "site-balances-updated";
+
 /// 广播「当前供应商变了」。
 ///
 /// ## 为什么必须发（2026-08-04 修的 bug）
@@ -108,6 +112,15 @@ pub fn emit_provider_switched(
         // 发不出去只是界面不刷新（用户重开面板就好），不该让切换本身失败 ——
         // 配置已经写进去了，报错会让用户以为没切成功而再切一次。
         log::warn!("发射 {PROVIDER_SWITCHED} 事件失败: {e}");
+    }
+}
+
+/// 看板站点余额后台刷新完成。余额在后台单飞刷新（`relay::balance::spawn_stale_refresh`），
+/// 到货后靠这个事件让看板补值 —— 没有它，新余额要等下一次聚焦/30s stale 才出现。
+pub fn emit_site_balances_updated(app_handle: &tauri::AppHandle) {
+    if let Err(e) = app_handle.emit(SITE_BALANCES_UPDATED, ()) {
+        // 发不出去只是余额晚一点显示（下次看板重取自然带上），不值得报错。
+        log::warn!("发射 {SITE_BALANCES_UPDATED} 事件失败: {e}");
     }
 }
 
@@ -159,6 +172,7 @@ mod consistency_tests {
                 "ONBOARDING_STAR_REWARD_OFFER",
                 super::ONBOARDING_STAR_REWARD_OFFER,
             ),
+            ("SITE_BALANCES_UPDATED", super::SITE_BALANCES_UPDATED),
         ];
 
         for (ts_name, rust_value) in pairs {

--- a/src-tauri/src/proxy/auto_mode_e2e_tests.rs
+++ b/src-tauri/src/proxy/auto_mode_e2e_tests.rs
@@ -759,7 +759,7 @@ async fn passive_anomaly_lands_and_surfaces() {
 
     // 档位看板点亮异常
     let state = crate::store::AppState::new(fx.db.clone());
-    let board = crate::commands::auto_mode::tier_board_impl(&state, "claude")
+    let board = crate::commands::auto_mode::tier_board_impl(&state, "claude", None)
         .await
         .unwrap();
     let tier = board

--- a/src-tauri/src/proxy/real_upstream_smoke_tests.rs
+++ b/src-tauri/src/proxy/real_upstream_smoke_tests.rs
@@ -229,7 +229,7 @@ async fn real_tier_board_snapshot() {
     let _ = rustls::crypto::ring::default_provider().install_default();
     let (_home, db) = smoke_db();
     let state = crate::store::AppState::new(db);
-    let board = crate::tier_board_impl(&state, "claude")
+    let board = crate::tier_board_impl(&state, "claude", None)
         .await
         .expect("tier board");
     println!(
@@ -265,7 +265,7 @@ async fn real_manual_order_routes_to_user_first_pick() {
     // 与自动策略序不同（否则证明力为零）。断言探针选「必有 HTTP 交换」的档位
     // ——网络层失败（连接拒绝/超时）不写 proxy_request_logs，只有 HTTP 交换
     // （2xx/4xx/5xx）留痕；newapi/sub2api 站点总会回 HTTP。
-    let board = crate::tier_board_impl(&state, "claude")
+    let board = crate::tier_board_impl(&state, "claude", None)
         .await
         .expect("tier board");
     assert!(board.tiers.len() >= 2, "至少两档才能构造证明性手动序");

--- a/src-tauri/src/relay/balance.rs
+++ b/src-tauri/src/relay/balance.rs
@@ -41,6 +41,7 @@
 
 use futures::future::join_all;
 
+use crate::error::AppError;
 use crate::provider::{UsageData, UsageResult};
 use crate::relay::{api, backend, creds};
 
@@ -280,9 +281,299 @@ fn wallet_usage(balance: f64) -> UsageResult {
     }
 }
 
+// ============================================================================
+// 站点余额缓存（省心看板 SWR）
+// ============================================================================
+
+/// 看板余额的缓存表：`origin → (余额, 拉取时刻)`，每站一行。
+///
+/// 由 `create_tables_on_conn`（全新库）与 LoongPort 迁移 v18 → v19（老库）
+/// 共同调用，两边建的必须是同一形态 —— 见 `database/loongport_schema.rs`
+/// 的头注释。
+pub fn create_site_balance_cache_table(conn: &rusqlite::Connection) -> Result<(), AppError> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS site_balance_cache (
+            site_origin TEXT PRIMARY KEY,
+            balance_usd REAL,
+            fetched_at INTEGER NOT NULL
+        )",
+        [],
+    )
+    .map_err(|e| AppError::Database(format!("创建 site_balance_cache 表失败: {e}")))?;
+    Ok(())
+}
+
+/// 缓存 TTL（秒）：超过视为 stale，看板读到时踢一次后台刷新。
+pub const SITE_BALANCE_TTL_SECS: i64 = 600;
+
+/// 单站余额链预算。usage → billing 双端点各自 30s 总超时且串行，不设预算时
+/// 一家黑洞站最坏拖 90s —— 刷新虽已在后台，超预算的站仍会长期占着单飞槽位。
+const SITE_BALANCE_FETCH_BUDGET_SECS: u64 = 15;
+
+/// 一行缓存：`balance` 为 `None` = 负缓存（最近查过、这家没有可用值）——
+/// 没有负缓存的话，查不出余额的站每次打开看板都会重查一遍。
+pub type SiteBalanceEntry = (Option<f64>, i64);
+
+/// 读全表（行数 = 站点数，个位到几十）。
+pub fn cached_site_balances(
+    db: &crate::database::Database,
+) -> std::collections::HashMap<String, SiteBalanceEntry> {
+    // 非 Result 返回值的锁惯例：毒锁取内值（与 commands::auto_mode 的直查一致），
+    // 读缓存失败按「无缓存」处理 —— 看板照常返回，stale 判定自然触发刷新。
+    let conn = db
+        .conn
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut stmt =
+        match conn.prepare("SELECT site_origin, balance_usd, fetched_at FROM site_balance_cache") {
+            Ok(stmt) => stmt,
+            Err(e) => {
+                log::warn!("读 site_balance_cache 失败（按无缓存处理）: {e}");
+                return std::collections::HashMap::new();
+            }
+        };
+    let rows = stmt.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            (row.get::<_, Option<f64>>(1)?, row.get::<_, i64>(2)?),
+        ))
+    });
+    match rows {
+        Ok(rows) => rows.filter_map(Result::ok).collect(),
+        Err(e) => {
+            log::warn!("遍历 site_balance_cache 失败（按无缓存处理）: {e}");
+            std::collections::HashMap::new()
+        }
+    }
+}
+
+/// 幂等写一行（含负缓存）。
+pub fn upsert_site_balance(
+    db: &crate::database::Database,
+    origin: &str,
+    entry: SiteBalanceEntry,
+) -> Result<(), AppError> {
+    let conn = crate::database::lock_conn!(db.conn);
+    conn.execute(
+        "INSERT INTO site_balance_cache (site_origin, balance_usd, fetched_at)
+         VALUES (?1, ?2, ?3)
+         ON CONFLICT(site_origin) DO UPDATE SET
+            balance_usd = excluded.balance_usd,
+            fetched_at = excluded.fetched_at",
+        rusqlite::params![origin, entry.0, entry.1],
+    )
+    .map_err(|e| AppError::Database(format!("写 site_balance_cache 失败: {e}")))?;
+    Ok(())
+}
+
+/// 哪些站需要刷新：没进过缓存的 + `fetched_at` 超 TTL 的（纯函数）。
+fn stale_balance_sites(
+    wanted: &std::collections::HashMap<String, String>,
+    cached: &std::collections::HashMap<String, SiteBalanceEntry>,
+    now: i64,
+) -> Vec<(String, String)> {
+    wanted
+        .iter()
+        .filter(|(origin, _)| match cached.get(*origin) {
+            Some((_, fetched_at)) => now - *fetched_at > SITE_BALANCE_TTL_SECS,
+            None => true,
+        })
+        .map(|(origin, key)| (origin.clone(), key.clone()))
+        .collect()
+}
+
+/// 单飞集合：正在后台刷新的 origin。看板查询可能高频触发（多 app + 窗口聚焦），
+/// 没有这道闸会叠出一串重复扇出。
+static REFRESH_INFLIGHT: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<String>>> =
+    std::sync::OnceLock::new();
+
+/// 读时惰性刷新（SWR 的 revalidate）：筛出 stale 站点交给后台任务 ——
+/// sk 直查 → 写缓存 → 发 [`crate::events::SITE_BALANCES_UPDATED`] 让前端补值。
+///
+/// **这不是 interval 轮询**：唯一触发点是「看板被读」这类用户可见时刻，与
+/// 2026-08「余额采样零新增路径、不做后台轮询」的决策（PR #127）一致。那条
+/// 决策防的是**登录态路**的周期请求 —— NewAPI 的 refresh cookie 一次性轮换，
+/// 充值窗口持有独占权时后台续期会把用户踢出充值页。本链路只走 sk
+/// （`usage_with_api_key` / `billing_balance_with_api_key`），不携带登录态、
+/// 不碰 cookie。⚠️ 若将来把这条链改走登录态，必须先补「充值窗口活跃站跳过」。
+pub fn spawn_stale_refresh(
+    db: std::sync::Arc<crate::database::Database>,
+    app_handle: Option<tauri::AppHandle>,
+    wanted: std::collections::HashMap<String, String>,
+) {
+    let now = chrono::Utc::now().timestamp();
+    let stale = {
+        let cached = cached_site_balances(&db);
+        let stale = stale_balance_sites(&wanted, &cached, now);
+        if stale.is_empty() {
+            return;
+        }
+        let inflight = REFRESH_INFLIGHT.get_or_init(Default::default);
+        let Ok(mut guard) = inflight.lock() else {
+            return;
+        };
+        let fresh: Vec<_> = stale
+            .into_iter()
+            .filter(|(origin, _)| guard.insert(origin.clone()))
+            .collect();
+        fresh
+    };
+    if stale.is_empty() {
+        return;
+    }
+
+    tokio::spawn(async move {
+        let origins: Vec<String> = stale.iter().map(|(origin, _)| origin.clone()).collect();
+        let results = futures::future::join_all(stale.into_iter().map(|(origin, key)| async move {
+            let fetched = match tokio::time::timeout(
+                std::time::Duration::from_secs(SITE_BALANCE_FETCH_BUDGET_SECS),
+                fetch_site_balance(&origin, &key),
+            )
+            .await
+            {
+                Ok(balance) => balance,
+                Err(_elapsed) => {
+                    log::warn!("[site-balance] {origin} 余额链超预算（{SITE_BALANCE_FETCH_BUDGET_SECS}s），本次记负缓存");
+                    None
+                }
+            };
+            (origin, fetched)
+        }))
+        .await;
+
+        let now = chrono::Utc::now().timestamp();
+        for (origin, balance) in results {
+            if let Err(e) = upsert_site_balance(&db, &origin, (balance, now)) {
+                log::warn!("[site-balance] 写缓存失败 {origin}: {e}");
+            }
+        }
+
+        if let Some(inflight) = REFRESH_INFLIGHT.get() {
+            if let Ok(mut guard) = inflight.lock() {
+                for origin in origins {
+                    guard.remove(&origin);
+                }
+            }
+        }
+
+        if let Some(app_handle) = app_handle {
+            crate::events::emit_site_balances_updated(&app_handle);
+        }
+    });
+}
+
+/// 单站余额链（sk 直查，从看板原 `fetch_site_balances` 迁入）：
+/// sub2api `/v1/usage` 钱包 → one-api 系 billing 双端点回落。
+async fn fetch_site_balance(origin: &str, key: &str) -> Option<f64> {
+    let sub2api_wallet = crate::relay::api::usage_with_api_key(origin, key)
+        .await
+        .ok()
+        .and_then(|usage| {
+            usage
+                .data
+                .and_then(|items| items.first().and_then(|item| item.remaining))
+        });
+    match sub2api_wallet {
+        Some(balance) => Some(balance),
+        None => crate::relay::api::billing_balance_with_api_key(origin, key)
+            .await
+            .ok()
+            .flatten(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ==================== 站点余额缓存（看板 SWR） ====================
+
+    fn cache_db() -> crate::database::Database {
+        // Database::memory() 已按生产 schema 建齐全部表（含 v19 的
+        // site_balance_cache），别自建。
+        crate::database::Database::memory().expect("内存库")
+    }
+
+    /// 缓存读写 roundtrip：正/负缓存（None）都要能原样读回、upsert 幂等覆盖。
+    #[test]
+    fn site_balance_cache_roundtrips_including_negative_entries() {
+        let db = cache_db();
+        let now = 1_000_000_i64;
+        upsert_site_balance(&db, "https://a.example", (Some(9.5), now)).unwrap();
+        upsert_site_balance(&db, "https://dead.example", (None, now)).unwrap();
+
+        let cached = cached_site_balances(&db);
+        assert_eq!(cached.get("https://a.example"), Some(&(Some(9.5), now)));
+        assert_eq!(
+            cached.get("https://dead.example"),
+            Some(&(None, now)),
+            "负缓存（查过无值）也要占位，否则死站每次打开都重查"
+        );
+        assert!(!cached.contains_key("https://never.example"));
+
+        // 覆盖写：同站新值顶旧值
+        upsert_site_balance(&db, "https://a.example", (Some(8.0), now + 1)).unwrap();
+        assert_eq!(
+            cached_site_balances(&db).get("https://a.example"),
+            Some(&(Some(8.0), now + 1))
+        );
+    }
+
+    /// stale 判定：没进过缓存的、超 TTL 的要刷；TTL 内的（含负缓存）不刷。
+    #[test]
+    fn stale_balance_sites_pick_missing_and_over_ttl_only() {
+        let now = 10_000_i64;
+        let fresh = now - (SITE_BALANCE_TTL_SECS - 1);
+        let stale = now - (SITE_BALANCE_TTL_SECS + 1);
+        let mut wanted = std::collections::HashMap::new();
+        wanted.insert("https://fresh.example".to_string(), "k1".to_string());
+        wanted.insert("https://stale.example".to_string(), "k2".to_string());
+        wanted.insert("https://missing.example".to_string(), "k3".to_string());
+        wanted.insert(
+            "https://fresh-negative.example".to_string(),
+            "k4".to_string(),
+        );
+        let mut cached = std::collections::HashMap::new();
+        cached.insert("https://fresh.example".to_string(), (Some(1.0), fresh));
+        cached.insert("https://stale.example".to_string(), (Some(2.0), stale));
+        cached.insert("https://fresh-negative.example".to_string(), (None, fresh));
+
+        let mut stale_sites = stale_balance_sites(&wanted, &cached, now);
+        stale_sites.sort();
+        assert_eq!(
+            stale_sites,
+            vec![
+                ("https://missing.example".to_string(), "k3".to_string()),
+                ("https://stale.example".to_string(), "k2".to_string()),
+            ],
+            "TTL 内的正/负缓存都不刷；缺缓存与超 TTL 的要刷"
+        );
+    }
+
+    /// 后台管线贯通：不可达站点跑完「fetch（快速失败）→ 写缓存」后留下负缓存，
+    /// 下一次看板读取（TTL 内）不再重查。
+    #[tokio::test]
+    async fn background_refresh_writes_negative_cache_for_unreachable_site() {
+        let db = std::sync::Arc::new(cache_db());
+        let mut wanted = std::collections::HashMap::new();
+        // .example 是保留 TLD，DNS 必然快速失败（离线环境同样快速失败）
+        wanted.insert(
+            "https://nonexistent.example".to_string(),
+            "sk-x".to_string(),
+        );
+
+        crate::relay::balance::spawn_stale_refresh(db.clone(), None, wanted);
+
+        for _ in 0..250 {
+            let cached = cached_site_balances(&db);
+            if let Some((balance, _)) = cached.get("https://nonexistent.example") {
+                assert_eq!(*balance, None, "不可达站必须是负缓存而不是有值");
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        panic!("后台刷新没有为不可达站写下负缓存");
+    }
 
     #[test]
     fn relay_wallet_balance_owns_the_top_up_prompt_fact() {

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -50,3 +50,5 @@ export const MODEL_VERIFICATION_CHANGED = "model-verification-changed";
 export const ONBOARDING_REGISTER_COMPLETED = "onboarding-register-completed";
 /** 新人引导的「点 Star 领注册礼」邀请（`App.tsx` 的 StarRewardDialog 监听）：Rust 判完资格+配置+基线才发。 */
 export const ONBOARDING_STAR_REWARD_OFFER = "onboarding-star-reward-offer";
+/** 看板站点余额后台刷新完成（`useTierBoard` 监听，失效所有看板查询补值；站点余额跨 app 共享，无 payload）。 */
+export const SITE_BALANCES_UPDATED = "site-balances-updated";

--- a/src/lib/query/autoMode.ts
+++ b/src/lib/query/autoMode.ts
@@ -17,7 +17,7 @@ import {
 } from "@/config/appConfig";
 import { useProxyStatus } from "@/hooks/useProxyStatus";
 import { useTauriEvent } from "@/hooks/useTauriEvent";
-import { PROVIDER_SWITCHED } from "@/lib/api/events";
+import { PROVIDER_SWITCHED, SITE_BALANCES_UPDATED } from "@/lib/api/events";
 import type { ProviderSwitchEvent } from "@/lib/api/providers";
 
 /**
@@ -445,7 +445,7 @@ export function useSetFailoverAll() {
 
 /**
  * 档位看板（首页省心视图数据源）：顺序/倍率/单价/耗时/命中/余额一次拉全。
- * 余额链含站点查询，给个短 staleTime 避免频繁切 app 时反复打站点。
+ * 余额已是后端缓存（命令本身毫秒级），staleTime 防的是频繁切 app 时的重复聚合。
  */
 export function useTierBoard(appType: string, enabled = true) {
   const queryClient = useQueryClient();
@@ -456,6 +456,10 @@ export function useTierBoard(appType: string, enabled = true) {
     void queryClient.invalidateQueries({
       queryKey: ["easyModeTierBoard", appType],
     });
+  });
+  // 余额后台刷新完成（SWR 的补值时机）：站点余额跨 app 共享，失效全部看板。
+  useTauriEvent(SITE_BALANCES_UPDATED, () => {
+    void queryClient.invalidateQueries({ queryKey: ["easyModeTierBoard"] });
   });
   return useQuery({
     queryKey: ["easyModeTierBoard", appType],


### PR DESCRIPTION
## Summary / 概述

省心看板是省心视图里唯一的网络型命令：**余额查询对每站同步发起真实请求**（usage → billing 双端点串行、各 30s 总超时、每次新建连接），20-30 家站点里只要有一家超时型挂掉，整板就等它 30-90s；后端零缓存，冷启动与每次窗口聚焦（>30s stale）全量重演——即用户反馈的「每次打开软件省心模式要加载好久」。其余全部步骤（排序/倍率/首字/统计/健康/熔断）本就是毫秒级本地读。

修法：**后端 stale-while-revalidate**（缓存与刷新 owner 都在后端，前端只展示，符合仓规「前端只展示后端定义的业务事实」）：

- `site_balance_cache` 表（LoongPort schema **v19**，origin → 余额+拉取时刻）：`tier_board` 只读缓存，看板命令变纯本地毫秒级；未命中显示既有的「—」
- **读时惰性刷新（不是 interval 轮询）**：stale（TTL 10min）/缺缓存的站交给后台单飞任务（全局 in-flight 去重）——sk 直查 + 单站 15s 预算（原先一家黑洞站最坏 90s），**负缓存**让查过无值的死站不再每次重查；完成后发 `site-balances-updated` 事件，前端失效看板补上新值
- **与「余额不做后台轮询」决策（PR #127）相容**：那条决策防的是**登录态路**的周期请求（NewAPI refresh cookie 一次性轮换、充值窗口持有独占权，盲查会把用户踢出充值页）；本链路只走 sk（`/v1/usage`、billing 端点）不携带登录态。论证固化在 `spawn_stale_refresh` 文档注释：将来若改走登录态，必须先补「充值窗口活跃站跳过」
- 边界收拢：余额域（建表/缓存/刷新链）全部进 `relay/balance.rs`，auto_mode 只留档位→站点解析；中转站页的行级余额（登录态回落链、手动/事件驱动）**一行不动**

效果：打开看板即时渲染（本地聚合 + 缓存余额），余额最多晚一个后台刷新周期（~秒级）到位；只有真的在变的数据才重新问站点。

## Related Issue / 关联 Issue

用户反馈（无 issue）：每次打开软件省心模式加载很久

## Screenshots / 截图

无 UI 结构变化（余额列复用既有「—」占位）。

## Checklist / 检查清单

- [x] 后端三闸全绿（cargo test 16 套件 / clippy --all-targets -D warnings / fmt）
- [x] 前端三闸全绿（typecheck / format / vitest 1298）
- [x] 测试：缓存 roundtrip（含负缓存幂等覆盖）、stale 判定（TTL 内正/负缓存都不刷）、后台管线贯通（不可达站落负缓存）、v18→v19 迁移、看板零网络读缓存上板
- [x] 事件名走 events.rs/events.ts 唯源 + 一致性闸
