### PR TITLE
refactor(balance): 余额刷新触发与模式/视图解耦（启动冷启补刷 + 充值关窗失效重刷）

### DIFF
--- a/src-tauri/src/commands/auto_mode.rs
+++ b/src-tauri/src/commands/auto_mode.rs
@@ -428,19 +428,13 @@ pub struct TierBoardModelOption {
 #[tauri::command]
 pub async fn easy_mode_tier_board(
     state: tauri::State<'_, AppState>,
-    app_handle: tauri::AppHandle,
     app_type: String,
 ) -> Result<TierBoard, String> {
-    tier_board_impl(&state, &app_type, Some(app_handle)).await
+    tier_board_impl(&state, &app_type).await
 }
 
-/// 看板核心（真实 smoke 直接调它，不走 tauri State）。`app_handle` 只用于
-/// 余额后台刷新完成后发补值事件，headless 传 `None`。
-pub(crate) async fn tier_board_impl(
-    state: &AppState,
-    app_type: &str,
-    app_handle: Option<tauri::AppHandle>,
-) -> Result<TierBoard, String> {
+/// 看板核心（真实 smoke 直接调它，不走 tauri State）。
+pub(crate) async fn tier_board_impl(state: &AppState, app_type: &str) -> Result<TierBoard, String> {
     require_auto_mode_app(app_type)?;
     let db = &state.db;
     let providers = db.get_all_providers(app_type).map_err(|e| e.to_string())?;
@@ -472,11 +466,13 @@ pub(crate) async fn tier_board_impl(
         .provider_breaker_states(app_type, &ranked)
         .await;
 
-    // 余额走缓存（SWR）：看板保持纯本地毫秒级返回，stale 站点由后台单飞
-    // 刷新（sk 直查 + 预算超时）补值，完成后发事件让前端重取。此前这里是
-    // 同步网络扇出 —— 20-30 家里一家超时型挂掉，整板就等它 30-90s，且冷
-    // 启动/窗口聚焦每次重演（用户反馈「每次打开软件省心模式卡好久」）。
-    let (tier_origins, site_keys) = tier_site_keys(app_type, &ranked);
+    // 余额走缓存：看板纯读（模式/视图不驱动刷新 —— 触发点与红线论证收在
+    // services::site_balance_refresh 与 relay::balance::spawn_stale_refresh）。
+    // 此前这里是同步网络扇出 —— 20-30 家里一家超时型挂掉，整板就等它
+    // 30-90s，且冷启动/窗口聚焦每次重演（用户反馈「每次打开软件省心模式
+    // 卡好久」）。
+    let (tier_origins, _site_keys) =
+        crate::services::site_balance_refresh::tier_site_keys(app_type, &ranked);
     let cached = crate::relay::balance::cached_site_balances(db);
     let balances: std::collections::HashMap<String, Option<f64>> = tier_origins
         .iter()
@@ -490,7 +486,6 @@ pub(crate) async fn tier_board_impl(
             )
         })
         .collect();
-    crate::relay::balance::spawn_stale_refresh(state.db.clone(), app_handle, site_keys);
 
     // 健康快照（缺行时 DAO 合成默认健康行，见 get_provider_health 的契约）
     let mut health: std::collections::HashMap<String, crate::proxy::types::ProviderHealth> =
@@ -614,46 +609,6 @@ pub(crate) async fn tier_board_impl(
     })
 }
 
-/// 档位 → 站点余额查询材料的解析（纯本地，无网络）：
-/// - `tier_origins`：档位 id → 站点 origin（https 端点才参与，http/本地/无 sk
-///   自然跳过 —— 单元测试零网络）；
-/// - `site_keys`：origin → 该站第一把 sk（同站多档共用一份站点余额）。
-///
-/// 网络查询本身在 [`crate::relay::balance::spawn_stale_refresh`]（后台 SWR）。
-fn tier_site_keys(
-    app_type: &str,
-    tiers: &[crate::provider::Provider],
-) -> (
-    std::collections::HashMap<String, String>,
-    std::collections::HashMap<String, String>,
-) {
-    use crate::app_config::AppType;
-    let mut tier_origins = std::collections::HashMap::new();
-    let mut site_keys = std::collections::HashMap::new();
-    let app = match AppType::from_str(app_type) {
-        Ok(app) => app,
-        Err(_) => return (tier_origins, site_keys),
-    };
-    let Some(adapter) = crate::proxy::providers::get_adapter(&app) else {
-        return (tier_origins, site_keys);
-    };
-    for tier in tiers {
-        let (base, auth) = match (adapter.extract_base_url(tier), adapter.extract_auth(tier)) {
-            (Ok(base), Some(auth)) => (base, auth),
-            _ => continue,
-        };
-        let Some(origin) = origin_of(&base) else {
-            continue;
-        };
-        if !origin.starts_with("https://") {
-            continue;
-        }
-        tier_origins.insert(tier.id.clone(), origin.clone());
-        site_keys.entry(origin).or_insert(auth.api_key);
-    }
-    (tier_origins, site_keys)
-}
-
 /// 模型单价（每百万 token 输入+输出之和，美元）；价表未收录 → `None`。
 /// 与 `auto_strategy::tier_unit_price` 同一张表，只是按模型名直查。
 fn model_unit_price(db: &crate::Database, model: &str) -> Option<f64> {
@@ -666,16 +621,6 @@ fn model_unit_price(db: &crate::Database, model: &str) -> Option<f64> {
     let input: f64 = input.parse().ok()?;
     let output: f64 = output.parse().ok()?;
     Some(input + output)
-}
-
-/// 从 base_url 取 `scheme://authority`（`https://site/v1` → `https://site`）。
-fn origin_of(base_url: &str) -> Option<String> {
-    let (scheme, rest) = base_url.split_once("://")?;
-    let authority = rest.split('/').next()?;
-    if authority.is_empty() {
-        return None;
-    }
-    Some(format!("{scheme}://{authority}"))
 }
 
 #[cfg(test)]
@@ -717,7 +662,7 @@ mod tests {
         db.save_provider("claude", &tier).unwrap();
 
         // 无缓存：余额 None（显示 —）
-        let board = tier_board_impl(&state, "claude", None).await.unwrap();
+        let board = tier_board_impl(&state, "claude").await.unwrap();
         assert_eq!(board.tiers[0].balance_usd, None, "缓存未命中 → —");
 
         // 种子缓存（TTL 内）→ 上板；后台刷新因缓存新鲜而不触发（本测试零网络）
@@ -728,7 +673,7 @@ mod tests {
             (Some(12.34), now),
         )
         .unwrap();
-        let board = tier_board_impl(&state, "claude", None).await.unwrap();
+        let board = tier_board_impl(&state, "claude").await.unwrap();
         assert_eq!(
             board.tiers[0].balance_usd,
             Some(12.34),
@@ -767,7 +712,7 @@ mod tests {
             .unwrap();
         db.set_current_provider("claude", &expensive).unwrap();
 
-        let board = tier_board_impl(&state, "claude", None).await.unwrap();
+        let board = tier_board_impl(&state, "claude").await.unwrap();
         assert_eq!(board.mode, "auto");
         assert_eq!(board.strategy, "cheapest");
         assert_eq!(board.tiers.len(), 2);
@@ -807,7 +752,7 @@ mod tests {
             &verification_report(&expensive, "m-x", Verdict::Trusted),
         )
         .unwrap();
-        let board = tier_board_impl(&state, "claude", None).await.unwrap();
+        let board = tier_board_impl(&state, "claude").await.unwrap();
         let by_id = |id: &str| board.tiers.iter().find(|t| t.provider_id == id).unwrap();
         assert_eq!(
             by_id(&cheap).verification_verdict.as_deref(),
@@ -834,7 +779,7 @@ mod tests {
             &[expensive.clone(), cheap.clone()],
         )
         .unwrap();
-        let board = tier_board_impl(&state, "claude", None).await.unwrap();
+        let board = tier_board_impl(&state, "claude").await.unwrap();
         assert_eq!(board.mode, "manual");
         assert_eq!(board.tiers[0].provider_id, expensive, "手动序优先");
     }
@@ -870,7 +815,7 @@ mod tests {
         // 当前档位（贵）30 分钟内有流量 → 选路会亲和置顶；看板必须保持纯价格序
         seed_board_activity(&db, "claude", &expensive);
 
-        let board = tier_board_impl(&state, "claude", None).await.unwrap();
+        let board = tier_board_impl(&state, "claude").await.unwrap();
         assert_eq!(
             board.tiers[0].provider_id, cheap,
             "看板第一张是最便宜的，不被亲和置顶顶走"
@@ -912,7 +857,7 @@ mod tests {
         .await
         .unwrap();
 
-        let board = tier_board_impl(&state, "claude", None).await.unwrap();
+        let board = tier_board_impl(&state, "claude").await.unwrap();
         let by_id = |id: &str| board.tiers.iter().find(|t| t.provider_id == id).unwrap();
         assert_eq!(by_id(&dead).is_healthy, Some(false));
         assert_eq!(by_id(&dead).consecutive_failures, Some(1));
@@ -983,7 +928,7 @@ mod tests {
             -60,
         );
 
-        let board = tier_board_impl(&state, "claude", None).await.unwrap();
+        let board = tier_board_impl(&state, "claude").await.unwrap();
         let by_id = |id: &str| board.tiers.iter().find(|t| t.provider_id == id).unwrap();
         let remaining = by_id(&current)
             .affinity_remaining_secs
@@ -1092,7 +1037,7 @@ mod tests {
         );
         // cold 档没有任何行
 
-        let board = tier_board_impl(&state, "claude", None).await.unwrap();
+        let board = tier_board_impl(&state, "claude").await.unwrap();
         let by_id = |id: &str| board.tiers.iter().find(|t| t.provider_id == id).unwrap();
         let busy_tier = by_id(&busy);
         assert_eq!(busy_tier.today_cost_usd, Some(0.75), "昨日的 $9 不计入");
@@ -1143,7 +1088,7 @@ mod tests {
             .unwrap();
         }
 
-        let board = tier_board_impl(&state, "codex", None).await.unwrap();
+        let board = tier_board_impl(&state, "codex").await.unwrap();
         let by_model = |model: &str| {
             board
                 .model_options
@@ -1241,7 +1186,7 @@ mod tests {
             -8 * 3600,
         );
 
-        let board = tier_board_impl(&state, "claude", None).await.unwrap();
+        let board = tier_board_impl(&state, "claude").await.unwrap();
         let by_id = |id: &str| board.tiers.iter().find(|t| t.provider_id == id).unwrap();
         let activity = by_id(&busy)
             .recent_activity

--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -5736,10 +5736,26 @@ async fn open_sub2api_site_window<R: tauri::Runtime>(
     // 关窗刷余额。认 `Destroyed`（窗口真的没了）而不是 `CloseRequested`
     // （可被拦下的关闭请求，某些平台上会先于实际销毁触发、甚至可能被取消）。
     //
-    // 只 emit 事件、不在这里查余额：查余额要发 HTTP，而这个回调不能 await。
+    // 只 emit 事件、不在这里查余额：查余额要发 HTTP，而这个回调不能 await ——
+    // 站点级缓存（看板用）的失效+补刷走 spawn，不受此限。
+    let close_handle = app_handle.clone();
+    let close_site = op.site_origin.clone();
+    let close_api_base = op.api_base_url.clone();
     built.on_window_event(move |event| {
         if matches!(event, tauri::WindowEvent::Destroyed) {
             let _ = handle_for_close.emit(PURCHASE_CLOSED, closed_relay_id);
+            let handle = close_handle.clone();
+            let (site, api_base) = (close_site.clone(), close_api_base.clone());
+            // db 在事件内取：开窗路径不碰全局 state（headless 窗口测试没有 manage）
+            tauri::async_runtime::spawn(async move {
+                let db = handle.state::<AppState>().db.clone();
+                crate::services::site_balance_refresh::refresh_after_purchase(
+                    &db,
+                    Some(handle),
+                    &site,
+                    &api_base,
+                );
+            });
         }
     });
 

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -117,7 +117,7 @@ pub fn emit_provider_switched(
 
 /// 看板站点余额后台刷新完成。余额在后台单飞刷新（`relay::balance::spawn_stale_refresh`），
 /// 到货后靠这个事件让看板补值 —— 没有它，新余额要等下一次聚焦/30s stale 才出现。
-pub fn emit_site_balances_updated(app_handle: &tauri::AppHandle) {
+pub fn emit_site_balances_updated<R: tauri::Runtime>(app_handle: &tauri::AppHandle<R>) {
     if let Err(e) = app_handle.emit(SITE_BALANCES_UPDATED, ()) {
         // 发不出去只是余额晚一点显示（下次看板重取自然带上），不值得报错。
         log::warn!("发射 {SITE_BALANCES_UPDATED} 事件失败: {e}");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1291,6 +1291,17 @@ pub fn run() {
             app.manage(crate::services::app_update::AppUpdateStage::new());
             maintenance::start(app.handle().clone());
 
+            // 站点余额冷启补刷（一次性、模式无关）：让用户点进任何视图时缓存
+            // 已就绪。延迟一会儿，避开启动高峰的 DB/网络初始化。
+            {
+                let db = app.state::<AppState>().db.clone();
+                let handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_secs(15)).await;
+                    crate::services::site_balance_refresh::startup_kick(&db, Some(handle));
+                });
+            }
+
             // 初始化 SkillService
             let skill_service = SkillService::new();
             app.manage(commands::skill::SkillServiceState(Arc::new(skill_service)));

--- a/src-tauri/src/proxy/auto_mode_e2e_tests.rs
+++ b/src-tauri/src/proxy/auto_mode_e2e_tests.rs
@@ -759,7 +759,7 @@ async fn passive_anomaly_lands_and_surfaces() {
 
     // 档位看板点亮异常
     let state = crate::store::AppState::new(fx.db.clone());
-    let board = crate::commands::auto_mode::tier_board_impl(&state, "claude", None)
+    let board = crate::commands::auto_mode::tier_board_impl(&state, "claude")
         .await
         .unwrap();
     let tier = board

--- a/src-tauri/src/proxy/real_upstream_smoke_tests.rs
+++ b/src-tauri/src/proxy/real_upstream_smoke_tests.rs
@@ -229,7 +229,7 @@ async fn real_tier_board_snapshot() {
     let _ = rustls::crypto::ring::default_provider().install_default();
     let (_home, db) = smoke_db();
     let state = crate::store::AppState::new(db);
-    let board = crate::tier_board_impl(&state, "claude", None)
+    let board = crate::tier_board_impl(&state, "claude")
         .await
         .expect("tier board");
     println!(
@@ -265,7 +265,7 @@ async fn real_manual_order_routes_to_user_first_pick() {
     // 与自动策略序不同（否则证明力为零）。断言探针选「必有 HTTP 交换」的档位
     // ——网络层失败（连接拒绝/超时）不写 proxy_request_logs，只有 HTTP 交换
     // （2xx/4xx/5xx）留痕；newapi/sub2api 站点总会回 HTTP。
-    let board = crate::tier_board_impl(&state, "claude", None)
+    let board = crate::tier_board_impl(&state, "claude")
         .await
         .expect("tier board");
     assert!(board.tiers.len() >= 2, "至少两档才能构造证明性手动序");

--- a/src-tauri/src/relay/balance.rs
+++ b/src-tauri/src/relay/balance.rs
@@ -366,6 +366,26 @@ pub fn upsert_site_balance(
     Ok(())
 }
 
+/// 删指定站的缓存行 —— 充值等「余额已确定变化」的时刻用：旧值必然错了，
+/// 留着只会误导，删掉后由紧随的单站刷新重新落值。
+pub fn drop_site_cache(
+    db: &crate::database::Database,
+    origins: &std::collections::HashSet<String>,
+) {
+    let conn = db
+        .conn
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for origin in origins {
+        if let Err(e) = conn.execute(
+            "DELETE FROM site_balance_cache WHERE site_origin = ?1",
+            rusqlite::params![origin],
+        ) {
+            log::warn!("[site-balance] 删缓存失败 {origin}: {e}");
+        }
+    }
+}
+
 /// 哪些站需要刷新：没进过缓存的 + `fetched_at` 超 TTL 的（纯函数）。
 fn stale_balance_sites(
     wanted: &std::collections::HashMap<String, String>,
@@ -396,9 +416,9 @@ static REFRESH_INFLIGHT: std::sync::OnceLock<std::sync::Mutex<std::collections::
 /// 充值窗口持有独占权时后台续期会把用户踢出充值页。本链路只走 sk
 /// （`usage_with_api_key` / `billing_balance_with_api_key`），不携带登录态、
 /// 不碰 cookie。⚠️ 若将来把这条链改走登录态，必须先补「充值窗口活跃站跳过」。
-pub fn spawn_stale_refresh(
+pub fn spawn_stale_refresh<R: tauri::Runtime>(
     db: std::sync::Arc<crate::database::Database>,
-    app_handle: Option<tauri::AppHandle>,
+    app_handle: Option<tauri::AppHandle<R>>,
     wanted: std::collections::HashMap<String, String>,
 ) {
     let now = chrono::Utc::now().timestamp();
@@ -562,7 +582,7 @@ mod tests {
             "sk-x".to_string(),
         );
 
-        crate::relay::balance::spawn_stale_refresh(db.clone(), None, wanted);
+        crate::relay::balance::spawn_stale_refresh(db.clone(), None::<tauri::AppHandle>, wanted);
 
         for _ in 0..250 {
             let cached = cached_site_balances(&db);

--- a/src-tauri/src/relay/newapi_purchase.rs
+++ b/src-tauri/src/relay/newapi_purchase.rs
@@ -273,11 +273,27 @@ pub(crate) fn build_window<R: tauri::Runtime>(
     .map_err(|e| AppError::Config(format!("打开站点窗口失败: {e}")))?;
 
     // 认 `Destroyed`（窗口真的没了）而不是 `CloseRequested`（可被拦下、可能取消）：
-    // 关窗即刷余额（emit）+ 停 monitor（shutdown）。
+    // 关窗即刷余额（emit）+ 停 monitor（shutdown）。站点级缓存（看板用）的
+    // 失效+补刷走 spawn —— 与 sub2api 站点窗同一形状（回调不能 await）。
+    let close_handle = app_handle.clone();
+    let close_site = relay.site_origin.clone();
+    let close_api_base = relay.api_base_url.clone();
     built.on_window_event(move |event| {
         if matches!(event, tauri::WindowEvent::Destroyed) {
             let _ = handle_for_close.emit(PURCHASE_CLOSED, closed_relay_id);
             let _ = shutdown.send(true);
+            let handle = close_handle.clone();
+            let (site, api_base) = (close_site.clone(), close_api_base.clone());
+            // db 在事件内取：开窗路径不碰全局 state（headless 窗口测试没有 manage）
+            tauri::async_runtime::spawn(async move {
+                let db = handle.state::<AppState>().db.clone();
+                crate::services::site_balance_refresh::refresh_after_purchase(
+                    &db,
+                    Some(handle),
+                    &site,
+                    &api_base,
+                );
+            });
         }
     });
 

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -25,6 +25,7 @@ pub mod session_usage_gemini;
 pub mod session_usage_grokbuild;
 pub mod session_usage_opencode;
 pub mod session_usage_pi;
+pub mod site_balance_refresh;
 pub mod skill;
 pub mod speedtest;
 pub mod sql_helpers;

--- a/src-tauri/src/services/site_balance_refresh.rs
+++ b/src-tauri/src/services/site_balance_refresh.rs
@@ -1,0 +1,241 @@
+//! 站点余额刷新的**编排层**（模式无关）。
+//!
+//! 触发点与视图/模式解耦（2026-09-06 用户定的原则）：用户选省心还是自主，
+//! 与底层的余额/模型等数据刷新本无关联 —— 刷新是数据层自己的事，唯一的
+//! 合法触发是「没数据时补一次」这类与模式无关的时刻。看板等视图**纯读**
+//! [`crate::relay::balance::cached_site_balances`]，不驱动刷新。
+//!
+//! 两个触发点（都不是 interval，与「余额禁轮询」决策相容，红线论证见
+//! [`crate::relay::balance::spawn_stale_refresh`] 的文档）：
+//! 1. **应用启动冷启补刷**（[`startup_kick`]，lib.rs 挂）：启动后一次性把
+//!    stale/缺缓存的站刷齐 —— 用户点进任何视图时缓存已就绪；
+//! 2. **充值窗关闭失效重刷**（[`refresh_after_purchase`]，关窗事件旁路）：
+//!    充值是余额真正变化的时刻，属「零新增路径」的事件驱动采样。
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use std::str::FromStr;
+
+use crate::app_config::AppType;
+use crate::database::Database;
+use crate::provider::Provider;
+use crate::relay::balance;
+
+/// 从 base_url 取 `scheme://authority`（`https://site/v1` → `https://site`）。
+pub(crate) fn origin_of(base_url: &str) -> Option<String> {
+    let (scheme, rest) = base_url.split_once("://")?;
+    let authority = rest.split('/').next()?;
+    if authority.is_empty() {
+        return None;
+    }
+    Some(format!("{scheme}://{authority}"))
+}
+
+/// 档位 → 站点余额查询材料的解析（纯本地，无网络）：
+/// - `tier_origins`：档位 id → 站点 origin（https 端点才参与，http/本地/无 sk
+///   自然跳过 —— 单元测试零网络）；
+/// - `site_keys`：origin → 该站第一把 sk（同站多档共用一份站点余额）。
+///
+/// 网络查询本身在 [`balance::spawn_stale_refresh`]（后台 SWR）。
+pub(crate) fn tier_site_keys(
+    app_type: &str,
+    tiers: &[Provider],
+) -> (HashMap<String, String>, HashMap<String, String>) {
+    let mut tier_origins = HashMap::new();
+    let mut site_keys = HashMap::new();
+    let app = match AppType::from_str(app_type) {
+        Ok(app) => app,
+        Err(_) => return (tier_origins, site_keys),
+    };
+    let Some(adapter) = crate::proxy::providers::get_adapter(&app) else {
+        return (tier_origins, site_keys);
+    };
+    for tier in tiers {
+        let (base, auth) = match (adapter.extract_base_url(tier), adapter.extract_auth(tier)) {
+            (Ok(base), Some(auth)) => (base, auth),
+            _ => continue,
+        };
+        let Some(origin) = origin_of(&base) else {
+            continue;
+        };
+        if !origin.starts_with("https://") {
+            continue;
+        }
+        tier_origins.insert(tier.id.clone(), origin.clone());
+        site_keys.entry(origin).or_insert(auth.api_key);
+    }
+    (tier_origins, site_keys)
+}
+
+/// 全部托管档（跨 app）的站点查询材料。模式无关：只看「有哪些托管档」，
+/// 不看用户在用省心还是自主 —— 两种模式底下是同一批站点数据。
+fn collect_all_site_keys(db: &Database) -> HashMap<String, String> {
+    let mut merged: HashMap<String, String> = HashMap::new();
+    for app in AppType::all() {
+        let Ok(providers) = db.get_all_providers(app.as_str()) else {
+            continue;
+        };
+        let tiers: Vec<Provider> = providers
+            .into_values()
+            .filter(|p| crate::relay::is_managed(&p.id))
+            .collect();
+        if tiers.is_empty() {
+            continue;
+        }
+        let (_, site_keys) = tier_site_keys(app.as_str(), &tiers);
+        for (origin, key) in site_keys {
+            merged.entry(origin).or_insert(key);
+        }
+    }
+    merged
+}
+
+/// 应用启动冷启补刷：stale/缺缓存的站交给后台单飞刷新（TTL 内的缓存不动，
+/// 所以日常重启也只是把过期的补齐，不是全量重查）。
+pub fn startup_kick<R: tauri::Runtime>(
+    db: &Arc<Database>,
+    app_handle: Option<tauri::AppHandle<R>>,
+) {
+    let wanted = collect_all_site_keys(db);
+    balance::spawn_stale_refresh(db.clone(), app_handle, wanted);
+}
+
+/// 充值窗关闭：先删该站缓存行（充值后旧值必错），再立即单站补刷 ——
+/// 事件驱动、单站、秒级，与关窗刷行余额（JWT 路）互补。
+pub fn refresh_after_purchase<R: tauri::Runtime>(
+    db: &Arc<Database>,
+    app_handle: Option<tauri::AppHandle<R>>,
+    relay_site_origin: &str,
+    relay_api_base: &str,
+) {
+    let origins: HashSet<String> = [relay_site_origin, relay_api_base]
+        .into_iter()
+        .filter_map(origin_of)
+        .collect();
+    if origins.is_empty() {
+        return;
+    }
+    balance::drop_site_cache(db, &origins);
+
+    let wanted: HashMap<String, String> = collect_all_site_keys(db)
+        .into_iter()
+        .filter(|(origin, _)| origins.contains(origin))
+        .collect();
+    if wanted.is_empty() {
+        return;
+    }
+    balance::spawn_stale_refresh(db.clone(), app_handle, wanted);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn origin_of_strips_paths() {
+        assert_eq!(
+            origin_of("https://api.example/v1"),
+            Some("https://api.example".to_string())
+        );
+        assert_eq!(
+            origin_of("https://site.example"),
+            Some("https://site.example".to_string())
+        );
+        assert_eq!(origin_of("note-a-url"), None);
+        assert_eq!(origin_of("https://"), None);
+    }
+
+    /// 冷启补刷的站点收集：同站多档去重、只认托管档、http 端点不参与（零网络）。
+    #[test]
+    fn collect_all_site_keys_dedupes_and_filters() {
+        let db = Database::memory().unwrap();
+        let tier = |id: &str, app: &str, base: &str| {
+            db.save_provider(
+                app,
+                &Provider::with_id(
+                    id.to_string(),
+                    id.to_string(),
+                    serde_json::json!({
+                        "env": {
+                            "ANTHROPIC_BASE_URL": base,
+                            "ANTHROPIC_AUTH_TOKEN": "sk-test-not-a-real-key",
+                        }
+                    }),
+                    None,
+                ),
+            )
+            .unwrap();
+        };
+        // 同站两档（不同分组）：origin 去重成一把 key
+        tier(
+            &crate::relay::provision::provider_id_for("https://a.example", Some(1), 1),
+            "claude",
+            "https://a.example",
+        );
+        tier(
+            &crate::relay::provision::provider_id_for("https://a.example", Some(1), 2),
+            "claude",
+            "https://a.example/v1",
+        );
+        // 非托管档与 http 档：不进收集
+        tier("manual-tier", "claude", "https://b.example");
+        tier(
+            &crate::relay::provision::provider_id_for("http://c.example", Some(1), 3),
+            "claude",
+            "http://c.example",
+        );
+
+        let wanted = collect_all_site_keys(&db);
+        assert_eq!(wanted.len(), 1, "只留 a.example（同站去重、http/手工排除）");
+        assert!(wanted.contains_key("https://a.example"));
+    }
+
+    /// 充值关窗编排：旧缓存行被删、该站被单站补刷（不可达站最终落负缓存）。
+    /// 充值后旧值必然错 —— 删而不刷会让看板显示"—"直到下次启动，所以两步都要。
+    #[tokio::test]
+    async fn refresh_after_purchase_drops_and_refetches_that_site() {
+        let db = Arc::new(Database::memory().unwrap());
+        // 该站一个托管档（https、不可达 —— .example 保留域 DNS 快速失败）
+        let id = crate::relay::provision::provider_id_for("https://gone.example", Some(1), 1);
+        db.save_provider(
+            "claude",
+            &Provider::with_id(
+                id,
+                "充值站".to_string(),
+                serde_json::json!({
+                    "env": {
+                        "ANTHROPIC_BASE_URL": "https://gone.example",
+                        "ANTHROPIC_AUTH_TOKEN": "sk-test-not-a-real-key",
+                    }
+                }),
+                None,
+            ),
+        )
+        .unwrap();
+        // 充值前的旧值（不同 fetched_at，用远过去时间避开与刷新结果撞值）
+        crate::relay::balance::upsert_site_balance(&db, "https://gone.example", (Some(1.23), 100))
+            .unwrap();
+
+        crate::services::site_balance_refresh::refresh_after_purchase(
+            &db,
+            None::<tauri::AppHandle>,
+            "https://panel.gone.example",
+            "https://gone.example",
+        );
+
+        for _ in 0..250 {
+            let entry = crate::relay::balance::cached_site_balances(&db)
+                .get("https://gone.example")
+                .copied();
+            // 旧值(1.23, 100)被删，最终落到补刷结果（负缓存、新 fetched_at）
+            if let Some((balance, fetched_at)) = entry {
+                assert_eq!(balance, None, "不可达站补刷结果 = 负缓存");
+                assert!(fetched_at > 1_000, "必须是补刷写的新行，不是充值前旧值");
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        panic!("充值关窗没有完成「删旧值 + 单站补刷」");
+    }
+}


### PR DESCRIPTION
## Summary / 概述

#283 落地后用户定的架构原则：**用户选省心还是自主，与底层余额/模型等数据刷新本无关联**——刷新是数据层自己的事，唯一合法的触发是「刚开始没数据，补一次」这类与模式无关的时刻；视图（看板）纯读缓存，不驱动刷新。

本 PR 把 #283 挂在看板读路径上的刷新触发迁出：

- **新编排层 `services/site_balance_refresh`（模式无关）**，两个触发点都不是 interval（「余额禁轮询」红线论证在 `relay::balance::spawn_stale_refresh` 文档）：
  - `startup_kick`：应用启动一次性补刷 stale/缺缓存的站（lib.rs 挂、延迟 15s 避开启动高峰）。TTL 内的缓存不动 ⇒ 日常重启只补过期站；顺带消灭 #283 遗留的「首次打开余额闪 —」——用户点进任何视图时缓存已就绪
  - `refresh_after_purchase`：充值窗关闭（sub2api/NewAPI 两处）先删该站缓存行（充值后旧值必然错了）再单站补刷，秒级回新值——事件驱动采样，与关窗刷行余额（JWT 路）互补
- `tier_board_impl` 撤掉刷新调用，纯读缓存；#283 为发事件加的 `app_handle` 参数整个回退（命令签名与 13 处调用点复原）
- 档位→站点解析（`tier_site_keys`/`origin_of`）迁入编排层成为唯一实现，看板读路径与冷启收集共用
- 充值关窗在事件内取 db：开窗路径不碰全局 state（headless 窗口测试没有 manage，开窗时取 state 会炸）

## Related Issue / 关联 Issue

用户架构反馈（无 issue）：模式选择与底层数据刷新解耦，冷启动触发一次即可

## Screenshots / 截图

不涉及 UI。

## Checklist / 检查清单

- [x] 后端三闸全绿（cargo test 16 套件 3784+ / clippy --all-targets -D warnings / fmt）
- [x] 测试：origin 解析、冷启收集（同站去重/托管过滤/http 排除）、充值路径「删旧值+单站补刷落负缓存」端到端
- [x] 前端零改动（#283 的事件订阅仍有效：事件改由新触发点发射）
