### PR TITLE
feat(crowd): /v1/trend 趋势端点——三档时间范围的逐桶站点序列

### DIFF
--- a/crowd-metrics/src/aggregate.test.ts
+++ b/crowd-metrics/src/aggregate.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildSnapshot,
+  buildTrends,
   COHORT_FACTOR,
   MIN_ASN,
   MIN_SOURCES,
@@ -250,5 +251,45 @@ describe("分布直方图与口径", () => {
   it("门槛常量钉住：MIN_SOURCES=1、MIN_ASN=1（2026-09-06 临时放开，恢复 3/2 时连着常量注释与 README 一起改）", () => {
     expect(MIN_SOURCES).toBe(1);
     expect(MIN_ASN).toBe(1);
+  });
+});
+
+describe("趋势（buildTrends）", () => {
+  it("三档粒度与桶数：24h=24×1h、7d=56×3h、30d=60×12h", () => {
+    const trend = buildTrends(sources(3), NOW);
+    expect(Object.keys(trend.ranges).sort()).toEqual(["24h", "30d", "7d"]);
+    expect(trend.ranges["24h"].bucketSeconds).toBe(3600);
+    expect(trend.ranges["24h"].sites["example.com"].buckets).toHaveLength(24);
+    expect(trend.ranges["7d"].bucketSeconds).toBe(3 * 3600);
+    expect(trend.ranges["7d"].sites["example.com"].buckets).toHaveLength(56);
+    expect(trend.ranges["30d"].bucketSeconds).toBe(12 * 3600);
+    expect(trend.ranges["30d"].sites["example.com"].buckets).toHaveLength(60);
+  });
+
+  it("最后一格对齐当前小时；数据落倒数第二格，空桶为 null 占位", () => {
+    const trend = buildTrends(sources(3), NOW);
+    const buckets = trend.ranges["24h"].sites["example.com"].buckets;
+    const last = buckets[buckets.length - 1];
+    // 网格末格 = 当前（可能未满的）小时的整点起点
+    expect(last.start).toBe(Math.floor(NOW / 3600) * 3600);
+    expect(last.p50Ms).toBeNull(); // 当前小时还没数据
+    // makeRaw 的小时 = NOW 前一小时 → 倒数第二格
+    const dataBucket = buckets[buckets.length - 2];
+    expect(dataBucket.p50Ms).not.toBeNull();
+    expect(dataBucket.start).toBe(Math.floor(NOW / 3600) * 3600 - 3600);
+    expect(buckets[0].p50Ms).toBeNull(); // 只有一小时数据，其余桶为 null 占位
+  });
+
+  it("逐桶 k-匿：单来源的桶不发布（当前门槛 1/1 下未受信来源不算数）", () => {
+    const rows = [makeRaw({ source: "only", ua_trusted: 0 })];
+    const trend = buildTrends(rows, NOW);
+    expect(trend.ranges["24h"].sites["example.com"]).toBeUndefined();
+  });
+
+  it("范围分布累计（ttftBins）= 过桶行的 bins 合并", () => {
+    const trend = buildTrends(sources(3), NOW);
+    const bins = trend.ranges["24h"].sites["example.com"].ttftBins;
+    const sum = bins.reduce((s, c) => s + c, 0);
+    expect(sum).toBe(30); // 3 来源 × 10 样本全落 bin[2]
   });
 });

--- a/crowd-metrics/src/aggregate.ts
+++ b/crowd-metrics/src/aggregate.ts
@@ -23,7 +23,15 @@
 
 import { binMidpoint, quantileFromBins, TTFT_BIN_COUNT } from "./bins";
 import { hourToEpochSec } from "./validate";
-import type { HourSlot, SiteStats, Snapshot, WindowStats } from "./types";
+import type {
+  HourSlot,
+  SiteStats,
+  SiteTrend,
+  Snapshot,
+  TrendBucket,
+  TrendPayload,
+  WindowStats,
+} from "./types";
 
 /**
  * k-匿名门槛：少于这么多受信独立来源的聚合不发布。
@@ -373,4 +381,86 @@ export function buildSnapshot(rows: RawRow[], nowSec: number): Snapshot {
   }
 
   return { version: 1, generatedAt: nowSec, sites };
+}
+
+/** 趋势档位：跨度 + 输出桶粒度。粒度选点让每档点位数落在 24~60 之间
+ *  （折线可读、悬停可命中），且都是小时的整数倍（原始桶按小时存）。 */
+const TREND_RANGES = [
+  { key: "24h" as const, spanSecs: 24 * 3600, bucketSecs: 3600 },
+  { key: "7d" as const, spanSecs: 7 * 86400, bucketSecs: 3 * 3600 },
+  { key: "30d" as const, spanSecs: 30 * 86400, bucketSecs: 12 * 3600 },
+];
+
+/**
+ * 一个输出桶的统计：k-匿与时段槽同款（只看受信来源数，不加 ASN 门槛——
+ * 桶天然稀疏，主指标在窗口上）。不过门槛返回 null。bins 一并交回供
+ * 范围分布累计（与窗口统计同口径：用裁剪后的行）。
+ */
+function trendBucketOrNull(bucketRows: ParsedRow[]): { bucket: TrendBucket; bins: number[] } | null {
+  const trusted = bucketRows.filter((r) => r.uaTrusted);
+  const sources = new Set(trusted.map((r) => r.source)).size;
+  if (sources < MIN_SOURCES) return null;
+  const kept = trimExtremeSources(bucketRows);
+  const totals = emptyTotals();
+  for (const r of kept) addInto(totals, r);
+  const cacheDenom = totals.cacheReadTokens + totals.cacheCreationTokens + totals.inputTokens;
+  return {
+    bucket: {
+      // 桶起点由调用方给（对齐网格），这里只算指标
+      start: 0,
+      p50Ms: quantileFromBins(totals.bins, 0.5),
+      p95Ms: quantileFromBins(totals.bins, 0.95),
+      errRate: totals.samples > 0 ? totals.errors / totals.samples : null,
+      cacheRate: cacheDenom > 0 ? totals.cacheReadTokens / cacheDenom : null,
+    },
+    bins: totals.bins,
+  };
+}
+
+/** 由原始桶行构建三档趋势（30 天原始数据一次查询复用）。 */
+export function buildTrends(rows: RawRow[], nowSec: number): TrendPayload {
+  const bySite = new Map<string, ParsedRow[]>();
+  for (const row of rows) {
+    const parsed = parseRow(row);
+    if (parsed === null) continue;
+    const list = bySite.get(parsed.site) ?? [];
+    list.push(parsed);
+    bySite.set(parsed.site, list);
+  }
+
+  const ranges: TrendPayload["ranges"] = {} as TrendPayload["ranges"];
+  for (const { key, spanSecs, bucketSecs } of TREND_RANGES) {
+    // 网格锚在「整点对齐的窗口末尾」，最后一格是当前（可能未满的）小时。
+    const endHour = Math.floor(nowSec / 3600) * 3600;
+    const start = endHour - spanSecs + 3600;
+    const sites: Record<string, SiteTrend> = {};
+
+    for (const [site, siteRows] of bySite) {
+      const inRange = siteRows.filter((r) => r.epoch >= start && r.epoch <= endHour);
+      const bucketCount = spanSecs / bucketSecs;
+      const buckets: TrendBucket[] = [];
+      const rangeBins = new Array<number>(TTFT_BIN_COUNT).fill(0);
+      let anyPublished = false;
+
+      for (let i = 0; i < bucketCount; i++) {
+        const bStart = start + i * bucketSecs;
+        const bEnd = bStart + bucketSecs;
+        const bucketRows = inRange.filter((r) => r.epoch >= bStart && r.epoch < bEnd);
+        const computed = bucketRows.length > 0 ? trendBucketOrNull(bucketRows) : null;
+        if (computed) {
+          computed.bucket.start = bStart;
+          buckets.push(computed.bucket);
+          anyPublished = true;
+          for (let j = 0; j < TTFT_BIN_COUNT; j++) rangeBins[j] += computed.bins[j];
+        } else {
+          buckets.push({ start: bStart, p50Ms: null, p95Ms: null, errRate: null, cacheRate: null });
+        }
+      }
+      if (anyPublished) sites[site] = { buckets, ttftBins: rangeBins };
+    }
+
+    ranges[key] = { bucketSeconds: bucketSecs, sites };
+  }
+
+  return { version: 1, generatedAt: nowSec, ranges };
 }

--- a/crowd-metrics/src/index.ts
+++ b/crowd-metrics/src/index.ts
@@ -6,7 +6,7 @@
  * - scheduled（每 5 分钟） 重算快照写 KV + 清理 30 天前的原始桶 / 2 天前的限流计数
  */
 
-import { buildSnapshot, type RawRow } from "./aggregate";
+import { buildSnapshot, buildTrends, type RawRow } from "./aggregate";
 import { TTFT_BIN_EDGES_MS } from "./bins";
 import { cleanupDue, isFresh } from "./freshness";
 import { handleIngest, type Env } from "./ingest";
@@ -19,6 +19,8 @@ const RAW_RETENTION_SECS = 30 * 86400;
 const RATE_LIMIT_RETENTION_SECS = 2 * 86400;
 /** KV 快照键。 */
 const SNAPSHOT_KEY = "snapshot:v1";
+/** KV 趋势键（三档一包，recompute 与快照同拍写、同 freshness 策略）。 */
+const TREND_KEY = "trend:v1";
 
 const CORS_HEADERS: Record<string, string> = {
   "access-control-allow-origin": "*",
@@ -29,8 +31,9 @@ const CORS_HEADERS: Record<string, string> = {
 const SNAPSHOT_CACHE_CONTROL = "public, max-age=60, stale-while-revalidate=300";
 
 async function queryRawRows(env: Env, nowSec: number): Promise<RawRow[]> {
-  // 7 天窗口 + 1 小时余量（整点对齐会把边界小时整桶切进切出）。
-  const cutoff = hourFloorUtc(nowSec - 7 * 86400 - 3600);
+  // 30 天窗口 + 1 小时余量（整点对齐会把边界小时整桶切进切出）。
+  // 趋势（/v1/trend 的 30d 档）需要全保留期数据；快照仍按 epoch 过滤 7 天内。
+  const cutoff = hourFloorUtc(nowSec - 30 * 86400 - 3600);
   const { results } = await env.DB.prepare(
     `SELECT hour, site, app, source, asn, ua_trusted, samples, errors,
             ttft_bins, ttft_count, input_tokens, output_tokens,
@@ -46,13 +49,16 @@ async function queryRawRows(env: Env, nowSec: number): Promise<RawRow[]> {
 const CLEANUP_LAST_RUN_KEY = "cleanup:last-run";
 
 /**
- * 现算快照并写 KV。清理（保留期删除）折叠在这里、按小时时间闸节流 ——
- * cron 从未触发过（见 freshness.ts 的背景说明），保留期不能指望它。
+ * 现算快照+趋势并写 KV（一次查询喂两个聚合）。清理（保留期删除）折叠在这里、
+ * 按小时时间闸节流 —— cron 从未触发过（见 freshness.ts 的背景说明），
+ * 保留期不能指望它。
  */
 async function recomputeSnapshot(env: Env, nowSec: number): Promise<Snapshot> {
   const rows = await queryRawRows(env, nowSec);
   const snapshot = buildSnapshot(rows, nowSec);
   snapshot.ttftBinEdges = [...TTFT_BIN_EDGES_MS];
+  const trend = buildTrends(rows, nowSec);
+  trend.ttftBinEdges = [...TTFT_BIN_EDGES_MS];
 
   const rawCutoff = hourFloorUtc(nowSec - RAW_RETENTION_SECS);
   const rlCutoff = hourFloorUtc(nowSec - RATE_LIMIT_RETENTION_SECS);
@@ -66,30 +72,33 @@ async function recomputeSnapshot(env: Env, nowSec: number): Promise<Snapshot> {
     await env.SNAPSHOT.put(CLEANUP_LAST_RUN_KEY, String(nowSec));
   })();
 
-  await Promise.all([env.SNAPSHOT.put(SNAPSHOT_KEY, JSON.stringify(snapshot)), cleanup]);
+  await Promise.all([
+    env.SNAPSHOT.put(SNAPSHOT_KEY, JSON.stringify(snapshot)),
+    env.SNAPSHOT.put(TREND_KEY, JSON.stringify(trend)),
+    cleanup,
+  ]);
   return snapshot;
 }
 
-async function handleSnapshot(env: Env, allowCompute: boolean): Promise<Response> {
+/** 与快照同款：KV 新鲜直回、陈旧/缺失走现算自愈（CDN 60s 限流并发重算）。 */
+async function serveKvPayload(
+  env: Env,
+  key: string,
+  recompute: () => Promise<unknown>,
+): Promise<Response> {
   const nowSec = Math.floor(Date.now() / 1000);
-  const cached = await env.SNAPSHOT.get(SNAPSHOT_KEY);
-  // 新鲜（≤10min）直接回缓存；陈旧/缺失且允许计算 → 请求路径里现算自愈。
-  // 并发重算由前面的 CDN 缓存（max-age=60）天然限流到约每分钟一次。
-  if (cached !== null && (isFresh(cached, nowSec) || !allowCompute)) {
-    return new Response(cached, {
-      status: 200,
-      headers: {
-        "content-type": "application/json; charset=utf-8",
-        "cache-control": SNAPSHOT_CACHE_CONTROL,
-        ...CORS_HEADERS,
-      },
-    });
+  const cached = await env.SNAPSHOT.get(key);
+  if (cached !== null && isFresh(cached, nowSec)) {
+    return cachedResponse(cached);
   }
-  if (!allowCompute) {
-    return jsonResponse({ error: "snapshot not ready" }, 503);
-  }
-  const snapshot = await recomputeSnapshot(env, nowSec);
-  return new Response(JSON.stringify(snapshot), {
+  await recompute();
+  const fresh = await env.SNAPSHOT.get(key);
+  if (fresh === null) return jsonResponse({ error: `${key} not ready` }, 503);
+  return cachedResponse(fresh);
+}
+
+function cachedResponse(body: string): Response {
+  return new Response(body, {
     status: 200,
     headers: {
       "content-type": "application/json; charset=utf-8",
@@ -118,9 +127,12 @@ export default {
       return handleIngest(request, env);
     }
     if (request.method === "GET" && pathname === "/v1/snapshot") {
-      return handleSnapshot(env, true);
+      return serveKvPayload(env, SNAPSHOT_KEY, () => recomputeSnapshot(env, Math.floor(Date.now() / 1000)));
     }
-    if (request.method === "OPTIONS" && pathname === "/v1/snapshot") {
+    if (request.method === "GET" && pathname === "/v1/trend") {
+      return serveKvPayload(env, TREND_KEY, () => recomputeSnapshot(env, Math.floor(Date.now() / 1000)));
+    }
+    if (request.method === "OPTIONS" && (pathname === "/v1/snapshot" || pathname === "/v1/trend")) {
       return new Response(null, { status: 204, headers: CORS_HEADERS });
     }
     if (request.method === "GET" && pathname === "/healthz") {

--- a/crowd-metrics/src/types.ts
+++ b/crowd-metrics/src/types.ts
@@ -69,3 +69,27 @@ export interface Snapshot {
    *  悬浮提示需要真实毫秒区间，而边界调整必须与聚合侧同源。 */
   ttftBinEdges?: number[];
 }
+
+/** 趋势图的一个时间桶（GET /v1/trend）。k-匿未达标的桶各指标为 null。 */
+export interface TrendBucket {
+  /** 桶起点（epoch 秒，UTC）。 */
+  start: number;
+  p50Ms: number | null;
+  p95Ms: number | null;
+  errRate: number | null;
+  cacheRate: number | null;
+}
+
+export interface SiteTrend {
+  buckets: TrendBucket[];
+  /** 该范围内合并的 TTFT 直方图（分布图随时间范围联动用）。 */
+  ttftBins: number[];
+}
+
+/** 档位 → 站点趋势。 */
+export type TrendPayload = {
+  version: 1;
+  generatedAt: number;
+  ranges: Record<'24h' | '7d' | '30d', { bucketSeconds: number; sites: Record<string, SiteTrend> }>;
+  ttftBinEdges?: number[];
+};


### PR DESCRIPTION
P1（spec-站点实测监控升级分期，design 仓）：24h=24×1h、7d=56×3h、30d=60×12h 三档一包，每桶 p50/p95/错误率/缓存率 + 范围合并分布。逐桶 k-匿与时段槽同款（受信来源门槛、不加 ASN——桶天然稀疏）；原始桶查询 7d→30d（一次查询喂快照+趋势）；KV trend:v1 与 snapshot 同拍写同自愈。客户端零改动（纯增量端点，旧消费方不受影响）。

- 测试 +4（63 绿）：档位粒度与桶数、网格对齐与空桶占位、逐桶 k-匿、分布累计口径
- KV 写 2/拍 × 288 = 576 写/天（免费档 1000 内）