### PR TITLE
chore(release): bump 版本号至 6.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-switch",
-  "version": "6.15.3",
+  "version": "6.16.0",
   "description": "All-in-One Assistant for Claude Code, Codex & Gemini CLI",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "cc-switch"
-version = "6.15.3"
+version = "6.16.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # （裁决见 CLAUDE.md「三点五」）。面向用户的二进制名走 tauri.conf.json 的
 # `mainBinaryName`（已是 `LoongPort`）。
 name = "cc-switch"
-version = "6.15.3"
+version = "6.16.0"
 description = "同样的 Codex，成本省 95% 以上 —— 填一个域名、登录一次，其余自动配好"
 authors = ["SailingLoong", "Jason Young"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LoongPort",
   "mainBinaryName": "LoongPort",
-  "version": "6.15.3",
+  "version": "6.16.0",
   "identifier": "dev.loongport.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary / 概述

v6.16.0 发版 bump（package.json / Cargo.toml / tauri.conf.json / Cargo.lock 四处）。

本版窗口（v6.15.3 之后）：广场白名单=展示充分条件修根（#285+#287 端到端闸）、收录 Airelay（#284，remote-config 已部署）、致命错误账号级跳过（#279）、看板「当前」徽章实时（#280）、实测 errors 口径收窄（#281）、k-匿门槛临时 1/1（#282）、看板余额后端 SWR（#283）、余额刷新与模式/视图解耦（#286）。

## Related Issue / 关联 Issue

Fixes #

## Screenshots / 截图

不适用。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查（仅版本号）
- [x] `pnpm format:check` passes / 通过代码格式检查（仅版本号）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（仅版本号）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（无文案变更）
