### PR TITLE
feat(i18n): 广场空态提示搜索框可直接添加站点

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3207,7 +3207,7 @@
       "errorTitle": "Could not load the relay directory",
       "errorBody": "Neither live data nor the last successful cache is available.",
       "refreshFailed": "Could not refresh the VeriDrop leaderboard: {{reason}}",
-      "empty": "No sites match the current filters",
+      "empty": "No sites match the current filters — type in the search box to add one directly",
       "scoreLabel": "VeriDrop",
       "signatureHint": "Claude thinking-signature verification rate",
       "transit": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3207,7 +3207,7 @@
       "errorTitle": "中継サイト一覧を読み込めません",
       "errorBody": "ライブデータと前回成功時のキャッシュのどちらも利用できません。",
       "refreshFailed": "VeriDrop ランキングを更新できませんでした：{{reason}}",
-      "empty": "現在の条件に一致するサイトはありません",
+      "empty": "現在の条件に一致するサイトはありません。検索ボックスから直接追加できます",
       "scoreLabel": "VeriDrop",
       "signatureHint": "Claude 思考署名の検証成功率",
       "transit": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3208,7 +3208,7 @@
       "errorTitle": "無法讀取中轉站排行榜",
       "errorBody": "即時資料與上次成功快取皆無法使用。",
       "refreshFailed": "重新整理 VeriDrop 排行榜失敗：{{reason}}",
-      "empty": "沒有符合目前篩選條件的站點",
+      "empty": "沒有符合目前篩選條件的站點，搜尋框可以直接新增",
       "scoreLabel": "VeriDrop",
       "signatureHint": "Claude 思維簽名驗證通過率",
       "transit": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -3207,7 +3207,7 @@
       "errorTitle": "无法读取中转站榜单",
       "errorBody": "实时数据和上次成功缓存均不可用。",
       "refreshFailed": "刷新 VeriDrop 榜单失败：{{reason}}",
-      "empty": "没有符合当前筛选条件的站点",
+      "empty": "没有符合当前筛选条件的站点，搜索框可以直接添加",
       "scoreLabel": "VeriDrop",
       "signatureHint": "Claude 思维签名验证通过率",
       "transit": {


### PR DESCRIPTION
## 动机

广场临时下线（#291/#292 远端撤空）期间，存量版本用户打开广场 tab 会高频撞上空态「没有符合当前筛选条件的站点」。原文案只说了"没有"，没说下一步能干什么。

## 变更

`loongport.directory.empty` 四语言补操作指引（广场搜索框本就有 noMatch 就地转添加能力，空态文案此前未提及）：

- zh：没有符合当前筛选条件的站点，**搜索框可以直接添加**
- zh-TW：沒有符合目前篩選條件的站點，**搜尋框可以直接新增**（沿用繁中既有「搜尋/新增」译法）
- en：No sites match the current filters — **type in the search box to add one directly**
- ja：現在の条件に一致するサイトはありません。**検索ボックスから直接追加できます**

## 验证

- `loongportLocales.test.ts` + `RelayDirectoryPage.test.tsx` 全过（47 测；页面测试断言 i18n key 不钉文案值）
- `pnpm format:check` 过

注：文案需随下个版本发版才到用户；远端配置侧无变更。