### PR TITLE
fix(remote-config): 广场下线遗留两件——闸不变量与闸生效范围

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,12 @@ jobs:
               - "src-tauri/**"
               - "rust-toolchain.toml"
               - ".github/workflows/**"
+              # 仓内 remote-config 的字节被闸测试 include_str!/include_bytes!
+              # 编译期嵌入（remote_config.rs 的 checked_in_config_*）——改它
+              # 等于改 backend 的测试输入。漏在这里的代价实测过：2026-09-06
+              # sponsors 撤空那次提交两条 Backend Checks 都没跑，坏不变量
+              # 直接进了 main，下一个碰 src-tauri 的 PR 替它红。
+              - "remote-config/**"
 
   frontend:
     name: Frontend Checks

--- a/src-tauri/src/relay/remote_config.rs
+++ b/src-tauri/src/relay/remote_config.rs
@@ -1681,7 +1681,11 @@ mod tests {
         let cfg = parse_verified(PUBLIC_KEY_HEX, body.as_bytes(), Some(sig))
             .expect("仓内 config.json + .sig 必须过客户端同一套验签与解析");
 
-        assert!(!cfg.sponsors.is_empty(), "推荐列表不该是空的");
+        // sponsors 允许为空：2026-09-06 起推荐屏随广场临时下线（站长推广期的
+        // 运营决策，恢复 = 回填 sponsors + 重新签名部署，见 c4296132）。有意的
+        // 运营状态不归这道闸管 —— 它拦的是「改了 JSON 忘了重签 / 写出客户端
+        // 解不出的形状」这类**事故**。下面的逐条校验在空列表上自然空转，
+        // 回填那天自动恢复约束力，无需再改本测试。
         for sponsor in &cfg.sponsors {
             assert!(
                 sponsor.site_origin.starts_with("https://"),


### PR DESCRIPTION
## 背景

PR #294 的 Backend Checks 在 main 上红了（与本 PR 无关）：`checked_in_config_passes_the_clients_own_gate` 挂在 `!sponsors.is_empty()`。根因是今早 c4296132（推荐屏随广场下线、sponsors 撤空）没带闸测试的跟进——而它当时没红的原因才是更大的问题：

## 缺口

ci.yml 的 changed-areas 过滤器里 **`remote-config/**` 不在任何桶** ⇒ 配置-only 提交两条 Backend Checks 都跳过。这道专为 config.json 设的闸（注释里写明动因：「改了 JSON 忘了重签…CI 层面是空的」）**从没在它该拦的变更上生效过**——签名/形状事故照样直接进 main，只是这次恰好撞上一个碰 src-tauri 的后继 PR 才暴露。

## 变更

1. **闸测试**：sponsors 为空改为合法线下态（站长推广期临时下线，恢复=回填+重签部署）。有意的运营状态不归闸管，闸拦的是事故（忘重签/坏形状）。逐 sponsor 校验在空列表上空转，恢复那天自动恢复约束力，测试零改动。
2. **ci.yml**：`remote-config/**` 归入 backend 桶——闸测试 `include_str!`/`include_bytes!` 把这份文件在**编译期**嵌进测试，改它就是改 backend 的测试输入。

## 验证

- 本地已用生产公钥 openssl 验签当前 config.json/.sig 对（Signature Verified Successfully）；aff_codes 32 键无空值
- 移除非空断言后测试其余断言全部满足（sponsors 循环空转）

合入后 `gh pr update-branch 294` 触发重跑，解除 #294 阻塞。