### PR TITLE
feat(crowd): P4a 模型维度数据管道——客户端 v2 载荷 + Worker 新表/模型趋势

### DIFF
--- a/crowd-metrics/schema.sql
+++ b/crowd-metrics/schema.sql
@@ -40,3 +40,26 @@ CREATE TABLE IF NOT EXISTS upload_ip_hour (
     count   INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (ip_hash, hour)
 ) WITHOUT ROWID;
+
+-- P4 模型维度原始桶（v2 客户端）。一行 = 某来源在某小时对某站点某 app 某
+-- 模型的聚合。与 bucket_raw 同款幂等（PK + INSERT OR REPLACE）与反作弊列；
+-- 站点级聚合仍走 bucket_raw（顶层字段是全量口径），本表只喂模型维度的趋势/分布。
+CREATE TABLE IF NOT EXISTS bucket_model_raw (
+    hour                TEXT    NOT NULL,
+    site                TEXT    NOT NULL,
+    app                 TEXT    NOT NULL,
+    model               TEXT    NOT NULL,
+    source              TEXT    NOT NULL,
+    asn                 INTEGER NOT NULL DEFAULT 0,
+    ua_trusted          INTEGER NOT NULL DEFAULT 0,
+    samples             INTEGER NOT NULL,
+    errors              INTEGER NOT NULL,
+    ttft_bins           TEXT    NOT NULL,
+    tps_bins            TEXT    NOT NULL,
+    input_tokens        INTEGER NOT NULL,
+    output_tokens       INTEGER NOT NULL,
+    cache_read_tokens   INTEGER NOT NULL,
+    cache_creation_tokens INTEGER NOT NULL,
+    cost_usd_micros     INTEGER NOT NULL,
+    PRIMARY KEY (hour, site, app, model, source)
+) WITHOUT ROWID;

--- a/crowd-metrics/src/aggregate.test.ts
+++ b/crowd-metrics/src/aggregate.test.ts
@@ -3,12 +3,14 @@ import { describe, expect, it } from "vitest";
 import {
   buildSnapshot,
   buildTrends,
+  type RawModelRow,
   COHORT_FACTOR,
   MIN_ASN,
   MIN_SOURCES,
   type RawRow,
 } from "./aggregate";
 import { hourFloorUtc } from "./validate";
+import { TPS_BIN_COUNT } from "./bins";
 import { TTFT_BIN_COUNT } from "./bins";
 
 // 固定「现在」：2026-08-26T12:00:00Z。测试用 example 域名（公开仓隐私纪律）。
@@ -291,5 +293,50 @@ describe("趋势（buildTrends）", () => {
     const bins = trend.ranges["24h"].sites["example.com"].ttftBins;
     const sum = bins.reduce((s, c) => s + c, 0);
     expect(sum).toBe(30); // 3 来源 × 10 样本全落 bin[2]
+  });
+});
+
+describe("趋势模型维度（P4）", () => {
+  const modelRaw = (overrides: Partial<RawModelRow> = {}): RawModelRow => ({
+    hour: hourFloorUtc(NOW - 3600),
+    site: "example.com",
+    app: "claude",
+    model: "gpt-example",
+    source: "src-m",
+    asn: 4134,
+    ua_trusted: 1,
+    samples: 10,
+    errors: 1,
+    ttft_bins: makeRaw().ttft_bins, // 已是 JSON 字符串，别再包一层
+    tps_bins: JSON.stringify(new Array<number>(TPS_BIN_COUNT).fill(0).map((_, i) => (i === 4 ? 10 : 0))),
+    input_tokens: 1000,
+    output_tokens: 500,
+    cache_read_tokens: 300,
+    cache_creation_tokens: 100,
+    cost_usd_micros: 100_000,
+    ...overrides,
+  });
+
+  it("模型趋势挂到站点 trend 的 models 下，桶粒度与站点一致", () => {
+    const trend = buildTrends(sources(3), NOW, [modelRaw(), modelRaw({ source: "src-m2" })]);
+    const site = trend.ranges["24h"].sites["example.com"];
+    const model = site.models?.["gpt-example"];
+    expect(model).toBeDefined();
+    expect(model!.buckets).toHaveLength(24);
+    const dataBucket = model!.buckets[22];
+    expect(dataBucket.p50Ms).not.toBeNull();
+    expect(dataBucket.tpsP50Ms).not.toBeNull();
+    expect(dataBucket.errRate).toBeCloseTo(0.1);
+  });
+
+  it("模型桶逐 k-匿：单未受信源不发布", () => {
+    const trend = buildTrends(sources(3), NOW, [modelRaw({ ua_trusted: 0 })]);
+    const site = trend.ranges["24h"].sites["example.com"];
+    expect(site.models?.["gpt-example"]).toBeUndefined();
+  });
+
+  it("无模型数据时 sites 不带 models 键（v1 期形状不变）", () => {
+    const trend = buildTrends(sources(3), NOW);
+    expect(trend.ranges["24h"].sites["example.com"].models).toBeUndefined();
   });
 });

--- a/crowd-metrics/src/aggregate.ts
+++ b/crowd-metrics/src/aggregate.ts
@@ -21,10 +21,11 @@
  * 花费参考值 = 微美元 / 总 token（$/Mtok，模型混合会拉偏，展示侧标「参考」）。
  */
 
-import { binMidpoint, quantileFromBins, TTFT_BIN_COUNT } from "./bins";
+import { binMidpoint, quantileFromBins, TPS_BIN_COUNT, tpsQuantileFromBins, TTFT_BIN_COUNT } from "./bins";
 import { hourToEpochSec } from "./validate";
 import type {
   HourSlot,
+  SiteTrendLite,
   SiteStats,
   SiteTrend,
   Snapshot,
@@ -417,8 +418,9 @@ function trendBucketOrNull(bucketRows: ParsedRow[]): { bucket: TrendBucket; bins
   };
 }
 
-/** 由原始桶行构建三档趋势（30 天原始数据一次查询复用）。 */
-export function buildTrends(rows: RawRow[], nowSec: number): TrendPayload {
+/** 由原始桶行构建三档趋势（30 天原始数据一次查询复用）。
+ *  P4：同时按模型出趋势（modelRows 来自 bucket_model_raw；v1 期数据缺省为空）。 */
+export function buildTrends(rows: RawRow[], nowSec: number, modelRows: RawModelRow[] = []): TrendPayload {
   const bySite = new Map<string, ParsedRow[]>();
   for (const row of rows) {
     const parsed = parseRow(row);
@@ -426,6 +428,14 @@ export function buildTrends(rows: RawRow[], nowSec: number): TrendPayload {
     const list = bySite.get(parsed.site) ?? [];
     list.push(parsed);
     bySite.set(parsed.site, list);
+  }
+  const bySiteModel = new Map<string, ParsedModelRow[]>();
+  for (const row of modelRows) {
+    const parsed = parseModelRow(row);
+    if (parsed === null) continue;
+    const list = bySiteModel.get(parsed.site) ?? [];
+    list.push(parsed);
+    bySiteModel.set(parsed.site, list);
   }
 
   const ranges: TrendPayload["ranges"] = {} as TrendPayload["ranges"];
@@ -456,11 +466,125 @@ export function buildTrends(rows: RawRow[], nowSec: number): TrendPayload {
           buckets.push({ start: bStart, p50Ms: null, p95Ms: null, errRate: null, cacheRate: null });
         }
       }
-      if (anyPublished) sites[site] = { buckets, ttftBins: rangeBins };
+      if (!anyPublished) continue;
+
+      // P4：该站在此档的模型趋势（逐 (site, model, bucket) 过 k-匿，
+      // 与站点桶同款规则；tpsP50Ms 从 tps 直方图求）。
+      const models: Record<string, SiteTrendLite> = {};
+      const siteModelRows = bySiteModel.get(site) ?? [];
+      const modelsSeen = new Map<string, ParsedModelRow[]>();
+      for (const row of siteModelRows) {
+        if (row.epoch < start || row.epoch > endHour) continue;
+        const list = modelsSeen.get(row.model) ?? [];
+        list.push(row);
+        modelsSeen.set(row.model, list);
+      }
+      for (const [model, modelRowsOf] of modelsSeen) {
+        const modelBuckets: TrendBucket[] = [];
+        let modelPublished = false;
+        for (let i = 0; i < bucketCount; i++) {
+          const bStart = start + i * bucketSecs;
+          const bEnd = bStart + bucketSecs;
+          const bucketRows = modelRowsOf.filter((r) => r.epoch >= bStart && r.epoch < bEnd);
+          const computed = bucketRows.length > 0 ? trendModelBucketOrNull(bucketRows) : null;
+          if (computed) {
+            computed.start = bStart;
+            modelBuckets.push(computed);
+            modelPublished = true;
+          } else {
+            modelBuckets.push({ start: bStart, p50Ms: null, p95Ms: null, errRate: null, cacheRate: null });
+          }
+        }
+        if (modelPublished) models[model] = { buckets: modelBuckets } satisfies SiteTrendLite;
+      }
+
+      sites[site] = { buckets, ttftBins: rangeBins, ...(Object.keys(models).length > 0 ? { models } : {}) };
     }
 
     ranges[key] = { bucketSeconds: bucketSecs, sites };
   }
 
   return { version: 1, generatedAt: nowSec, ranges };
+}
+
+/** P4：bucket_model_raw 的一行。 */
+export interface RawModelRow {
+  hour: string;
+  site: string;
+  app: string;
+  model: string;
+  source: string;
+  asn: number;
+  ua_trusted: number;
+  samples: number;
+  errors: number;
+  ttft_bins: string;
+  tps_bins: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
+  cost_usd_micros: number;
+}
+
+interface ParsedModelRow {
+  epoch: number;
+  site: string;
+  model: string;
+  source: string;
+  uaTrusted: boolean;
+  samples: number;
+  errors: number;
+  ttftBins: number[];
+  tpsBins: number[];
+}
+
+function parseModelRow(row: RawModelRow): ParsedModelRow | null {
+  let ttftBins: number[];
+  let tpsBins: number[];
+  try {
+    const a: unknown = JSON.parse(row.ttft_bins);
+    const b: unknown = JSON.parse(row.tps_bins);
+    if (!Array.isArray(a) || a.length !== TTFT_BIN_COUNT) return null;
+    if (!Array.isArray(b) || b.length !== TPS_BIN_COUNT) return null;
+    ttftBins = a as number[];
+    tpsBins = b as number[];
+  } catch {
+    return null;
+  }
+  return {
+    epoch: hourToEpochSec(row.hour),
+    site: row.site,
+    model: row.model,
+    source: row.source,
+    uaTrusted: row.ua_trusted === 1,
+    samples: row.samples,
+    errors: row.errors,
+    ttftBins,
+    tpsBins,
+  };
+}
+
+/** P4：模型桶指标（k-匿与站点桶同款；不过门槛返回 null —— 不发布）。 */
+function trendModelBucketOrNull(
+  bucketRows: ParsedModelRow[],
+): (TrendBucket & { tpsP50Ms: number | null }) | null {
+  const trusted = bucketRows.filter((r) => r.uaTrusted);
+  const sources = new Set(trusted.map((r) => r.source)).size;
+  if (sources < MIN_SOURCES) return null;
+  const totals = { samples: 0, errors: 0, ttftBins: new Array<number>(TTFT_BIN_COUNT).fill(0), tpsBins: new Array<number>(TPS_BIN_COUNT).fill(0) };
+  for (const r of bucketRows) {
+    totals.samples += r.samples;
+    totals.errors += r.errors;
+    for (let i = 0; i < TTFT_BIN_COUNT; i++) totals.ttftBins[i] += r.ttftBins[i];
+    for (let i = 0; i < TPS_BIN_COUNT; i++) totals.tpsBins[i] += r.tpsBins[i];
+  }
+  return {
+    start: 0,
+    p50Ms: quantileFromBins(totals.ttftBins, 0.5),
+    p95Ms: quantileFromBins(totals.ttftBins, 0.95),
+    errRate: totals.samples > 0 ? totals.errors / totals.samples : null,
+    cacheRate: null,
+    tpsP50Ms: tpsQuantileFromBins(totals.tpsBins, 0.5),
+  };
 }

--- a/crowd-metrics/src/bins.ts
+++ b/crowd-metrics/src/bins.ts
@@ -21,6 +21,52 @@ export const TTFT_BIN_COUNT = TTFT_BIN_EDGES_MS.length + 1;
 /** 溢出桶的上界外推值（[9600, ∞) 无法插值，按 1.5×末边外推）。 */
 const OVERFLOW_HI_MS = TTFT_BIN_EDGES_MS[TTFT_BIN_EDGES_MS.length - 1] * 1.5;
 
+/**
+ * TPS（输出速度，tokens/秒）直方图分桶边界，单位 tok/s。
+ *
+ * P4 引入（模型维度的输出速度分布）：与 TTFT 同样的跨语言共享常量
+ * （客户端 bins.rs 同名常量 + 一致性闸测试）。桶语义同上：最后一个桶是
+ * 溢出桶 [480, ∞)。分桶的行值 = output_tokens / max((latency -
+ * first_token)/1s, 0.1s)，只统计 output_tokens > 0 的行。
+ */
+export const TPS_BIN_EDGES: readonly number[] = [
+  5, 10, 20, 40, 60, 80, 120, 160, 240, 320, 480,
+];
+
+/** TPS 桶数 = 边界数 + 1（含溢出桶）。 */
+export const TPS_BIN_COUNT = TPS_BIN_EDGES.length + 1;
+
+/** 溢出桶的上界外推值（[480, ∞) 按 1.5×末边外推）。 */
+const TPS_OVERFLOW_HI = TPS_BIN_EDGES[TPS_BIN_EDGES.length - 1] * 1.5;
+
+/** TPS 桶 i 的 [lo, hi) 边界（lo_0 = 0）。 */
+export function tpsBinBounds(i: number): { lo: number; hi: number } {
+  const lo = i === 0 ? 0 : TPS_BIN_EDGES[i - 1];
+  const hi = i < TPS_BIN_EDGES.length ? TPS_BIN_EDGES[i] : TPS_OVERFLOW_HI;
+  return { lo, hi };
+}
+
+/** TPS 直方图求分位数（与 quantileFromBins 同一套插值近似）。 */
+export function tpsQuantileFromBins(
+  bins: readonly number[],
+  q: number,
+): number | null {
+  const total = bins.reduce((a, b) => a + b, 0);
+  if (total === 0) return null;
+  const rank = q * (total - 1);
+  let cumulative = 0;
+  for (let i = 0; i < bins.length; i++) {
+    const count = bins[i];
+    if (count === 0) continue;
+    if (rank < cumulative + count) {
+      const { lo, hi } = tpsBinBounds(i);
+      return lo + ((rank - cumulative) / count) * (hi - lo);
+    }
+    cumulative += count;
+  }
+  return TPS_OVERFLOW_HI;
+}
+
 /** 桶 i 的 [lo, hi) 边界。 */
 export function binBounds(i: number): { lo: number; hi: number } {
   const lo = i === 0 ? 0 : TTFT_BIN_EDGES_MS[i - 1];

--- a/crowd-metrics/src/index.ts
+++ b/crowd-metrics/src/index.ts
@@ -6,7 +6,7 @@
  * - scheduled（每 5 分钟） 重算快照写 KV + 清理 30 天前的原始桶 / 2 天前的限流计数
  */
 
-import { buildSnapshot, buildTrends, type RawRow } from "./aggregate";
+import { buildSnapshot, buildTrends, type RawModelRow, type RawRow } from "./aggregate";
 import { TTFT_BIN_EDGES_MS } from "./bins";
 import { cleanupDue, isFresh } from "./freshness";
 import { handleIngest, type Env } from "./ingest";
@@ -45,6 +45,25 @@ async function queryRawRows(env: Env, nowSec: number): Promise<RawRow[]> {
   return results ?? [];
 }
 
+/** P4：模型维度原始桶（v2 客户端写入；表不存在时容错为空 —— 部署顺序闸：
+ *  先跑 schema 重放（deploy.sh 自带）再进这里，但本地/灰度环境可能滞后）。 */
+async function queryModelRows(env: Env, nowSec: number): Promise<RawModelRow[]> {
+  const cutoff = hourFloorUtc(nowSec - 30 * 86400 - 3600);
+  try {
+    const { results } = await env.DB.prepare(
+      `SELECT hour, site, app, model, source, asn, ua_trusted, samples, errors,
+              ttft_bins, tps_bins, input_tokens, output_tokens,
+              cache_read_tokens, cache_creation_tokens, cost_usd_micros
+       FROM bucket_model_raw WHERE hour >= ?1 ORDER BY hour`,
+    )
+      .bind(cutoff)
+      .all<RawModelRow>();
+    return results ?? [];
+  } catch {
+    return [];
+  }
+}
+
 /** KV 里记上次清理时间的键（值 = epoch 秒）。 */
 const CLEANUP_LAST_RUN_KEY = "cleanup:last-run";
 
@@ -54,10 +73,10 @@ const CLEANUP_LAST_RUN_KEY = "cleanup:last-run";
  * 保留期不能指望它。
  */
 async function recomputeSnapshot(env: Env, nowSec: number): Promise<Snapshot> {
-  const rows = await queryRawRows(env, nowSec);
+  const [rows, modelRows] = await Promise.all([queryRawRows(env, nowSec), queryModelRows(env, nowSec)]);
   const snapshot = buildSnapshot(rows, nowSec);
   snapshot.ttftBinEdges = [...TTFT_BIN_EDGES_MS];
-  const trend = buildTrends(rows, nowSec);
+  const trend = buildTrends(rows, nowSec, modelRows);
   trend.ttftBinEdges = [...TTFT_BIN_EDGES_MS];
 
   const rawCutoff = hourFloorUtc(nowSec - RAW_RETENTION_SECS);
@@ -67,6 +86,7 @@ async function recomputeSnapshot(env: Env, nowSec: number): Promise<Snapshot> {
     if (!cleanupDue(lastRun == null ? null : Number(lastRun), nowSec)) return;
     await env.DB.batch([
       env.DB.prepare("DELETE FROM bucket_raw WHERE hour < ?1").bind(rawCutoff),
+      env.DB.prepare("DELETE FROM bucket_model_raw WHERE hour < ?1").bind(rawCutoff),
       env.DB.prepare("DELETE FROM upload_ip_hour WHERE hour < ?1").bind(rlCutoff),
     ]);
     await env.SNAPSHOT.put(CLEANUP_LAST_RUN_KEY, String(nowSec));

--- a/crowd-metrics/src/ingest.ts
+++ b/crowd-metrics/src/ingest.ts
@@ -89,8 +89,8 @@ export async function handleIngest(request: Request, env: Env): Promise<Response
     ? 1
     : 0;
 
-  const statements = parsed.payload.hours.map((b) =>
-    env.DB.prepare(
+  const statements = parsed.payload.hours.flatMap((b) => {
+    const siteRow = env.DB.prepare(
       `INSERT OR REPLACE INTO bucket_raw (
          hour, site, app, source, asn, ua_trusted,
          samples, errors, ttft_bins, ttft_count,
@@ -113,8 +113,37 @@ export async function handleIngest(request: Request, env: Env): Promise<Response
       b.cacheReadTokens,
       b.cacheCreationTokens,
       b.costUsdMicros,
-    ),
-  );
+    );
+    // P4：模型子桶落独立表（v1 载荷 models 为空 → 只有站点行）。
+    const modelRows = (b.models ?? []).map((m) =>
+      env.DB.prepare(
+        `INSERT OR REPLACE INTO bucket_model_raw (
+           hour, site, app, model, source, asn, ua_trusted,
+           samples, errors, ttft_bins, tps_bins,
+           input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+           cost_usd_micros
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)`,
+      ).bind(
+        b.hour,
+        b.site,
+        b.app,
+        m.model,
+        parsed.payload.sourceId,
+        asn,
+        uaTrusted,
+        m.samples,
+        m.errors,
+        JSON.stringify(m.ttftBins),
+        JSON.stringify(m.tpsBins),
+        m.inputTokens,
+        m.outputTokens,
+        m.cacheReadTokens,
+        m.cacheCreationTokens,
+        m.costUsdMicros,
+      ),
+    );
+    return [siteRow, ...modelRows];
+  });
   await env.DB.batch(statements);
 
   return jsonResponse({ accepted: parsed.payload.hours.length }, 202);

--- a/crowd-metrics/src/types.ts
+++ b/crowd-metrics/src/types.ts
@@ -20,6 +20,24 @@ export interface HourBucketPayload {
   cacheCreationTokens: number;
   /** 该桶总花费，微美元（整数，避免浮点漂移）。 */
   costUsdMicros: number;
+  /** P4（version 2）：模型子桶。version 1 载荷缺省。 */
+  models?: ModelBucketPayload[];
+}
+
+/** P4：站点 × app × 小时 × 模型 的子聚合（顶层字段仍是全量口径）。 */
+export interface ModelBucketPayload {
+  /** 服务端模型名（公开目录名，白名单形状校验）。 */
+  model: string;
+  samples: number;
+  errors: number;
+  ttftBins: number[];
+  /** 输出速度直方图（tok/s），长度 = TPS_BIN_COUNT。 */
+  tpsBins: number[];
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  costUsdMicros: number;
 }
 
 /** POST /v1/ingest 的载荷。一次 flush 携带若干个已闭合的小时桶。 */
@@ -84,6 +102,13 @@ export interface SiteTrend {
   buckets: TrendBucket[];
   /** 该范围内合并的 TTFT 直方图（分布图随时间范围联动用）。 */
   ttftBins: number[];
+  /** P4：模型维度的趋势（有 v2 数据才有；键=模型名）。 */
+  models?: Record<string, SiteTrendLite>;
+}
+
+/** P4：模型趋势（无范围分布 —— 站点级已有，模型级省载荷）。 */
+export interface SiteTrendLite {
+  buckets: Array<TrendBucket & { tpsP50Ms?: number | null }>;
 }
 
 /** 档位 → 站点趋势。 */

--- a/crowd-metrics/src/validate.test.ts
+++ b/crowd-metrics/src/validate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { TTFT_BIN_COUNT } from "./bins";
+import { TPS_BIN_COUNT, TTFT_BIN_COUNT } from "./bins";
 import { hourFloorUtc, hourToEpochSec, isValidSite, parseIngestPayload } from "./validate";
 import type { IngestPayload } from "./types";
 
@@ -33,6 +33,28 @@ function makePayload(overrides: Record<string, unknown> = {}): Record<string, un
     version: 1,
     sourceId: "0123456789abcdef0123456789abcdef",
     hours: [makeBucket()],
+    ...overrides,
+  };
+}
+
+/** P4：合法模型子桶（v2）。 */
+function makeModelBucket(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const ttft = new Array<number>(TTFT_BIN_COUNT).fill(0);
+  ttft[1] = 8;
+  const tps = new Array<number>(TPS_BIN_COUNT).fill(0);
+  tps[4] = 6;
+  tps[5] = 2;
+  return {
+    model: "gpt-example",
+    samples: 10,
+    errors: 1,
+    ttftBins: ttft,
+    tpsBins: tps,
+    inputTokens: 1000,
+    outputTokens: 500,
+    cacheReadTokens: 300,
+    cacheCreationTokens: 100,
+    costUsdMicros: 12_345,
     ...overrides,
   };
 }
@@ -77,8 +99,38 @@ describe("parseIngestPayload", () => {
     }
   });
 
-  it("版本不是 1 拒绝", () => {
+  it("版本不是 1/2 拒绝（v2 自 P4 起接受）", () => {
+    expect(parseIngestPayload(makePayload({ version: 3 }), NOW).ok).toBe(false);
+    expect(parseIngestPayload(makePayload({ version: 2 }), NOW).ok).toBe(false); // v2 必须 models
+  });
+
+  it("v2：模型子桶合法通过、逐位保留", () => {
+    const result = parseIngestPayload(makePayload({ version: 2, hours: [makeBucket({ models: [makeModelBucket()] })] }), NOW);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const m = result.payload.hours[0].models?.[0];
+      expect(m?.model).toBe("gpt-example");
+      expect(m?.tpsBins).toHaveLength(TPS_BIN_COUNT);
+    }
+  });
+
+  it("v2：缺 models 数组 / 坏模型名 / 子桶超母桶样本 / tps 桶长错 一律拒绝", () => {
     expect(parseIngestPayload(makePayload({ version: 2 }), NOW).ok).toBe(false);
+    expect(
+      parseIngestPayload(makePayload({ version: 2, hours: [makeBucket({ models: [makeModelBucket({ model: "bad name!" })] })] }), NOW).ok,
+    ).toBe(false);
+    expect(
+      parseIngestPayload(makePayload({ version: 2, hours: [makeBucket({ models: [makeModelBucket({ samples: 99 })] })] }), NOW).ok,
+    ).toBe(false);
+    expect(
+      parseIngestPayload(makePayload({ version: 2, hours: [makeBucket({ models: [makeModelBucket({ tpsBins: [1] })] })] }), NOW).ok,
+    ).toBe(false);
+  });
+
+  it("v1 载荷（无 models 键）照旧通过 —— 双版本兼容期", () => {
+    const result = parseIngestPayload(makePayload(), NOW);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.payload.hours[0].models).toBeUndefined();
   });
 
   it("sourceId 非 32 位小写 hex 拒绝", () => {

--- a/crowd-metrics/src/validate.ts
+++ b/crowd-metrics/src/validate.ts
@@ -5,11 +5,15 @@
  * 所有数值必须是安全非负整数且带合理上限；小时串必须日历合法且不未来、不太老。
  */
 
-import { TTFT_BIN_COUNT } from "./bins";
-import type { IngestPayload } from "./types";
+import { TPS_BIN_COUNT, TTFT_BIN_COUNT } from "./bins";
+import type { IngestPayload, ModelBucketPayload } from "./types";
 
-export const MAX_BODY_BYTES = 64 * 1024;
+export const MAX_BODY_BYTES = 256 * 1024;
 export const MAX_HOURS_PER_UPLOAD = 200;
+/** P4：单小时桶的模型子桶数上限（长尾模型归 UI 侧聚合，这里只防垃圾填充）。 */
+const MAX_MODELS_PER_BUCKET = 64;
+/** 模型名形状：公开目录名 —— 字母数字与常规分隔符，拒绝任意可注入文本。 */
+const MODEL_RE = /^[A-Za-z0-9][A-Za-z0-9._\/:+-]{0,119}$/;
 /** 单桶请求数上限：一小时十万次请求必然是脏数据。 */
 const MAX_SAMPLES = 100_000;
 /** token / 花费字段的数量级上限（防溢出与垃圾填充）。 */
@@ -90,7 +94,7 @@ export function parseIngestPayload(
   }
   const obj = json as Record<string, unknown>;
 
-  if (obj.version !== 1) {
+  if (obj.version !== 1 && obj.version !== 2) {
     return { ok: false, error: "unsupported version" };
   }
   if (typeof obj.sourceId !== "string" || !SOURCE_RE.test(obj.sourceId)) {
@@ -159,6 +163,75 @@ export function parseIngestPayload(
       return { ok: false, error: "ttftBins sum != ttftCount" };
     }
 
+    // P4（version 2）：模型子桶。v1 载荷没有 models 键 —— 跳过。
+    let models: ModelBucketPayload[] | undefined;
+    if (obj.version === 2) {
+      if (!Array.isArray(b.models)) {
+        return { ok: false, error: "v2 hour bucket must carry models array" };
+      }
+      if (b.models.length > MAX_MODELS_PER_BUCKET) {
+        return { ok: false, error: `too many model buckets (>${MAX_MODELS_PER_BUCKET})` };
+      }
+      const modelSeen = new Set<string>();
+      models = [];
+      for (const rawModel of b.models) {
+        if (typeof rawModel !== "object" || rawModel === null) {
+          return { ok: false, error: "model bucket must be an object" };
+        }
+        const m = rawModel as Record<string, unknown>;
+        if (typeof m.model !== "string" || !MODEL_RE.test(m.model)) {
+          return { ok: false, error: `bad model: ${String(m.model)}` };
+        }
+        if (modelSeen.has(m.model)) {
+          return { ok: false, error: "duplicate model bucket" };
+        }
+        modelSeen.add(m.model);
+        const mSamples = m.samples;
+        const mErrors = m.errors;
+        if (!isSafeUint(mSamples, samples)) {
+          return { ok: false, error: "bad model samples (must be <= bucket samples)" };
+        }
+        if (!isSafeUint(mErrors, mSamples)) {
+          return { ok: false, error: "bad model errors" };
+        }
+        if (
+          !isSafeUint(m.inputTokens, MAX_COUNT) ||
+          !isSafeUint(m.outputTokens, MAX_COUNT) ||
+          !isSafeUint(m.cacheReadTokens, MAX_COUNT) ||
+          !isSafeUint(m.cacheCreationTokens, MAX_COUNT) ||
+          !isSafeUint(m.costUsdMicros, MAX_COUNT)
+        ) {
+          return { ok: false, error: "bad model token/cost counters" };
+        }
+        if (
+          !Array.isArray(m.ttftBins) ||
+          m.ttftBins.length !== TTFT_BIN_COUNT ||
+          !m.ttftBins.every((c) => isSafeUint(c, mSamples))
+        ) {
+          return { ok: false, error: "bad model ttftBins" };
+        }
+        if (
+          !Array.isArray(m.tpsBins) ||
+          m.tpsBins.length !== TPS_BIN_COUNT ||
+          !m.tpsBins.every((c) => isSafeUint(c, mSamples))
+        ) {
+          return { ok: false, error: "bad model tpsBins" };
+        }
+        models.push({
+          model: m.model,
+          samples: mSamples,
+          errors: mErrors,
+          ttftBins: m.ttftBins as number[],
+          tpsBins: m.tpsBins as number[],
+          inputTokens: m.inputTokens as number,
+          outputTokens: m.outputTokens as number,
+          cacheReadTokens: m.cacheReadTokens as number,
+          cacheCreationTokens: m.cacheCreationTokens as number,
+          costUsdMicros: m.costUsdMicros as number,
+        });
+      }
+    }
+
     hours.push({
       hour: b.hour,
       site: b.site as string,
@@ -172,8 +245,9 @@ export function parseIngestPayload(
       cacheReadTokens: b.cacheReadTokens as number,
       cacheCreationTokens: b.cacheCreationTokens as number,
       costUsdMicros: b.costUsdMicros as number,
+      models,
     });
   }
 
-  return { ok: true, payload: { version: 1, sourceId: obj.sourceId, hours } };
+  return { ok: true, payload: { version: obj.version, sourceId: obj.sourceId, hours } };
 }

--- a/src-tauri/src/crowd/bins.rs
+++ b/src-tauri/src/crowd/bins.rs
@@ -31,6 +31,35 @@ pub(crate) fn ttft_bin_sum_exprs(alias: &str) -> String {
     exprs.join(", ")
 }
 
+/// 输出速度（tokens/秒）分桶上边界 —— 与 Worker 共享的第二组跨语言常量
+/// （P4 模型维度）。行值 = output_tokens / max((latency - first_token)/1s, 0.1s)，
+/// 只统计 output_tokens > 0 的行（0 输出的行没有速度语义）。
+pub const TPS_BIN_EDGES: &[i64] = &[5, 10, 20, 40, 60, 80, 120, 160, 240, 320, 480];
+
+/// TPS 桶数 = 边界数 + 1（含溢出桶）。上传载荷的 `tpsBins` 长度必须等于它。
+pub const TPS_BIN_COUNT: usize = TPS_BIN_EDGES.len() + 1;
+
+/// 逐桶计数表达式（与 `ttft_bin_sum_exprs` 同构）。行速度表达式在 SQL 里
+/// 内联生成（SQLite 无变量复用，重复求值无碍聚合正确性）。
+pub(crate) fn tps_bin_sum_exprs(alias: &str) -> String {
+    let row_tps = format!(
+        "CAST({alias}.output_tokens AS REAL) * 1000.0 / MAX({alias}.latency_ms - COALESCE({alias}.first_token_ms, 0), 100)"
+    );
+    let mut exprs = Vec::with_capacity(TPS_BIN_COUNT);
+    for i in 0..TPS_BIN_COUNT {
+        let lo = if i == 0 { 0 } else { TPS_BIN_EDGES[i - 1] };
+        let cond = if i < TPS_BIN_EDGES.len() {
+            format!("{row_tps} >= {lo} AND {row_tps} < {}", TPS_BIN_EDGES[i])
+        } else {
+            format!("{row_tps} >= {lo}")
+        };
+        exprs.push(format!(
+            "SUM(CASE WHEN {alias}.output_tokens > 0 AND ({cond}) THEN 1 ELSE 0 END)"
+        ));
+    }
+    exprs.join(", ")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -69,27 +98,20 @@ mod tests {
         );
     }
 
-    /// ⭐ 跨语言一致性闸：Rust 侧边界必须与 Worker（crowd-metrics/src/bins.ts）
-    /// 完全一致 —— 服务端按位置求和，边界分叉 = 数据垃圾。
-    #[test]
-    fn ttft_edges_match_the_worker_typescript_constant() {
-        let ts = include_str!("../../../crowd-metrics/src/bins.ts");
-
+    /// 从 bins.ts 里按常量名提取数组字面量（用 "= [" 定位 —— 类型标注
+    /// `number[]` 里也有方括号，直接找第一个 '[' 会把类型标注误当数组体）。
+    fn ts_edges(ts: &str, name: &str) -> Vec<i64> {
         let start = ts
-            .find("TTFT_BIN_EDGES_MS")
-            .expect("bins.ts 里应有 TTFT_BIN_EDGES_MS 常量");
-        // 用 "= [" 定位数组字面量 —— 类型标注 `number[]` 里也有方括号，
-        // 直接找第一个 '[' 会把类型标注误当数组体。
+            .find(name)
+            .unwrap_or_else(|| panic!("bins.ts 里应有 {name} 常量"));
         let assign_offset = ts[start..]
             .find("= [")
-            .expect("TTFT_BIN_EDGES_MS 应有数组字面量初始化");
+            .unwrap_or_else(|| panic!("{name} 应有数组字面量初始化"));
         let array_start = start + assign_offset + 2; // "= [" 的 '[' 本身
         let bracket_end = ts[array_start..]
             .find("];")
-            .expect("TTFT_BIN_EDGES_MS 数组应闭合");
-        let body = &ts[array_start + 1..array_start + bracket_end];
-
-        let ts_edges: Vec<i64> = body
+            .unwrap_or_else(|| panic!("{name} 数组应闭合"));
+        ts[array_start + 1..array_start + bracket_end]
             .split(',')
             .map(str::trim)
             .filter(|s| !s.is_empty())
@@ -97,8 +119,16 @@ mod tests {
                 s.parse::<i64>()
                     .unwrap_or_else(|_| panic!("bins.ts 里出现非整数边界: {s}"))
             })
-            .collect();
+            .collect()
+    }
 
+    /// ⭐ 跨语言一致性闸：Rust 侧边界必须与 Worker（crowd-metrics/src/bins.ts）
+    /// 完全一致 —— 服务端按位置求和，边界分叉 = 数据垃圾。
+    #[test]
+    fn ttft_edges_match_the_worker_typescript_constant() {
+        let ts = include_str!("../../../crowd-metrics/src/bins.ts");
+
+        let ts_edges = ts_edges(ts, "TTFT_BIN_EDGES_MS");
         assert_eq!(
             ts_edges, TTFT_BIN_EDGES_MS,
             "Rust 与 Worker 的 TTFT 桶边界不一致 —— 两边必须一起改"
@@ -108,6 +138,22 @@ mod tests {
         assert!(
             ts.contains("TTFT_BIN_COUNT = TTFT_BIN_EDGES_MS.length + 1"),
             "bins.ts 的 TTFT_BIN_COUNT 公式变了 —— 检查两侧桶数定义是否仍同构"
+        );
+    }
+
+    /// ⭐ TPS 边界的同款跨语言闸（P4）。
+    #[test]
+    fn tps_edges_match_the_worker_typescript_constant() {
+        let ts = include_str!("../../../crowd-metrics/src/bins.ts");
+
+        let ts_edges = ts_edges(ts, "TPS_BIN_EDGES");
+        assert_eq!(
+            ts_edges, TPS_BIN_EDGES,
+            "Rust 与 Worker 的 TPS 桶边界不一致 —— 两边必须一起改"
+        );
+        assert!(
+            ts.contains("TPS_BIN_COUNT = TPS_BIN_EDGES.length + 1"),
+            "bins.ts 的 TPS_BIN_COUNT 公式变了 —— 检查两侧桶数定义是否仍同构"
         );
     }
 }

--- a/src-tauri/src/crowd/bucket.rs
+++ b/src-tauri/src/crowd/bucket.rs
@@ -14,7 +14,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use rusqlite::params;
 
-use crate::crowd::bins::{ttft_bin_sum_exprs, TTFT_BIN_COUNT};
+use crate::crowd::bins::{tps_bin_sum_exprs, ttft_bin_sum_exprs, TPS_BIN_COUNT, TTFT_BIN_COUNT};
 use crate::database::Database;
 use crate::error::AppError;
 use crate::services::sql_helpers::fresh_input_sql;
@@ -68,6 +68,27 @@ pub struct HourBucket {
     pub cache_creation_tokens: i64,
     /// 桶内总花费（微美元）。
     pub cost_usd_micros: i64,
+    /// P4 模型维度：桶内按模型的子聚合（按模型名排序，载荷字节稳定）。
+    /// 顶层字段仍是全量口径 —— 站点级聚合/旧消费方不受影响。
+    pub models: Vec<ModelBucket>,
+}
+
+/// P4：模型维度的子聚合（站点 × app × 小时 × 模型）。
+/// 字段是 HourBucket 的子集 + tps 直方图 —— 供网站模型筛选/斩杀线图阵。
+#[derive(Debug, Clone, PartialEq)]
+pub struct ModelBucket {
+    /// 落库 `model` 原样（服务端模型名，公开目录名，无身份信息）。
+    pub model: String,
+    pub samples: i64,
+    pub errors: i64,
+    pub ttft_bins: Vec<i64>,
+    /// 输出速度直方图（tok/s，边界见 bins.rs `TPS_BIN_EDGES`），长度恒 [`TPS_BIN_COUNT`]。
+    pub tps_bins: Vec<i64>,
+    pub output_tokens: i64,
+    pub input_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub cache_creation_tokens: i64,
+    pub cost_usd_micros: i64,
 }
 
 /// SQL 切出的 provider 维度桶（站点归属尚未解析）。
@@ -80,6 +101,24 @@ struct RawBucket {
     errors: i64,
     ttft_bins: Vec<i64>,
     ttft_count: i64,
+    input_tokens: i64,
+    output_tokens: i64,
+    cache_read_tokens: i64,
+    cache_creation_tokens: i64,
+    cost_usd_micros: i64,
+}
+
+/// P4：模型维度的 provider 桶（站点归属尚未解析）。
+#[derive(Debug, Clone)]
+struct RawModelBucket {
+    hour_epoch: i64,
+    provider_id: String,
+    app_type: String,
+    model: String,
+    samples: i64,
+    errors: i64,
+    ttft_bins: Vec<i64>,
+    tps_bins: Vec<i64>,
     input_tokens: i64,
     output_tokens: i64,
     cache_read_tokens: i64,
@@ -144,6 +183,71 @@ fn query_raw_buckets(
     Ok(raw_buckets)
 }
 
+/// P4：模型维度切桶 —— 与 [`query_raw_buckets`] 同窗口同口径，只是多按
+/// `model` 分组并带 TPS 直方图。两次查询分开走（UNION ALL 会把 SQL 撑得
+/// 不可读，且模型行的列集不同）。
+fn query_raw_model_buckets(
+    db: &Database,
+    after_epoch: i64,
+    before_epoch: i64,
+) -> Result<Vec<RawModelBucket>, AppError> {
+    let ttft_exprs = ttft_bin_sum_exprs("l");
+    let tps_exprs = tps_bin_sum_exprs("l");
+    let sql = format!(
+        "SELECT CAST(l.created_at / 3600 AS INTEGER) * 3600 AS hour_epoch, \
+                l.provider_id, l.app_type, l.model, \
+                COUNT(*), \
+                SUM(CASE WHEN {site_side_error} THEN 1 ELSE 0 END), \
+                {ttft_exprs}, \
+                {tps_exprs}, \
+                SUM({fresh_input}), \
+                SUM(l.output_tokens), SUM(l.cache_read_tokens), SUM(l.cache_creation_tokens), \
+                CAST(ROUND(SUM(CAST(l.total_cost_usd AS REAL)) * 1000000.0) AS INTEGER) \
+         FROM proxy_request_logs l \
+         WHERE l.data_source = 'proxy' AND l.created_at > ?1 AND l.created_at <= ?2 \
+         GROUP BY hour_epoch, l.provider_id, l.app_type, l.model",
+        fresh_input = fresh_input_sql("l"),
+        site_side_error = SITE_SIDE_ERROR_EXPR,
+    );
+
+    let conn = crate::database::lock_conn!(db.conn);
+    let mut stmt = conn
+        .prepare(&sql)
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    let mut rows = stmt
+        .query(params![after_epoch, before_epoch])
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+    let mut raws = Vec::new();
+    while let Some(row) = rows.next().map_err(|e| AppError::Database(e.to_string()))? {
+        let mut ttft_bins = Vec::with_capacity(TTFT_BIN_COUNT);
+        for i in 0..TTFT_BIN_COUNT {
+            ttft_bins.push(row.get::<_, i64>(5 + i)?);
+        }
+        let mut tps_bins = Vec::with_capacity(TPS_BIN_COUNT);
+        for i in 0..TPS_BIN_COUNT {
+            tps_bins.push(row.get::<_, i64>(5 + TTFT_BIN_COUNT + i)?);
+        }
+        let base = 5 + TTFT_BIN_COUNT + TPS_BIN_COUNT;
+        raws.push(RawModelBucket {
+            hour_epoch: row.get(0)?,
+            provider_id: row.get(1)?,
+            app_type: row.get(2)?,
+            model: row.get(3)?,
+            samples: row.get(4)?,
+            errors: row.get(5)?,
+            ttft_bins,
+            tps_bins,
+            input_tokens: row.get(base)?,
+            output_tokens: row.get(base + 1)?,
+            cache_read_tokens: row.get(base + 2)?,
+            cache_creation_tokens: row.get(base + 3)?,
+            cost_usd_micros: row.get(base + 4)?,
+        });
+    }
+    Ok(raws)
+}
+
 /// provider → 站点身份（注册域），只保留 relay 模块登记过的站点。
 ///
 /// 判据：provider 的 base_url 指纹归到注册域后，命中 `loongport_relay` 表里任一
@@ -197,8 +301,10 @@ fn resolve_relay_hosts(
 }
 
 /// 纯函数：按 `(hour, site, app)` 合并。host 映射里没有的 provider 直接丢弃。
+/// P4：模型子桶按 `(hour, site, app, model)` 同步合并进 `HourBucket.models`。
 fn merge_by_site(
     raws: Vec<RawBucket>,
+    model_raws: Vec<RawModelBucket>,
     hosts: &HashMap<(String, String), String>,
 ) -> Vec<HourBucket> {
     let mut merged: BTreeMap<(i64, String, String), HourBucket> = BTreeMap::new();
@@ -220,6 +326,7 @@ fn merge_by_site(
             cache_read_tokens: 0,
             cache_creation_tokens: 0,
             cost_usd_micros: 0,
+            models: Vec::new(),
         });
         entry.samples += raw.samples;
         entry.errors += raw.errors;
@@ -232,6 +339,51 @@ fn merge_by_site(
         entry.cache_read_tokens += raw.cache_read_tokens;
         entry.cache_creation_tokens += raw.cache_creation_tokens;
         entry.cost_usd_micros += raw.cost_usd_micros;
+    }
+
+    // 模型子桶：并进对应 HourBucket（键必然已存在 —— 模型行来自同一查询窗口，
+    // 顶层桶先合并完；万一站点级桶被丢弃，模型行同样丢弃，不产生孤儿）。
+    let mut models: BTreeMap<(i64, String, String, String), ModelBucket> = BTreeMap::new();
+    for raw in model_raws {
+        let Some(site) = hosts.get(&(raw.provider_id.clone(), raw.app_type.clone())) else {
+            continue;
+        };
+        let key = (
+            raw.hour_epoch,
+            site.clone(),
+            raw.app_type.clone(),
+            raw.model.clone(),
+        );
+        let entry = models.entry(key).or_insert_with(|| ModelBucket {
+            model: raw.model.clone(),
+            samples: 0,
+            errors: 0,
+            ttft_bins: vec![0; TTFT_BIN_COUNT],
+            tps_bins: vec![0; TPS_BIN_COUNT],
+            output_tokens: 0,
+            input_tokens: 0,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            cost_usd_micros: 0,
+        });
+        entry.samples += raw.samples;
+        entry.errors += raw.errors;
+        for (i, count) in raw.ttft_bins.iter().enumerate() {
+            entry.ttft_bins[i] += count;
+        }
+        for (i, count) in raw.tps_bins.iter().enumerate() {
+            entry.tps_bins[i] += count;
+        }
+        entry.output_tokens += raw.output_tokens;
+        entry.input_tokens += raw.input_tokens;
+        entry.cache_read_tokens += raw.cache_read_tokens;
+        entry.cache_creation_tokens += raw.cache_creation_tokens;
+        entry.cost_usd_micros += raw.cost_usd_micros;
+    }
+    for ((hour_epoch, site, app, _), model_bucket) in models {
+        if let Some(hour_bucket) = merged.get_mut(&(hour_epoch, site.clone(), app.clone())) {
+            hour_bucket.models.push(model_bucket);
+        }
     }
     merged.into_values().collect()
 }
@@ -246,12 +398,13 @@ pub fn build_hour_buckets(
     if raws.is_empty() {
         return Ok(Vec::new());
     }
+    let model_raws = query_raw_model_buckets(db, after_epoch, before_epoch)?;
     let refs: HashSet<(String, String)> = raws
         .iter()
         .map(|raw| (raw.provider_id.clone(), raw.app_type.clone()))
         .collect();
     let hosts = resolve_relay_hosts(db, &refs)?;
-    Ok(merge_by_site(raws, &hosts))
+    Ok(merge_by_site(raws, model_raws, &hosts))
 }
 
 #[cfg(test)]
@@ -662,7 +815,7 @@ mod tests {
             "example.com".to_string(),
         );
 
-        let merged = merge_by_site(raws, &hosts);
+        let merged = merge_by_site(raws, Vec::new(), &hosts);
         assert_eq!(
             merged.len(),
             1,

--- a/src-tauri/src/crowd/uploader.rs
+++ b/src-tauri/src/crowd/uploader.rs
@@ -11,6 +11,8 @@ use std::time::Duration;
 
 use serde::Serialize;
 
+#[cfg(test)]
+use crate::crowd::bucket::ModelBucket;
 use crate::crowd::bucket::{self, HourBucket};
 use crate::database::Database;
 use crate::error::AppError;
@@ -51,11 +53,29 @@ pub(crate) struct HourBucketPayload<'a> {
     pub cache_read_tokens: i64,
     pub cache_creation_tokens: i64,
     pub cost_usd_micros: i64,
+    /// P4（version 2）：模型子桶。旧服务端忽略未知字段，发布顺序安全。
+    pub models: Vec<ModelBucketPayload<'a>>,
+}
+
+/// P4：模型维度子桶的载荷形状（与 bucket::ModelBucket 同集）。
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ModelBucketPayload<'a> {
+    pub model: &'a str,
+    pub samples: i64,
+    pub errors: i64,
+    pub ttft_bins: &'a [i64],
+    pub tps_bins: &'a [i64],
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cache_read_tokens: i64,
+    pub cache_creation_tokens: i64,
+    pub cost_usd_micros: i64,
 }
 
 fn payload_from_bucket<'a>(source_id: &'a str, buckets: &'a [HourBucket]) -> IngestPayload<'a> {
     IngestPayload {
-        version: 1,
+        version: 2,
         source_id,
         hours: buckets
             .iter()
@@ -72,6 +92,22 @@ fn payload_from_bucket<'a>(source_id: &'a str, buckets: &'a [HourBucket]) -> Ing
                 cache_read_tokens: b.cache_read_tokens,
                 cache_creation_tokens: b.cache_creation_tokens,
                 cost_usd_micros: b.cost_usd_micros,
+                models: b
+                    .models
+                    .iter()
+                    .map(|m| ModelBucketPayload {
+                        model: &m.model,
+                        samples: m.samples,
+                        errors: m.errors,
+                        ttft_bins: &m.ttft_bins,
+                        tps_bins: &m.tps_bins,
+                        input_tokens: m.input_tokens,
+                        output_tokens: m.output_tokens,
+                        cache_read_tokens: m.cache_read_tokens,
+                        cache_creation_tokens: m.cache_creation_tokens,
+                        cost_usd_micros: m.cost_usd_micros,
+                    })
+                    .collect(),
             })
             .collect(),
     }
@@ -201,6 +237,18 @@ mod tests {
             cache_read_tokens: 300,
             cache_creation_tokens: 100,
             cost_usd_micros: 12_345,
+            models: vec![ModelBucket {
+                model: "example-model".to_string(),
+                samples: 10,
+                errors: 1,
+                ttft_bins: vec![0; crate::crowd::bins::TTFT_BIN_COUNT],
+                tps_bins: vec![0; crate::crowd::bins::TPS_BIN_COUNT],
+                output_tokens: 500,
+                input_tokens: 1000,
+                cache_read_tokens: 300,
+                cache_creation_tokens: 100,
+                cost_usd_micros: 12_345,
+            }],
         }
     }
 
@@ -248,6 +296,7 @@ mod tests {
                 "errors",
                 "hour",
                 "inputTokens",
+                "models",
                 "outputTokens",
                 "samples",
                 "site",
@@ -255,6 +304,32 @@ mod tests {
                 "ttftCount",
             ],
             "小时桶的字段集合变了 —— 加字段前请回 crowd 模块文档那张表"
+        );
+
+        // P4：模型子桶的键集合同样钉死。
+        let model_json = &json["hours"][0]["models"][0];
+        let mut model_keys: Vec<&str> = model_json
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(|k| k.as_str())
+            .collect();
+        model_keys.sort_unstable();
+        assert_eq!(
+            model_keys,
+            vec![
+                "cacheCreationTokens",
+                "cacheReadTokens",
+                "costUsdMicros",
+                "errors",
+                "inputTokens",
+                "model",
+                "outputTokens",
+                "samples",
+                "tpsBins",
+                "ttftBins",
+            ],
+            "模型子桶的字段集合变了 —— 加字段前请回 crowd 模块文档那张表"
         );
 
         // 反面：身份/凭据形态一个都不许出现（判据同 relay::stats）。


### PR DESCRIPTION
P4a（spec-站点实测监控升级分期）：为模型筛选与斩杀线图阵铺数据管道。客户端改动随下版发。

- 客户端：HourBucket 增 models 子桶（site×app×hour×model：samples/errors/ttft+tps 直方图/token/花费）；载荷 version 2，顶层仍是全量口径
- TPS 直方图跨语言常量 TPS_BIN_EDGES（互锁闸泛化双断言）；行值=output_tokens/max((latency-first_token)/1s,0.1s)，只统计 output>0
- Worker：bucket_model_raw 新表（同款幂等 PK+反作弊列）；ingest v1/v2 双兼容（v2 模型名白名单形状/子桶样本≤母桶/桶长闸）；清理覆盖新表；body 上限 256K
- /v1/trend 出参增量 models（buckets 带 tpsP50Ms），逐 (site,model,bucket) 过 k-匿；v1 期形状不变
- worker 69 测试（+6）、rust crowd 13 绿（双互锁闸）、clippy 0、fmt 过

熔断计数拆 P4b（需 proxy 运行时埋点）；网站消费面下一期。