### PR TITLE
feat(crowd): P4b 熔断跳闸计数——事件表 + 载荷 v2 breakerTrips + Worker 落列

### DIFF
--- a/crowd-metrics/deploy.sh
+++ b/crowd-metrics/deploy.sh
@@ -37,6 +37,10 @@ MIGRATE_OUT=$(npx wrangler d1 execute loongport-metrics -y --remote   --command 
   echo "$MIGRATE_OUT" | grep -q "duplicate column" \
     || { echo "✘ ua_trusted 列迁移失败："; echo "$MIGRATE_OUT"; exit 1; }
 }
+MIGRATE_OUT=$(npx wrangler d1 execute loongport-metrics -y --remote   --command "ALTER TABLE bucket_raw ADD COLUMN breaker_trips INTEGER NOT NULL DEFAULT 0" 2>&1) || {
+  echo "$MIGRATE_OUT" | grep -q "duplicate column" \
+    || { echo "✘ breaker_trips 列迁移失败："; echo "$MIGRATE_OUT"; exit 1; }
+}
 
 npx wrangler deploy
 

--- a/crowd-metrics/schema.sql
+++ b/crowd-metrics/schema.sql
@@ -28,6 +28,7 @@ CREATE TABLE IF NOT EXISTS bucket_raw (
     cache_read_tokens   INTEGER NOT NULL,
     cache_creation_tokens INTEGER NOT NULL,
     cost_usd_micros     INTEGER NOT NULL, -- 该桶总花费（微美元）
+    breaker_trips       INTEGER NOT NULL DEFAULT 0, -- P4b：非致命熔断跳闸次数（站点侧信号）
     PRIMARY KEY (hour, site, app, source)
 ) WITHOUT ROWID;
 

--- a/crowd-metrics/src/ingest.ts
+++ b/crowd-metrics/src/ingest.ts
@@ -95,8 +95,8 @@ export async function handleIngest(request: Request, env: Env): Promise<Response
          hour, site, app, source, asn, ua_trusted,
          samples, errors, ttft_bins, ttft_count,
          input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
-         cost_usd_micros
-       ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)`,
+         cost_usd_micros, breaker_trips
+       ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)`,
     ).bind(
       b.hour,
       b.site,
@@ -113,6 +113,7 @@ export async function handleIngest(request: Request, env: Env): Promise<Response
       b.cacheReadTokens,
       b.cacheCreationTokens,
       b.costUsdMicros,
+      b.breakerTrips ?? 0,
     );
     // P4：模型子桶落独立表（v1 载荷 models 为空 → 只有站点行）。
     const modelRows = (b.models ?? []).map((m) =>

--- a/crowd-metrics/src/types.ts
+++ b/crowd-metrics/src/types.ts
@@ -22,6 +22,8 @@ export interface HourBucketPayload {
   costUsdMicros: number;
   /** P4（version 2）：模型子桶。version 1 载荷缺省。 */
   models?: ModelBucketPayload[];
+  /** P4b：非致命熔断跳闸次数（凭证级致命跳闸不计，同 errors 口径）。 */
+  breakerTrips?: number;
 }
 
 /** P4：站点 × app × 小时 × 模型 的子聚合（顶层字段仍是全量口径）。 */

--- a/crowd-metrics/src/validate.test.ts
+++ b/crowd-metrics/src/validate.test.ts
@@ -204,3 +204,24 @@ describe("载荷隐私边界（对应客户端 Rust 侧的同类闸）", () => {
     }
   });
 });
+
+describe("P4b 跳闸计数校验", () => {
+  it("breakerTrips 可选、合法时逐位保留", () => {
+    const r1 = parseIngestPayload(makePayload(), NOW);
+    expect(r1.ok).toBe(true);
+    if (r1.ok) expect(r1.payload.hours[0].breakerTrips).toBeUndefined();
+
+    const r2 = parseIngestPayload(makePayload({ hours: [makeBucket({ breakerTrips: 2 })] }), NOW);
+    expect(r2.ok).toBe(true);
+    if (r2.ok) expect(r2.payload.hours[0].breakerTrips).toBe(2);
+  });
+
+  it("breakerTrips 非法值拒绝", () => {
+    expect(
+      parseIngestPayload(makePayload({ hours: [makeBucket({ breakerTrips: -1 })] }), NOW).ok,
+    ).toBe(false);
+    expect(
+      parseIngestPayload(makePayload({ hours: [makeBucket({ breakerTrips: 1e9 })] }), NOW).ok,
+    ).toBe(false);
+  });
+});

--- a/crowd-metrics/src/validate.ts
+++ b/crowd-metrics/src/validate.ts
@@ -10,6 +10,8 @@ import type { IngestPayload, ModelBucketPayload } from "./types";
 
 export const MAX_BODY_BYTES = 256 * 1024;
 export const MAX_HOURS_PER_UPLOAD = 200;
+/** P4b：单桶跳闸计数上限（一小时一万次跳闸必然是脏数据）。 */
+const MAX_TRIPS_PER_BUCKET = 10_000;
 /** P4：单小时桶的模型子桶数上限（长尾模型归 UI 侧聚合，这里只防垃圾填充）。 */
 const MAX_MODELS_PER_BUCKET = 64;
 /** 模型名形状：公开目录名 —— 字母数字与常规分隔符，拒绝任意可注入文本。 */
@@ -232,12 +234,22 @@ export function parseIngestPayload(
       }
     }
 
+    // P4b：跳闸计数（可选；上限远宽于合理值 —— 防垃圾填充不防真实值）。
+    let breakerTrips: number | undefined;
+    if (b.breakerTrips !== undefined) {
+      if (!isSafeUint(b.breakerTrips, MAX_TRIPS_PER_BUCKET)) {
+        return { ok: false, error: "bad breakerTrips" };
+      }
+      breakerTrips = b.breakerTrips;
+    }
+
     hours.push({
       hour: b.hour,
       site: b.site as string,
       app: b.app,
       samples,
       errors,
+      breakerTrips,
       ttftBins: b.ttftBins as number[],
       ttftCount,
       inputTokens: b.inputTokens as number,

--- a/src-tauri/src/crowd/bucket.rs
+++ b/src-tauri/src/crowd/bucket.rs
@@ -71,6 +71,8 @@ pub struct HourBucket {
     /// P4 模型维度：桶内按模型的子聚合（按模型名排序，载荷字节稳定）。
     /// 顶层字段仍是全量口径 —— 站点级聚合/旧消费方不受影响。
     pub models: Vec<ModelBucket>,
+    /// P4b：该小时该站的非致命熔断跳闸次数（事件表计数；口径见 events.rs）。
+    pub breaker_trips: i64,
 }
 
 /// P4：模型维度的子聚合（站点 × app × 小时 × 模型）。
@@ -327,6 +329,7 @@ fn merge_by_site(
             cache_creation_tokens: 0,
             cost_usd_micros: 0,
             models: Vec::new(),
+            breaker_trips: 0,
         });
         entry.samples += raw.samples;
         entry.errors += raw.errors;
@@ -388,6 +391,29 @@ fn merge_by_site(
     merged.into_values().collect()
 }
 
+/// P4b：跳闸事件按 (hour, provider, app) 计数。返回键与 RawBucket 的
+/// provider 维度同构，复用同一张 hosts 映射。
+fn query_breaker_trip_counts(
+    db: &Database,
+    after_epoch: i64,
+    before_epoch: i64,
+) -> Result<HashMap<(i64, String, String), i64>, AppError> {
+    let conn = crate::database::lock_conn!(db.conn);
+    let mut stmt = conn
+        .prepare(
+            "SELECT hour_epoch, provider_id, app_type, COUNT(*)              FROM crowd_breaker_events              WHERE hour_epoch > ?1 AND hour_epoch <= ?2              GROUP BY hour_epoch, provider_id, app_type",
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    let mut rows = stmt
+        .query(params![after_epoch, before_epoch])
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    let mut counts = HashMap::new();
+    while let Some(row) = rows.next().map_err(|e| AppError::Database(e.to_string()))? {
+        counts.insert((row.get(0)?, row.get(1)?, row.get(2)?), row.get(3)?);
+    }
+    Ok(counts)
+}
+
 /// 组合入口：查桶 → 解析站点归属 → 合并。由 [`super::uploader`] 调用。
 pub fn build_hour_buckets(
     db: &Database,
@@ -404,7 +430,25 @@ pub fn build_hour_buckets(
         .map(|raw| (raw.provider_id.clone(), raw.app_type.clone()))
         .collect();
     let hosts = resolve_relay_hosts(db, &refs)?;
-    Ok(merge_by_site(raws, model_raws, &hosts))
+    let mut merged = merge_by_site(raws, model_raws, &hosts);
+    // P4b：跳闸计数并入。事件键是 provider 维度，先折成站点维度再对桶 ——
+    // 与桶共用同一张 hosts 映射（未登记 provider 的事件自然丢弃，无主计数不出门）。
+    let trips = query_breaker_trip_counts(db, after_epoch, before_epoch)?;
+    let mut trips_by_site: HashMap<(i64, String, String), i64> = HashMap::new();
+    for ((hour, provider, app), count) in &trips {
+        if let Some(site) = hosts.get(&(provider.clone(), app.clone())) {
+            *trips_by_site
+                .entry((*hour, site.clone(), app.clone()))
+                .or_insert(0) += count;
+        }
+    }
+    for bucket in &mut merged {
+        bucket.breaker_trips = trips_by_site
+            .get(&(bucket.hour_epoch, bucket.site.clone(), bucket.app.clone()))
+            .copied()
+            .unwrap_or(0);
+    }
+    Ok(merged)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/crowd/events.rs
+++ b/src-tauri/src/crowd/events.rs
@@ -1,0 +1,48 @@
+//! P4b：熔断跳闸事件（站点侧信号的本地事件源）。
+//!
+//! `proxy_request_logs` 里切不出「跳闸」—— 它是熔断器的状态转换，不是一行
+//! 请求日志。所以在跳闸发生时（`provider_router::record_result` 的非致命
+//! 分支）落一行事件，上传切桶时按 (hour, provider, app) 计数并入小时桶。
+//!
+//! 口径：**只记非致命跳闸**。致命跳闸（401/402/凭证级 403 一次即开）是
+//! 上传者自己的凭证/余额问题，计入会把它变成站点的公开健康分 —— 与
+//! `bucket::SITE_SIDE_ERROR_EXPR` 剔除同类失败是同一条纪律。
+//!
+//! 表是纯追加的事件流：上传幂等靠「按小时重算计数」而不是删行（行本身
+//! 不可变，重算结果稳定）；清理走 flush 时顺手裁掉 35 天前的旧行。
+
+use rusqlite::params;
+
+use crate::database::Database;
+use crate::error::AppError;
+
+/// 落一条跳闸事件。调用点在转发主链路里 —— 失败只回 Err 由调用方打日志，
+/// 绝不向上传播影响请求本身。
+pub fn record_breaker_trip(
+    db: &Database,
+    provider_id: &str,
+    app_type: &str,
+) -> Result<(), AppError> {
+    let hour_epoch = chrono::Utc::now().timestamp() / 3600 * 3600;
+    let conn = crate::database::lock_conn!(db.conn);
+    conn.execute(
+        "INSERT INTO crowd_breaker_events (hour_epoch, provider_id, app_type) VALUES (?1, ?2, ?3)",
+        params![hour_epoch, provider_id, app_type],
+    )
+    .map_err(|e| AppError::Database(e.to_string()))?;
+    Ok(())
+}
+
+/// 裁掉窗口外的旧事件（35 天 = Worker 接受上限 30 天 + 余量）。
+/// 挂在 flush 成功后调用 —— 上传节奏天然节流，不需要单独的清理任务。
+pub fn prune_old_events(db: &Database, now_epoch: i64) -> Result<u64, AppError> {
+    let cutoff = (now_epoch / 3600 * 3600) - 35 * 86400;
+    let conn = crate::database::lock_conn!(db.conn);
+    let n = conn
+        .execute(
+            "DELETE FROM crowd_breaker_events WHERE hour_epoch < ?1",
+            params![cutoff],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    Ok(n as u64)
+}

--- a/src-tauri/src/crowd/mod.rs
+++ b/src-tauri/src/crowd/mod.rs
@@ -48,5 +48,6 @@
 
 pub mod bins;
 pub mod bucket;
+pub mod events;
 pub mod snapshot;
 pub mod uploader;

--- a/src-tauri/src/crowd/uploader.rs
+++ b/src-tauri/src/crowd/uploader.rs
@@ -55,6 +55,8 @@ pub(crate) struct HourBucketPayload<'a> {
     pub cost_usd_micros: i64,
     /// P4（version 2）：模型子桶。旧服务端忽略未知字段，发布顺序安全。
     pub models: Vec<ModelBucketPayload<'a>>,
+    /// P4b：非致命熔断跳闸次数（v2 追加，同上向后兼容）。
+    pub breaker_trips: i64,
 }
 
 /// P4：模型维度子桶的载荷形状（与 bucket::ModelBucket 同集）。
@@ -92,6 +94,7 @@ fn payload_from_bucket<'a>(source_id: &'a str, buckets: &'a [HourBucket]) -> Ing
                 cache_read_tokens: b.cache_read_tokens,
                 cache_creation_tokens: b.cache_creation_tokens,
                 cost_usd_micros: b.cost_usd_micros,
+                breaker_trips: b.breaker_trips,
                 models: b
                     .models
                     .iter()
@@ -185,7 +188,11 @@ pub async fn flush_once(db: &std::sync::Arc<Database>) -> Result<(), AppError> {
     // 否则空转周期会反复重算同一段空窗口。
     let db_for_watermark = std::sync::Arc::clone(db);
     tauri::async_runtime::spawn_blocking(move || {
-        db_for_watermark.set_setting(SETTING_FLUSHED_THROUGH, &last_closed_hour.to_string())
+        db_for_watermark.set_setting(SETTING_FLUSHED_THROUGH, &last_closed_hour.to_string())?;
+        // P4b：顺手裁掉窗口外的跳闸事件（挂上传节奏，不需要单独清理任务；
+        // 失败只影响下次多裁一次，不碰上传结果）。
+        let _ = super::events::prune_old_events(&db_for_watermark, now);
+        Ok::<(), AppError>(())
     })
     .await
     .map_err(|e| AppError::Message(format!("crowd flush 水位线写入任务失败: {e}")))??;
@@ -237,6 +244,7 @@ mod tests {
             cache_read_tokens: 300,
             cache_creation_tokens: 100,
             cost_usd_micros: 12_345,
+            breaker_trips: 1,
             models: vec![ModelBucket {
                 model: "example-model".to_string(),
                 samples: 10,
@@ -290,6 +298,7 @@ mod tests {
             hour_keys,
             vec![
                 "app",
+                "breakerTrips",
                 "cacheCreationTokens",
                 "cacheReadTokens",
                 "costUsdMicros",

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -236,6 +236,26 @@ impl Database {
         .map_err(|e| AppError::Database(e.to_string()))?;
         Self::create_request_logs_usage_indexes_if_supported(conn)?;
 
+        // 10b. crowd 跳闸事件（P4b）：非致命熔断跳闸的追加式事件流，
+        // 上传切桶时按 (hour, provider, app) 计数并入小时桶；清理见
+        // crowd::events::prune_old_events。
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS crowd_breaker_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                hour_epoch INTEGER NOT NULL,
+                provider_id TEXT NOT NULL,
+                app_type TEXT NOT NULL,
+                created_at INTEGER NOT NULL
+            )",
+            [],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_crowd_breaker_hour ON crowd_breaker_events(hour_epoch, provider_id, app_type)",
+            [],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
         // 11. Model Pricing 表
         conn.execute(
             "CREATE TABLE IF NOT EXISTS model_pricing (

--- a/src-tauri/src/proxy/circuit_breaker.rs
+++ b/src-tauri/src/proxy/circuit_breaker.rs
@@ -99,6 +99,9 @@ pub struct CircuitBreaker {
     config: Arc<RwLock<CircuitBreakerConfig>>,
     /// 半开状态已放行的请求数（用于限流）
     half_open_requests: Arc<AtomicU32>,
+    /// 累计跳闸次数（含致命；单调递增）。crowd 上传只取非致命跳闸计数，
+    /// record_failure/fatal 的返回值就是「本次调用是否新跳闸」。
+    trip_count: Arc<AtomicU32>,
 }
 
 /// 熔断器对外的只读快照（看板「熔断/自动重试倒计时」用）。
@@ -133,6 +136,7 @@ impl CircuitBreaker {
             fatal_open: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             config: Arc::new(RwLock::new(config)),
             half_open_requests: Arc::new(AtomicU32::new(0)),
+            trip_count: Arc::new(AtomicU32::new(0)),
         }
     }
 
@@ -254,8 +258,10 @@ impl CircuitBreaker {
         }
     }
 
-    /// 记录失败
-    pub async fn record_failure(&self, used_half_open_permit: bool) {
+    /// 记录失败。返回**本次调用是否新跳闸**（Closed/HalfOpen → Open）——
+    /// crowd 上传用它计数站点侧跳闸（致命变体不计：那是用户自己的凭证问题）。
+    pub async fn record_failure(&self, used_half_open_permit: bool) -> bool {
+        let trips_before = self.trip_count.load(Ordering::SeqCst);
         let state = *self.state.read().await;
         let config = self.config.read().await;
 
@@ -318,6 +324,7 @@ impl CircuitBreaker {
             }
             _ => {}
         }
+        self.trip_count.load(Ordering::SeqCst) > trips_before
     }
 
     /// 记录致命失败（凭证/余额级错误，如上游 401/402/403）
@@ -329,7 +336,8 @@ impl CircuitBreaker {
     ///
     /// 致命分级只在成功（`transition_to_closed`）时清除：半开探测失败会沿用上一次
     /// 打开时的致命冷却 —— 一个曾因欠费打开的档位，探测又失败，说明它还是坏的。
-    pub async fn record_fatal_failure(&self, used_half_open_permit: bool) {
+    pub async fn record_fatal_failure(&self, used_half_open_permit: bool) -> bool {
+        let trips_before = self.trip_count.load(Ordering::SeqCst);
         let config = self.config.read().await;
 
         if used_half_open_permit {
@@ -348,6 +356,7 @@ impl CircuitBreaker {
             log_cb::TRIGGERED_FATAL
         );
         self.transition_to_open(true).await;
+        self.trip_count.load(Ordering::SeqCst) > trips_before
     }
 
     /// 只读快照：`None` = Closed（正常，不上板）。
@@ -456,6 +465,7 @@ impl CircuitBreaker {
         self.fatal_open.store(fatal, Ordering::SeqCst);
         self.consecutive_failures.store(0, Ordering::SeqCst);
         self.consecutive_successes.store(0, Ordering::SeqCst);
+        self.trip_count.fetch_add(1, Ordering::SeqCst);
     }
 
     /// 转换到半开状态
@@ -497,6 +507,30 @@ pub struct CircuitBreakerStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn record_failure_returns_tripped_only_on_transition() {
+        // P4b：跳闸返回值的语义钉死 —— 只在「本次调用导致 Closed/HalfOpen → Open」
+        // 时为 true；已在 Open 上继续失败、以及致命路径之外的成功都不算。
+        let config = CircuitBreakerConfig {
+            failure_threshold: 2,
+            timeout_seconds: 600,
+            ..Default::default()
+        };
+        let breaker = CircuitBreaker::new(config);
+        assert!(!breaker.record_failure(false).await, "第 1 次失败未到阈值");
+        assert!(breaker.record_failure(false).await, "第 2 次失败触发跳闸");
+        assert!(
+            !breaker.record_failure(false).await,
+            "已 Open 再失败不重复计跳闸"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_fatal_failure_also_reports_tripped() {
+        let breaker = CircuitBreaker::new(CircuitBreakerConfig::default());
+        assert!(breaker.record_fatal_failure(false).await, "致命一次即开");
+    }
 
     #[tokio::test]
     async fn snapshot_reports_open_with_countdown_and_closed_as_none() {

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -266,7 +266,19 @@ impl ProviderRouter {
                 }
             }
         } else {
-            breaker.record_failure(used_half_open_permit).await;
+            let tripped = breaker.record_failure(used_half_open_permit).await;
+            // 非致命跳闸落 crowd 事件表（站点侧信号；致命跳闸是用户自身凭证
+            // 问题，对齐 crowd errors 口径不计）。失败只打日志——计数是尽力而为
+            // 的统计，不能反过来影响转发主链路。
+            if tripped {
+                if let Err(e) = crate::crowd::events::record_breaker_trip(
+                    self.db.as_ref(),
+                    provider_id,
+                    app_type,
+                ) {
+                    log::debug!("[{app_type}] 记录跳闸事件失败: {e}");
+                }
+            }
         }
 
         // 3. 更新数据库健康状态（使用配置的阈值）
@@ -309,7 +321,7 @@ impl ProviderRouter {
         // 2. 更新熔断器状态（致命失败）
         let circuit_key = format!("{app_type}:{provider_id}");
         let breaker = self.get_or_create_circuit_breaker(&circuit_key).await;
-        breaker.record_fatal_failure(used_half_open_permit).await;
+        let _fatal_tripped = breaker.record_fatal_failure(used_half_open_permit).await;
 
         // 3. 账号级熔断同步打开（致命一次即开，长冷却）
         if let Some(provider) = self
@@ -320,7 +332,7 @@ impl ProviderRouter {
         {
             if let Some(account_key) = account_circuit_key(app_type, &provider) {
                 let account_breaker = self.get_or_create_circuit_breaker(&account_key).await;
-                account_breaker.record_fatal_failure(false).await;
+                let _ = account_breaker.record_fatal_failure(false).await;
             }
         }
 


### PR DESCRIPTION
P4b（spec-站点实测监控升级分期）。「这站老把人切走」的独有信号：熔断状态转换切不出自请求日志，需要运行时事件源。客户端随下版发。

- CircuitBreaker trip_count + record_failure/fatal 返回「本次是否新跳闸」（已 Open 再失败不重复计；半开探测失败再开算一次）
- provider_router 非致命跳闸落 crowd_breaker_events（追加式事件表）；**致命跳闸不计**——上传者自身凭证问题，与 errors 口径（#281）同一条纪律；落库失败只 debug 日志不碰转发主链路
- bucket.rs 按 (hour, provider, app) 计数、共用 hosts 映射折叠进 HourBucket；flush 后顺手裁 35 天外旧事件
- 载荷 v2 增 breakerTrips（键集闸同步）；Worker bucket_raw 增 breaker_trips 列（新环境 schema 一次成型 + 存量库护栏 ALTER）+ validate/ingest
- failover 次数有意不单独计：与错误率高度共线，跳闸才是独立信号

测试：rust 跳闸语义 2 例（circuit_breaker 9 绿）、worker 71 绿（+2）、clippy 0、fmt 过。