### PR TITLE
feat(crowd): 模型趋势桶补 costUsdPerMTok（P4c 价格轴前置）

### DIFF
--- a/crowd-metrics/src/aggregate.test.ts
+++ b/crowd-metrics/src/aggregate.test.ts
@@ -327,6 +327,8 @@ describe("趋势模型维度（P4）", () => {
     expect(dataBucket.p50Ms).not.toBeNull();
     expect(dataBucket.tpsP50Ms).not.toBeNull();
     expect(dataBucket.errRate).toBeCloseTo(0.1);
+    // $/Mtok = 微美元/token：100000 微美元 / (1000+500+300+100)=1900 token
+    expect(dataBucket.costUsdPerMTok).not.toBeNull();
   });
 
   it("模型桶逐 k-匿：单未受信源不发布", () => {

--- a/crowd-metrics/src/aggregate.ts
+++ b/crowd-metrics/src/aggregate.ts
@@ -537,6 +537,11 @@ interface ParsedModelRow {
   errors: number;
   ttftBins: number[];
   tpsBins: number[];
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  costUsdMicros: number;
 }
 
 function parseModelRow(row: RawModelRow): ParsedModelRow | null {
@@ -562,22 +567,36 @@ function parseModelRow(row: RawModelRow): ParsedModelRow | null {
     errors: row.errors,
     ttftBins,
     tpsBins,
+    inputTokens: row.input_tokens,
+    outputTokens: row.output_tokens,
+    cacheReadTokens: row.cache_read_tokens,
+    cacheCreationTokens: row.cache_creation_tokens,
+    costUsdMicros: row.cost_usd_micros,
   };
 }
 
 /** P4：模型桶指标（k-匿与站点桶同款；不过门槛返回 null —— 不发布）。 */
 function trendModelBucketOrNull(
   bucketRows: ParsedModelRow[],
-): (TrendBucket & { tpsP50Ms: number | null }) | null {
+): (TrendBucket & { tpsP50Ms: number | null; costUsdPerMTok: number | null }) | null {
   const trusted = bucketRows.filter((r) => r.uaTrusted);
   const sources = new Set(trusted.map((r) => r.source)).size;
   if (sources < MIN_SOURCES) return null;
-  const totals = { samples: 0, errors: 0, ttftBins: new Array<number>(TTFT_BIN_COUNT).fill(0), tpsBins: new Array<number>(TPS_BIN_COUNT).fill(0) };
+  const totals = {
+    samples: 0,
+    errors: 0,
+    ttftBins: new Array<number>(TTFT_BIN_COUNT).fill(0),
+    tpsBins: new Array<number>(TPS_BIN_COUNT).fill(0),
+    tokenTotal: 0,
+    costUsdMicros: 0,
+  };
   for (const r of bucketRows) {
     totals.samples += r.samples;
     totals.errors += r.errors;
     for (let i = 0; i < TTFT_BIN_COUNT; i++) totals.ttftBins[i] += r.ttftBins[i];
     for (let i = 0; i < TPS_BIN_COUNT; i++) totals.tpsBins[i] += r.tpsBins[i];
+    totals.tokenTotal += r.inputTokens + r.outputTokens + r.cacheReadTokens + r.cacheCreationTokens;
+    totals.costUsdMicros += r.costUsdMicros;
   }
   return {
     start: 0,
@@ -586,5 +605,7 @@ function trendModelBucketOrNull(
     errRate: totals.samples > 0 ? totals.errors / totals.samples : null,
     cacheRate: null,
     tpsP50Ms: tpsQuantileFromBins(totals.tpsBins, 0.5),
+    // $/Mtok 同站点窗口口径：微美元 / 总 token（含缓存）
+    costUsdPerMTok: totals.tokenTotal > 0 ? totals.costUsdMicros / totals.tokenTotal : null,
   };
 }

--- a/crowd-metrics/src/types.ts
+++ b/crowd-metrics/src/types.ts
@@ -110,7 +110,7 @@ export interface SiteTrend {
 
 /** P4：模型趋势（无范围分布 —— 站点级已有，模型级省载荷）。 */
 export interface SiteTrendLite {
-  buckets: Array<TrendBucket & { tpsP50Ms?: number | null }>;
+  buckets: Array<TrendBucket & { tpsP50Ms?: number | null; costUsdPerMTok?: number | null }>;
 }
 
 /** 档位 → 站点趋势。 */


### PR DESCRIPTION
P4c 前置小改：模型趋势桶（/v1/trend sites[].models）补 costUsdPerMTok——逐桶累计四类 token 与微美元，站点窗口同款口径（$/Mtok=微美元/总token含缓存）。加性出参；71 测试绿。

供网站模型筛选 UI 的单价展示与后续斩杀线图阵价格轴使用。