### PR TITLE
feat(crowd): (站点,模型,范围) 窗口聚合——斩杀线图阵散点口径

### DIFF
--- a/crowd-metrics/src/aggregate.test.ts
+++ b/crowd-metrics/src/aggregate.test.ts
@@ -331,6 +331,18 @@ describe("趋势模型维度（P4）", () => {
     expect(dataBucket.costUsdPerMTok).not.toBeNull();
   });
 
+  it("窗口聚合（P4c-2）：样本加权指标齐全", () => {
+    const trend = buildTrends(sources(3), NOW, [modelRaw(), modelRaw({ source: "src-m2" })]);
+    const win = trend.ranges["24h"].sites["example.com"].models?.["gpt-example"]?.window;
+    expect(win).toBeDefined();
+    expect(win!.samples).toBe(20);
+    expect(win!.p50Ms).not.toBeNull();
+    expect(win!.tpsP50Ms).not.toBeNull();
+    // 20 样本全落 bin[2]（[400,600)）→ rank=9.5 → 400+0.475*200=495ms
+    expect(win!.p50Ms).toBeCloseTo(495);
+    expect(win!.errRate).toBeCloseTo(0.1);
+  });
+
   it("模型桶逐 k-匿：单未受信源不发布", () => {
     const trend = buildTrends(sources(3), NOW, [modelRaw({ ua_trusted: 0 })]);
     const site = trend.ranges["24h"].sites["example.com"];

--- a/crowd-metrics/src/aggregate.ts
+++ b/crowd-metrics/src/aggregate.ts
@@ -25,6 +25,7 @@ import { binMidpoint, quantileFromBins, TPS_BIN_COUNT, tpsQuantileFromBins, TTFT
 import { hourToEpochSec } from "./validate";
 import type {
   HourSlot,
+  ModelWindowStats,
   SiteTrendLite,
   SiteStats,
   SiteTrend,
@@ -495,7 +496,10 @@ export function buildTrends(rows: RawRow[], nowSec: number, modelRows: RawModelR
             modelBuckets.push({ start: bStart, p50Ms: null, p95Ms: null, errRate: null, cacheRate: null });
           }
         }
-        if (modelPublished) models[model] = { buckets: modelBuckets } satisfies SiteTrendLite;
+        if (modelPublished) {
+          const window = modelWindowOrNull(modelRowsOf);
+          models[model] = { buckets: modelBuckets, ...(window ? { window } : {}) } satisfies SiteTrendLite;
+        }
       }
 
       sites[site] = { buckets, ttftBins: rangeBins, ...(Object.keys(models).length > 0 ? { models } : {}) };
@@ -542,6 +546,37 @@ interface ParsedModelRow {
   cacheReadTokens: number;
   cacheCreationTokens: number;
   costUsdMicros: number;
+}
+
+/** P4c-2：(站点,模型,范围) 窗口聚合 —— 样本加权合并整段（非逐桶平均），
+ *  k-匿与模型桶同款（受信来源门槛）。图阵散点用它而不是平均逐桶值：
+ *  平均会把 3 个满数据桶和 1 个空桶同等看待。 */
+function modelWindowOrNull(rows: ParsedModelRow[]): ModelWindowStats | null {
+  const trusted = rows.filter((r) => r.uaTrusted);
+  const sources = new Set(trusted.map((r) => r.source)).size;
+  if (sources < MIN_SOURCES) return null;
+  const ttftBins = new Array<number>(TTFT_BIN_COUNT).fill(0);
+  const tpsBins = new Array<number>(TPS_BIN_COUNT).fill(0);
+  let samples = 0;
+  let errors = 0;
+  let tokenTotal = 0;
+  let costUsdMicros = 0;
+  for (const r of rows) {
+    samples += r.samples;
+    errors += r.errors;
+    tokenTotal += r.inputTokens + r.outputTokens + r.cacheReadTokens + r.cacheCreationTokens;
+    costUsdMicros += r.costUsdMicros;
+    for (let i = 0; i < TTFT_BIN_COUNT; i++) ttftBins[i] += r.ttftBins[i];
+    for (let i = 0; i < TPS_BIN_COUNT; i++) tpsBins[i] += r.tpsBins[i];
+  }
+  return {
+    samples,
+    p50Ms: quantileFromBins(ttftBins, 0.5),
+    p95Ms: quantileFromBins(ttftBins, 0.95),
+    errRate: samples > 0 ? errors / samples : null,
+    tpsP50Ms: tpsQuantileFromBins(tpsBins, 0.5),
+    costUsdPerMTok: tokenTotal > 0 ? costUsdMicros / tokenTotal : null,
+  };
 }
 
 function parseModelRow(row: RawModelRow): ParsedModelRow | null {

--- a/crowd-metrics/src/types.ts
+++ b/crowd-metrics/src/types.ts
@@ -111,6 +111,19 @@ export interface SiteTrend {
 /** P4：模型趋势（无范围分布 —— 站点级已有，模型级省载荷）。 */
 export interface SiteTrendLite {
   buckets: Array<TrendBucket & { tpsP50Ms?: number | null; costUsdPerMTok?: number | null }>;
+  /** P4c-2：该范围内该 (站点,模型) 的窗口聚合（斩杀线图阵的散点口径；
+   *  范围级 k-匿未达标则缺省）。 */
+  window?: ModelWindowStats;
+}
+
+/** P4c-2：(站点,模型,范围) 窗口聚合——样本加权，非逐桶平均。 */
+export interface ModelWindowStats {
+  samples: number;
+  p50Ms: number | null;
+  p95Ms: number | null;
+  errRate: number | null;
+  tpsP50Ms: number | null;
+  costUsdPerMTok: number | null;
 }
 
 /** 档位 → 站点趋势。 */


### PR DESCRIPTION
P4c-2 前置：SiteTrendLite 增 window（样本加权窗口聚合：p50/p95/err/tpsP50/costUsdPerMTok），范围级 k-匿与模型桶同款。图阵散点用窗口口径而非逐桶平均（平均会把满桶与空桶同等看待）。加性出参；72 测试绿（+1：插值 495ms 语义钉死）。