### PR TITLE
feat(crowd): P5 模型真伪异常进众测管道（被动 Anomaly 计数）

### DIFF
--- a/crowd-metrics/deploy.sh
+++ b/crowd-metrics/deploy.sh
@@ -41,6 +41,10 @@ MIGRATE_OUT=$(npx wrangler d1 execute loongport-metrics -y --remote   --command 
   echo "$MIGRATE_OUT" | grep -q "duplicate column" \
     || { echo "✘ breaker_trips 列迁移失败："; echo "$MIGRATE_OUT"; exit 1; }
 }
+MIGRATE_OUT=$(npx wrangler d1 execute loongport-metrics -y --remote   --command "ALTER TABLE bucket_model_raw ADD COLUMN anomalies INTEGER NOT NULL DEFAULT 0" 2>&1) || {
+  echo "$MIGRATE_OUT" | grep -q "duplicate column" \
+    || { echo "✘ bucket_model_raw.anomalies 列迁移失败："; echo "$MIGRATE_OUT"; exit 1; }
+}
 
 npx wrangler deploy
 

--- a/crowd-metrics/schema.sql
+++ b/crowd-metrics/schema.sql
@@ -62,5 +62,6 @@ CREATE TABLE IF NOT EXISTS bucket_model_raw (
     cache_read_tokens   INTEGER NOT NULL,
     cache_creation_tokens INTEGER NOT NULL,
     cost_usd_micros     INTEGER NOT NULL,
+    anomalies           INTEGER NOT NULL DEFAULT 0, -- P5：被动观察到的模型真伪异常（Anomaly 级）次数
     PRIMARY KEY (hour, site, app, model, source)
 ) WITHOUT ROWID;

--- a/crowd-metrics/src/aggregate.test.ts
+++ b/crowd-metrics/src/aggregate.test.ts
@@ -331,6 +331,19 @@ describe("趋势模型维度（P4）", () => {
     expect(dataBucket.costUsdPerMTok).not.toBeNull();
   });
 
+  it("P5：异常计数进桶与窗口（旧行缺省 0）", () => {
+    const trend = buildTrends(
+      sources(3),
+      NOW,
+      [modelRaw({ anomalies: 2 }), modelRaw({ source: "src-m2", anomalies: 1 }), modelRaw({ source: "src-m3" })],
+    );
+    const model = trend.ranges["24h"].sites["example.com"].models?.["gpt-example"];
+    expect(model).toBeDefined();
+    // 桶与窗口都是直加：2+1+缺省 0 = 3
+    expect(model!.buckets[22].anomalies).toBe(3);
+    expect(model!.window!.anomalies).toBe(3);
+  });
+
   it("窗口聚合（P4c-2）：样本加权指标齐全", () => {
     const trend = buildTrends(sources(3), NOW, [modelRaw(), modelRaw({ source: "src-m2" })]);
     const win = trend.ranges["24h"].sites["example.com"].models?.["gpt-example"]?.window;

--- a/crowd-metrics/src/aggregate.ts
+++ b/crowd-metrics/src/aggregate.ts
@@ -529,6 +529,8 @@ export interface RawModelRow {
   cache_read_tokens: number;
   cache_creation_tokens: number;
   cost_usd_micros: number;
+  /** P5：被动观察到的模型真伪异常次数（列带 DEFAULT 0，旧行/旧行来源缺省）。 */
+  anomalies?: number;
 }
 
 interface ParsedModelRow {
@@ -546,6 +548,7 @@ interface ParsedModelRow {
   cacheReadTokens: number;
   cacheCreationTokens: number;
   costUsdMicros: number;
+  anomalies: number;
 }
 
 /** P4c-2：(站点,模型,范围) 窗口聚合 —— 样本加权合并整段（非逐桶平均），
@@ -561,9 +564,11 @@ function modelWindowOrNull(rows: ParsedModelRow[]): ModelWindowStats | null {
   let errors = 0;
   let tokenTotal = 0;
   let costUsdMicros = 0;
+  let anomalies = 0;
   for (const r of rows) {
     samples += r.samples;
     errors += r.errors;
+    anomalies += r.anomalies;
     tokenTotal += r.inputTokens + r.outputTokens + r.cacheReadTokens + r.cacheCreationTokens;
     costUsdMicros += r.costUsdMicros;
     for (let i = 0; i < TTFT_BIN_COUNT; i++) ttftBins[i] += r.ttftBins[i];
@@ -576,6 +581,7 @@ function modelWindowOrNull(rows: ParsedModelRow[]): ModelWindowStats | null {
     errRate: samples > 0 ? errors / samples : null,
     tpsP50Ms: tpsQuantileFromBins(tpsBins, 0.5),
     costUsdPerMTok: tokenTotal > 0 ? costUsdMicros / tokenTotal : null,
+    anomalies,
   };
 }
 
@@ -607,13 +613,14 @@ function parseModelRow(row: RawModelRow): ParsedModelRow | null {
     cacheReadTokens: row.cache_read_tokens,
     cacheCreationTokens: row.cache_creation_tokens,
     costUsdMicros: row.cost_usd_micros,
+    anomalies: row.anomalies ?? 0,
   };
 }
 
 /** P4：模型桶指标（k-匿与站点桶同款；不过门槛返回 null —— 不发布）。 */
 function trendModelBucketOrNull(
   bucketRows: ParsedModelRow[],
-): (TrendBucket & { tpsP50Ms: number | null; costUsdPerMTok: number | null }) | null {
+): (TrendBucket & { tpsP50Ms: number | null; costUsdPerMTok: number | null; anomalies: number }) | null {
   const trusted = bucketRows.filter((r) => r.uaTrusted);
   const sources = new Set(trusted.map((r) => r.source)).size;
   if (sources < MIN_SOURCES) return null;
@@ -624,10 +631,12 @@ function trendModelBucketOrNull(
     tpsBins: new Array<number>(TPS_BIN_COUNT).fill(0),
     tokenTotal: 0,
     costUsdMicros: 0,
+    anomalies: 0,
   };
   for (const r of bucketRows) {
     totals.samples += r.samples;
     totals.errors += r.errors;
+    totals.anomalies += r.anomalies;
     for (let i = 0; i < TTFT_BIN_COUNT; i++) totals.ttftBins[i] += r.ttftBins[i];
     for (let i = 0; i < TPS_BIN_COUNT; i++) totals.tpsBins[i] += r.tpsBins[i];
     totals.tokenTotal += r.inputTokens + r.outputTokens + r.cacheReadTokens + r.cacheCreationTokens;
@@ -642,5 +651,6 @@ function trendModelBucketOrNull(
     tpsP50Ms: tpsQuantileFromBins(totals.tpsBins, 0.5),
     // $/Mtok 同站点窗口口径：微美元 / 总 token（含缓存）
     costUsdPerMTok: totals.tokenTotal > 0 ? totals.costUsdMicros / totals.tokenTotal : null,
+    anomalies: totals.anomalies,
   };
 }

--- a/crowd-metrics/src/index.ts
+++ b/crowd-metrics/src/index.ts
@@ -19,8 +19,9 @@ const RAW_RETENTION_SECS = 30 * 86400;
 const RATE_LIMIT_RETENTION_SECS = 2 * 86400;
 /** KV 快照键。 */
 const SNAPSHOT_KEY = "snapshot:v1";
-/** KV 趋势键（三档一包，recompute 与快照同拍写、同 freshness 策略）。 */
-const TREND_KEY = "trend:v1";
+/** KV 趋势键（三档一包，recompute 与快照同拍写、同 freshness 策略）。
+ *  v2：P5 模型桶/窗口出参追加 anomalies —— 键升版强制旧缓存失效重算。 */
+const TREND_KEY = "trend:v2";
 
 const CORS_HEADERS: Record<string, string> = {
   "access-control-allow-origin": "*",

--- a/crowd-metrics/src/index.ts
+++ b/crowd-metrics/src/index.ts
@@ -54,7 +54,7 @@ async function queryModelRows(env: Env, nowSec: number): Promise<RawModelRow[]> 
     const { results } = await env.DB.prepare(
       `SELECT hour, site, app, model, source, asn, ua_trusted, samples, errors,
               ttft_bins, tps_bins, input_tokens, output_tokens,
-              cache_read_tokens, cache_creation_tokens, cost_usd_micros
+              cache_read_tokens, cache_creation_tokens, cost_usd_micros, anomalies
        FROM bucket_model_raw WHERE hour >= ?1 ORDER BY hour`,
     )
       .bind(cutoff)

--- a/crowd-metrics/src/ingest.ts
+++ b/crowd-metrics/src/ingest.ts
@@ -122,8 +122,8 @@ export async function handleIngest(request: Request, env: Env): Promise<Response
            hour, site, app, model, source, asn, ua_trusted,
            samples, errors, ttft_bins, tps_bins,
            input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
-           cost_usd_micros
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)`,
+           cost_usd_micros, anomalies
+         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)`,
       ).bind(
         b.hour,
         b.site,
@@ -141,6 +141,7 @@ export async function handleIngest(request: Request, env: Env): Promise<Response
         m.cacheReadTokens,
         m.cacheCreationTokens,
         m.costUsdMicros,
+        m.anomalies ?? 0,
       ),
     );
     return [siteRow, ...modelRows];

--- a/crowd-metrics/src/types.ts
+++ b/crowd-metrics/src/types.ts
@@ -40,6 +40,8 @@ export interface ModelBucketPayload {
   cacheReadTokens: number;
   cacheCreationTokens: number;
   costUsdMicros: number;
+  /** P5：被动观察到的模型真伪异常次数（Anomaly 级）。旧客户端缺省 = 0。 */
+  anomalies?: number;
 }
 
 /** POST /v1/ingest 的载荷。一次 flush 携带若干个已闭合的小时桶。 */
@@ -110,7 +112,7 @@ export interface SiteTrend {
 
 /** P4：模型趋势（无范围分布 —— 站点级已有，模型级省载荷）。 */
 export interface SiteTrendLite {
-  buckets: Array<TrendBucket & { tpsP50Ms?: number | null; costUsdPerMTok?: number | null }>;
+  buckets: Array<TrendBucket & { tpsP50Ms?: number | null; costUsdPerMTok?: number | null; anomalies?: number }>;
   /** P4c-2：该范围内该 (站点,模型) 的窗口聚合（斩杀线图阵的散点口径；
    *  范围级 k-匿未达标则缺省）。 */
   window?: ModelWindowStats;
@@ -124,6 +126,8 @@ export interface ModelWindowStats {
   errRate: number | null;
   tpsP50Ms: number | null;
   costUsdPerMTok: number | null;
+  /** P5：该范围内被动观察到的模型真伪异常（Anomaly 级）总次数。 */
+  anomalies: number;
 }
 
 /** 档位 → 站点趋势。 */

--- a/crowd-metrics/src/validate.test.ts
+++ b/crowd-metrics/src/validate.test.ts
@@ -114,6 +114,19 @@ describe("parseIngestPayload", () => {
     }
   });
 
+  it("P5：模型异常计数缺省 0、超模型样本数拒绝", () => {
+    const ok = parseIngestPayload(makePayload({ version: 2, hours: [makeBucket({ models: [makeModelBucket({ anomalies: 2 })] })] }), NOW);
+    expect(ok.ok).toBe(true);
+    if (ok.ok) expect(ok.payload.hours[0].models?.[0]?.anomalies).toBe(2);
+    // 缺省（旧客户端）→ 0
+    const legacy = parseIngestPayload(makePayload({ version: 2, hours: [makeBucket({ models: [makeModelBucket()] })] }), NOW);
+    if (legacy.ok) expect(legacy.payload.hours[0].models?.[0]?.anomalies).toBe(0);
+    // 异常次数恒 ≤ 该模型样本数（异常响应必然是被计数的请求之一）
+    expect(
+      parseIngestPayload(makePayload({ version: 2, hours: [makeBucket({ models: [makeModelBucket({ anomalies: 99 })] })] }), NOW).ok,
+    ).toBe(false);
+  });
+
   it("v2：缺 models 数组 / 坏模型名 / 子桶超母桶样本 / tps 桶长错 一律拒绝", () => {
     expect(parseIngestPayload(makePayload({ version: 2 }), NOW).ok).toBe(false);
     expect(

--- a/crowd-metrics/src/validate.ts
+++ b/crowd-metrics/src/validate.ts
@@ -219,6 +219,12 @@ export function parseIngestPayload(
         ) {
           return { ok: false, error: "bad model tpsBins" };
         }
+        // P5：模型异常计数（可选；恒 ≤ 该模型样本数 —— 异常响应必然是被
+        // 计数的请求之一，超限即乱填）。
+        const mAnomalies = m.anomalies ?? 0;
+        if (!isSafeUint(mAnomalies, mSamples)) {
+          return { ok: false, error: "bad model anomalies (must be <= model samples)" };
+        }
         models.push({
           model: m.model,
           samples: mSamples,
@@ -230,6 +236,7 @@ export function parseIngestPayload(
           cacheReadTokens: m.cacheReadTokens as number,
           cacheCreationTokens: m.cacheCreationTokens as number,
           costUsdMicros: m.costUsdMicros as number,
+          anomalies: mAnomalies,
         });
       }
     }

--- a/src-tauri/src/crowd/bucket.rs
+++ b/src-tauri/src/crowd/bucket.rs
@@ -421,11 +421,16 @@ fn query_breaker_trip_counts(
 
 /// P5：模型异常事件按 (hour, provider, app, model) 计数。返回键与
 /// RawModelBucket 的 provider 维度同构，复用同一张 hosts 映射。
+type ModelAnomalyCounts = HashMap<(i64, String, String, String), i64>;
+
+/// 站点维度折叠的中间形状：(hour, site, app) → model → 异常次数。
+type SiteAnomalyCounts = HashMap<(i64, String, String), HashMap<String, i64>>;
+
 fn query_model_anomaly_counts(
     db: &Database,
     after_epoch: i64,
     before_epoch: i64,
-) -> Result<HashMap<(i64, String, String, String), i64>, AppError> {
+) -> Result<ModelAnomalyCounts, AppError> {
     let conn = crate::database::lock_conn!(db.conn);
     let mut stmt = conn
         .prepare(
@@ -484,8 +489,7 @@ pub fn build_hour_buckets(
     // 合并的模型行 —— 异常响应必然有对应的请求日志（tap 只挂在转发路径），
     // 模型行理论上恒命中；万一失配（日志被裁等）按「无主计数不出门」丢弃。
     let anomalies = query_model_anomaly_counts(db, after_epoch, before_epoch)?;
-    let mut anomalies_by_site: HashMap<(i64, String, String), HashMap<String, i64>> =
-        HashMap::new();
+    let mut anomalies_by_site: SiteAnomalyCounts = HashMap::new();
     for ((hour, provider, app, model), count) in &anomalies {
         if let Some(site) = hosts.get(&(provider.clone(), app.clone())) {
             *anomalies_by_site

--- a/src-tauri/src/crowd/bucket.rs
+++ b/src-tauri/src/crowd/bucket.rs
@@ -91,6 +91,10 @@ pub struct ModelBucket {
     pub cache_read_tokens: i64,
     pub cache_creation_tokens: i64,
     pub cost_usd_micros: i64,
+    /// P5：被动观察到的模型真伪异常次数（Anomaly 级事件计数，事件源见
+    /// `crowd::events::record_model_anomaly`）。恒 ≤ `samples`（异常响应
+    /// 必然是被计数的请求之一）。
+    pub anomalies: i64,
 }
 
 /// SQL 切出的 provider 维度桶（站点归属尚未解析）。
@@ -368,6 +372,7 @@ fn merge_by_site(
             cache_read_tokens: 0,
             cache_creation_tokens: 0,
             cost_usd_micros: 0,
+            anomalies: 0,
         });
         entry.samples += raw.samples;
         entry.errors += raw.errors;
@@ -414,6 +419,32 @@ fn query_breaker_trip_counts(
     Ok(counts)
 }
 
+/// P5：模型异常事件按 (hour, provider, app, model) 计数。返回键与
+/// RawModelBucket 的 provider 维度同构，复用同一张 hosts 映射。
+fn query_model_anomaly_counts(
+    db: &Database,
+    after_epoch: i64,
+    before_epoch: i64,
+) -> Result<HashMap<(i64, String, String, String), i64>, AppError> {
+    let conn = crate::database::lock_conn!(db.conn);
+    let mut stmt = conn
+        .prepare(
+            "SELECT hour_epoch, provider_id, app_type, model, COUNT(*)              FROM crowd_model_anomaly_events              WHERE hour_epoch > ?1 AND hour_epoch <= ?2              GROUP BY hour_epoch, provider_id, app_type, model",
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    let mut rows = stmt
+        .query(params![after_epoch, before_epoch])
+        .map_err(|e| AppError::Database(e.to_string()))?;
+    let mut counts = HashMap::new();
+    while let Some(row) = rows.next().map_err(|e| AppError::Database(e.to_string()))? {
+        counts.insert(
+            (row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?),
+            row.get(4)?,
+        );
+    }
+    Ok(counts)
+}
+
 /// 组合入口：查桶 → 解析站点归属 → 合并。由 [`super::uploader`] 调用。
 pub fn build_hour_buckets(
     db: &Database,
@@ -447,6 +478,34 @@ pub fn build_hour_buckets(
             .get(&(bucket.hour_epoch, bucket.site.clone(), bucket.app.clone()))
             .copied()
             .unwrap_or(0);
+    }
+    // P5：模型异常计数并入模型子桶。事件键是 (hour, provider, app, model)，
+    // 先折成站点维度（同一张 hosts 映射，未登记 provider 丢弃），再对进已
+    // 合并的模型行 —— 异常响应必然有对应的请求日志（tap 只挂在转发路径），
+    // 模型行理论上恒命中；万一失配（日志被裁等）按「无主计数不出门」丢弃。
+    let anomalies = query_model_anomaly_counts(db, after_epoch, before_epoch)?;
+    let mut anomalies_by_site: HashMap<(i64, String, String), HashMap<String, i64>> =
+        HashMap::new();
+    for ((hour, provider, app, model), count) in &anomalies {
+        if let Some(site) = hosts.get(&(provider.clone(), app.clone())) {
+            *anomalies_by_site
+                .entry((*hour, site.clone(), app.clone()))
+                .or_default()
+                .entry(model.clone())
+                .or_insert(0) += count;
+        }
+    }
+    for bucket in &mut merged {
+        if let Some(per_model) =
+            anomalies_by_site.get(&(bucket.hour_epoch, bucket.site.clone(), bucket.app.clone()))
+        {
+            for model_row in &mut bucket.models {
+                model_row.anomalies = per_model
+                    .get(&model_row.model)
+                    .copied()
+                    .unwrap_or(model_row.anomalies);
+            }
+        }
     }
     Ok(merged)
 }
@@ -547,6 +606,74 @@ mod tests {
             "api 子域上的 provider 必须归属到站点的注册域"
         );
         assert_eq!(buckets[0].site, "panel.example");
+    }
+
+    #[test]
+    fn model_anomaly_events_fold_into_model_buckets() {
+        let db = setup_db();
+        {
+            let conn = db.conn.lock().unwrap();
+            crate::relay::creds::save_site(
+                &conn,
+                "https://panel.example",
+                "中性示例站",
+                "https://api.panel.example",
+            )
+            .unwrap();
+        }
+        db.conn
+            .lock()
+            .unwrap()
+            .execute(
+                "INSERT INTO providers (id, app_type, name, settings_config, meta)
+                 VALUES ('acct-a', 'codex', '示例档', ?1, '{}')",
+                params![serde_json::json!({
+                    "auth": {"OPENAI_API_KEY": "sk-test-not-a-real-key"},
+                    "base_url": "https://api.panel.example/v1"
+                })
+                .to_string()],
+            )
+            .unwrap();
+        seed_log(
+            &db,
+            "a",
+            "acct-a",
+            "codex",
+            200,
+            Some(250),
+            "0.5",
+            11 * 3600 + 100,
+            "proxy",
+        );
+        // 两命事件 + 一条模型名对不上的 + 一条未登记 provider 的 —— 后两者
+        // 都按「无主计数不出门」丢弃。
+        for (provider, model) in [
+            ("acct-a", "test-model"),
+            ("acct-a", "test-model"),
+            ("acct-a", "other-model"),
+            ("ghost", "test-model"),
+        ] {
+            db.conn
+                .lock()
+                .unwrap()
+                .execute(
+                    "INSERT INTO crowd_model_anomaly_events
+                     (hour_epoch, provider_id, app_type, model, created_at)
+                     VALUES (11 * 3600, ?1, 'codex', ?2, 0)",
+                    params![provider, model],
+                )
+                .unwrap();
+        }
+
+        let buckets = build_hour_buckets(&db, 0, 12 * 3600).unwrap();
+        assert_eq!(buckets.len(), 1);
+        assert_eq!(buckets[0].models.len(), 1, "模型行来自请求日志，恒为 1");
+        assert_eq!(buckets[0].models[0].model, "test-model");
+        assert_eq!(
+            buckets[0].models[0].anomalies, 2,
+            "只有命中同站点同模型的事件计数，其余丢弃"
+        );
+        assert_eq!(buckets[0].models[0].samples, 1);
     }
 
     #[test]

--- a/src-tauri/src/crowd/events.rs
+++ b/src-tauri/src/crowd/events.rs
@@ -1,12 +1,17 @@
-//! P4b：熔断跳闸事件（站点侧信号的本地事件源）。
+//! P4b：熔断跳闸事件 + P5：模型真伪异常事件（站点侧信号的本地事件源）。
 //!
-//! `proxy_request_logs` 里切不出「跳闸」—— 它是熔断器的状态转换，不是一行
-//! 请求日志。所以在跳闸发生时（`provider_router::record_result` 的非致命
-//! 分支）落一行事件，上传切桶时按 (hour, provider, app) 计数并入小时桶。
+//! 两张表都是「proxy_request_logs 里切不出来」的事实：跳闸是熔断器的状态
+//! 转换；模型异常是被动验证对响应的判定。所以在发生时各落一行事件，
+//! 上传切桶时按小时计数并入桶（跳闸 → 小时桶 breaker_trips，模型异常 →
+//! 模型子桶 anomalies）。
 //!
-//! 口径：**只记非致命跳闸**。致命跳闸（401/402/凭证级 403 一次即开）是
+//! 跳闸口径：**只记非致命跳闸**。致命跳闸（401/402/凭证级 403 一次即开）是
 //! 上传者自己的凭证/余额问题，计入会把它变成站点的公开健康分 —— 与
 //! `bucket::SITE_SIDE_ERROR_EXPR` 剔除同类失败是同一条纪律。
+//!
+//! 模型异常口径：**只记 Anomaly**（异源指纹/自述冒充级，高置信换芯证据）。
+//! Suspicious 是弱信号（回写降级生态下 ModelMatch 通过无意义、signature
+//! 缺失可能只是没开 thinking），公开面宁缺毋认，不进众测。
 //!
 //! 表是纯追加的事件流：上传幂等靠「按小时重算计数」而不是删行（行本身
 //! 不可变，重算结果稳定）；清理走 flush 时顺手裁掉 35 天前的旧行。
@@ -23,26 +28,86 @@ pub fn record_breaker_trip(
     provider_id: &str,
     app_type: &str,
 ) -> Result<(), AppError> {
-    let hour_epoch = chrono::Utc::now().timestamp() / 3600 * 3600;
+    let now = chrono::Utc::now().timestamp();
+    let hour_epoch = now / 3600 * 3600;
     let conn = crate::database::lock_conn!(db.conn);
     conn.execute(
-        "INSERT INTO crowd_breaker_events (hour_epoch, provider_id, app_type) VALUES (?1, ?2, ?3)",
-        params![hour_epoch, provider_id, app_type],
+        "INSERT INTO crowd_breaker_events (hour_epoch, provider_id, app_type, created_at) VALUES (?1, ?2, ?3, ?4)",
+        params![hour_epoch, provider_id, app_type, now],
     )
     .map_err(|e| AppError::Database(e.to_string()))?;
     Ok(())
 }
 
-/// 裁掉窗口外的旧事件（35 天 = Worker 接受上限 30 天 + 余量）。
-/// 挂在 flush 成功后调用 —— 上传节奏天然节流，不需要单独的清理任务。
+/// 落一条模型异常事件（被动验证判定为 Anomaly 时，由消费 worker 调用）。
+/// `observed_at` 用响应观察时间而不是入队时间 —— batch 在 channel 里排队
+/// 跨过整点时，事件仍归观察到它的那个小时。失败只回 Err 由调用方打日志。
+pub fn record_model_anomaly(
+    db: &Database,
+    provider_id: &str,
+    app_type: &str,
+    model: &str,
+    observed_at: i64,
+) -> Result<(), AppError> {
+    let hour_epoch = observed_at / 3600 * 3600;
+    let conn = crate::database::lock_conn!(db.conn);
+    conn.execute(
+        "INSERT INTO crowd_model_anomaly_events (hour_epoch, provider_id, app_type, model, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![hour_epoch, provider_id, app_type, model, chrono::Utc::now().timestamp()],
+    )
+    .map_err(|e| AppError::Database(e.to_string()))?;
+    Ok(())
+}
+
+/// 裁掉窗口外的旧事件（35 天 = Worker 接受上限 30 天 + 余量），两张事件表
+/// 一起裁。挂在 flush 成功后调用 —— 上传节奏天然节流，不需要单独的清理任务。
 pub fn prune_old_events(db: &Database, now_epoch: i64) -> Result<u64, AppError> {
     let cutoff = (now_epoch / 3600 * 3600) - 35 * 86400;
     let conn = crate::database::lock_conn!(db.conn);
-    let n = conn
+    let mut n = conn
         .execute(
             "DELETE FROM crowd_breaker_events WHERE hour_epoch < ?1",
             params![cutoff],
         )
         .map_err(|e| AppError::Database(e.to_string()))?;
+    n += conn
+        .execute(
+            "DELETE FROM crowd_model_anomaly_events WHERE hour_epoch < ?1",
+            params![cutoff],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
     Ok(n as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 回归闸（P5 修根时立）：DDL 的 `created_at NOT NULL` 与 INSERT 列集
+    /// 曾经不一致 —— 跳闸事件在真机上每次插入都失败、计数恒 0，桶测试直接
+    /// INSERT 全列所以没抓到。两条事件写入必须真的落行。
+    #[test]
+    fn event_writes_actually_persist() {
+        let db = Database::memory().expect("内存库");
+        record_breaker_trip(&db, "acct-a", "codex").expect("跳闸事件落库");
+        record_model_anomaly(&db, "acct-a", "codex", "test-model", 11 * 3600 + 30)
+            .expect("模型异常事件落库");
+
+        let conn = db.conn.lock().unwrap();
+        let breaker_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM crowd_breaker_events", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(breaker_count, 1, "跳闸事件必须落行");
+        let (hour, model): (i64, String) = conn
+            .query_row(
+                "SELECT hour_epoch, model FROM crowd_model_anomaly_events",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(hour, 11 * 3600, "异常事件归观察到它的小时（非入队时间）");
+        assert_eq!(model, "test-model");
+    }
 }

--- a/src-tauri/src/crowd/uploader.rs
+++ b/src-tauri/src/crowd/uploader.rs
@@ -73,6 +73,9 @@ pub(crate) struct ModelBucketPayload<'a> {
     pub cache_read_tokens: i64,
     pub cache_creation_tokens: i64,
     pub cost_usd_micros: i64,
+    /// P5：被动观察到的模型真伪异常次数（Anomaly 级，v2 追加，旧服务端
+    /// 忽略未知字段向后兼容）。
+    pub anomalies: i64,
 }
 
 fn payload_from_bucket<'a>(source_id: &'a str, buckets: &'a [HourBucket]) -> IngestPayload<'a> {
@@ -109,6 +112,7 @@ fn payload_from_bucket<'a>(source_id: &'a str, buckets: &'a [HourBucket]) -> Ing
                         cache_read_tokens: m.cache_read_tokens,
                         cache_creation_tokens: m.cache_creation_tokens,
                         cost_usd_micros: m.cost_usd_micros,
+                        anomalies: m.anomalies,
                     })
                     .collect(),
             })
@@ -256,6 +260,7 @@ mod tests {
                 cache_read_tokens: 300,
                 cache_creation_tokens: 100,
                 cost_usd_micros: 12_345,
+                anomalies: 2,
             }],
         }
     }
@@ -327,6 +332,7 @@ mod tests {
         assert_eq!(
             model_keys,
             vec![
+                "anomalies",
                 "cacheCreationTokens",
                 "cacheReadTokens",
                 "costUsdMicros",

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -256,6 +256,27 @@ impl Database {
         )
         .map_err(|e| AppError::Database(e.to_string()))?;
 
+        // 10c. crowd 模型异常事件（P5）：被动观察到的模型真伪异常（Anomaly 级）
+        // 追加式事件流，上传切桶时按 (hour, provider, app, model) 计数并入模型子桶；
+        // 清理与跳闸事件同走 crowd::events::prune_old_events。
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS crowd_model_anomaly_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                hour_epoch INTEGER NOT NULL,
+                provider_id TEXT NOT NULL,
+                app_type TEXT NOT NULL,
+                model TEXT NOT NULL,
+                created_at INTEGER NOT NULL
+            )",
+            [],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_crowd_model_anomaly_hour ON crowd_model_anomaly_events(hour_epoch, provider_id, app_type, model)",
+            [],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
         // 11. Model Pricing 表
         conn.execute(
             "CREATE TABLE IF NOT EXISTS model_pricing (

--- a/src-tauri/src/relay/model_verification/coordinator.rs
+++ b/src-tauri/src/relay/model_verification/coordinator.rs
@@ -177,6 +177,20 @@ impl ModelVerificationCoordinator {
                 let Some(db) = db.upgrade() else {
                     continue;
                 };
+                // P5：Anomaly 级（异源指纹/自述冒充）按事件计数进众测管道。
+                // 独立于 upsert —— 计数语义是「观察到几次」，与结果表怎么
+                // 合并无关；失败只告警，不影响验证报告本身。
+                if report.verdict == crate::relay::model_verification::types::Verdict::Anomaly {
+                    if let Err(error) = crate::crowd::events::record_model_anomaly(
+                        &db,
+                        &batch.target.provider_id,
+                        &batch.target.app_type,
+                        &batch.target.model,
+                        report.checked_at,
+                    ) {
+                        log::warn!("模型异常事件落库失败: {error}");
+                    }
+                }
                 match crate::relay::model_verification::store::upsert_passive(&db, &report) {
                     Ok(true) => {
                         let scope = TargetScope::new(


### PR DESCRIPTION
## 概要

P5（模型真伪甄别面）的众测上报管道：被动模型监控判定为 **Anomaly**（异源协议指纹/自述冒充级，高置信换芯证据）时按事件计数，随 v2 载荷模型子桶上报，/status 站点卡据此外显「模型真实性异常」（网站侧另行 PR）。

设计决策（spec-被动模型监控.md + spec-站点实测监控升级分期.md P5）：

- **只上传 Anomaly，不上传 Suspicious**——弱信号（回写生态下 ModelMatch 通过无意义、signature 缺失可能只是没开 thinking）不进公开面，宁缺毋认
- 事件表 `crowd_model_anomaly_events` 镜像 P4b 跳闸事件范式：纯追加、按小时重算计数（幂等）、35 天同裁、无主计数不出门
- 消费 worker 落事件独立于结果表 upsert（计数语义=观察到几次）；`observed_at` 归时（batch 跨整点排队不漂移）
- Worker：`bucket_model_raw` 加 `anomalies` 列（护栏 ALTER）、validate 恒 ≤ 模型样本数（异常响应 ⊆ 被计数请求）、逐桶与 (站点,模型,范围) 窗口出参、trend KV 键 v1→v2 强制重算
- k-匿复用模型桶既有门槛，无新增隐私面

## 顺手修根（独立成立）

`record_breaker_trip` 的 INSERT 漏 `created_at` 列（DDL NOT NULL）——**自 P4b 合入起跳闸事件每次插入都失败、breakerTrips 上传恒 0**。桶测试直接 INSERT 全列所以没抓到。本次补列 + events 落库回归闸钉住。

## 验证

- [x] Rust：crowd 15 测试全绿（含异常折叠测试、events 落库闸）、model_verification/response_processor 无回归、payload 键集闸更新
- [x] Worker：74 测试全绿（validate 缺省 0/超样本拒绝、桶+窗口直加）
- [x] 端到端冒烟（生产 Worker）：v2 POST anomalies=2 → D1 落列 → trend 出参桶/窗口均 2 → 残留已清、生产已验证干净
- [x] Worker 已部署（列迁移 + 代码）