### PR TITLE
feat(star): 删除首导入成功的点赞礼主动弹窗，顶栏红点成唯一入口

### DIFF
--- a/src-tauri/src/commands/onboarding.rs
+++ b/src-tauri/src/commands/onboarding.rs
@@ -2,21 +2,21 @@
 //!
 //! 见那个模块的文档 for 模块边界（策略收拢、机制复用、后续调整只动那边）。
 //!
-//! 引导形状（2026-08-17 起）：新人首启只**落到中转站广场**（`RelaySection`
-//! 的 `shouldPromptAddSite` 跳转），不弹任何邀约 —— 「点 Star 领注册礼」
-//! 推迟到**首个站点注册/登录成功之后**（[`offer_star_reward_after_first_import`]，
-//! 挂在 `import_site` 成功路径上）：用户有了使用感觉再邀请，比首启硬弹
-//! 打扰小。注册窗（[`onboarding_open_register_window`]）仍是 star 走通
-//! 之后的终点。
+//! 引导形状（2026-09-06 起）：新人首启只**落到中转站广场**（`RelaySection`
+//! 的 `shouldPromptAddSite` 跳转），全程不弹任何邀约。「点 Star 领注册礼」
+//! 的入口只剩顶栏 GitHub 按钮的红点（常亮到领取为止，用户自己点）——
+//! 曾经挂在 `import_site` 成功路径上的主动弹窗已删：刚接入站点时用户
+//! 还没有任何使用感，此时弹点赞礼只会被打断，实测用户不愿意点。
+//! 注册窗（[`onboarding_open_register_window`]）仍是 Star 对话框领取后
+//! 打开的终点。
 
 use serde::Serialize;
 use tauri::Emitter;
 
-use crate::events::{ONBOARDING_REGISTER_COMPLETED, ONBOARDING_STAR_REWARD_OFFER};
+use crate::events::ONBOARDING_REGISTER_COMPLETED;
 use crate::relay::onboarding;
 
 use super::relay::{import_site, BrowserEntrySource, ImportResult};
-use super::star_reward;
 
 /// 新人引导注册窗完成事件的 payload（前端 `src/lib/onboarding.ts` 消费）。
 #[derive(Clone, Serialize)]
@@ -26,55 +26,7 @@ struct RegisterCompletedPayload {
     site_name: String,
 }
 
-/// 首个站点接入成功后的「点 Star 领注册礼」邀请（不暴露成命令：只有
-/// `import_site` 的成功路径这一个调用方）。
-///
-/// 判据：礼还没领（`star_reward_claimed` 为空）&& 这次安装还没主动弹过
-/// （`star_reward_offered` 为空）。注意**不看账号数** —— 调用时机本身就是
-/// 「刚接入第一个站点」，比旧版首启判据（无账号）语义更直白。
-///
-/// 另一道闸（远端配置有 `star_reward`）沿用 [`star_reward::build_offer`]
-/// —— 纯本地读缓存，不打网络。不过就静默返回；「压根没拿到 offer」不置位
-/// 一次性标志（一次时序不巧不该把邀请永久吃掉），下次接入站点再试。
-pub(crate) async fn offer_star_reward_after_first_import(app_handle: &tauri::AppHandle) {
-    let settings = crate::settings::get_settings();
-    if settings.star_reward_claimed.is_some() || settings.star_reward_offered.is_some() {
-        return;
-    }
-
-    // 接入通常发生在启动数分钟后、后台目录任务早已把缓存落盘；补这一拉
-    // 只兜「启动 5 秒内就完成接入」的极端窗口。幂等：与后台任务写同一份缓存。
-    if star_reward::effective_star_reward().is_none() {
-        crate::relay::remote_config::refresh_and_cache().await;
-    }
-
-    let Some(offer) = star_reward::build_offer() else {
-        log::info!("Star 邀约未发出（远端配置无 star_reward），下次接入站点再试");
-        return;
-    };
-    mark_star_reward_offered();
-    if let Err(error) = app_handle.emit(ONBOARDING_STAR_REWARD_OFFER, offer) {
-        // 发不出去只是这次不弹（标志已置位，不再主动弹）—— 红点仍是
-        // 未领取用户的常驻「稍后再说」入口。
-        log::warn!("发射 star 邀请事件失败: {error}");
-    }
-}
-
-/// 标志只置位一次，且**只在确认拿到 offer、正要发事件时置位**：置位后无论
-/// 弹出去之后的结局如何（领了 / 取消 / 事件发不出去），都不再主动弹 ——
-/// 未领取的用户回落到顶栏红点（常亮，那是他们的「稍后再说」入口）。
-fn mark_star_reward_offered() {
-    crate::settings::mutate_settings(|settings| {
-        if settings.star_reward_offered.is_none() {
-            settings.star_reward_offered = Some(true);
-        }
-    })
-    .unwrap_or_else(|error| {
-        log::warn!("Star 邀约标志写入失败（不影响本次弹窗，但之后可能再弹一次）: {error}")
-    });
-}
-
-/// 打开官方站（BestAPI）注册窗 —— 只有「点 Star 领注册礼」走通之后才被调用，
+/// 打开官方站（BestAPI）注册窗 —— Star 对话框「领取」点击后调用，
 /// 所以优惠码必给且显式传入。
 ///
 /// 码走**显式参数**而不是塞进 `promo_codes` 码表：那张表是给所有导入无条件

--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -1329,15 +1329,9 @@ pub(crate) async fn import_site(
     )
     .await;
 
-    // 首个站点接入成功 → 事后邀请「点 Star 领注册礼」（用户有了使用感觉再弹，
-    // 见 `commands::onboarding`）。三道闸与一次性标志都在那边；这里只发信号，
-    // 不挡导入返回 —— 邀约要拉网络，让用户先看到导入成功的界面。
-    if result.is_ok() {
-        let handle = app_handle.clone();
-        tauri::async_runtime::spawn(async move {
-            crate::commands::onboarding::offer_star_reward_after_first_import(&handle).await;
-        });
-    }
+    // 曾经在这里挂「首个站点接入成功 → 弹 Star 邀请」（2026-09-06 删除）：
+    // 刚接入站点的用户还没有任何使用感，此刻弹点赞礼只会被打断。Star 礼
+    // 的入口只剩顶栏 GitHub 红点，见 `commands::onboarding` 的模块文档。
     result
 }
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -43,11 +43,9 @@ fn merge_settings_for_save(
 
     // 后端专有字段（2026-08-16 收口，与 local_migrations 同一个丢失更新理由）：
     // 切换链路在后端写 current_provider_*（`settings::set_current_provider`），
-    // Star 邀约与领取由后端流程写 `star_reward_offered` / `star_reward_claimed`
-    // （前者在 `commands::onboarding`、后者走窄命令 `star_reward_mark_claimed`）。
+    // Star 领取标记由窄命令 `star_reward_mark_claimed` 写。
     // 前端全量保存的快照取自某个过去时刻，透传它们 = 把并发写入整体抹掉
     // （当晚实测 claimed 被旧快照抹除；"当前在用"指针被抹会让整片供应商失去选中态）。
-    incoming.star_reward_offered = existing.star_reward_offered;
     incoming.star_reward_claimed = existing.star_reward_claimed;
     incoming.current_provider_claude = existing.current_provider_claude.clone();
     incoming.current_provider_claude_desktop = existing.current_provider_claude_desktop.clone();
@@ -485,7 +483,6 @@ mod tests {
     #[test]
     fn save_settings_must_not_overwrite_backend_owned_fields() {
         let existing = AppSettings {
-            star_reward_offered: Some(true),
             star_reward_claimed: Some(true),
             current_provider_codex: Some("provider-1".to_string()),
             current_provider_claude: Some("provider-2".to_string()),
@@ -500,7 +497,6 @@ mod tests {
 
         let merged = merge_settings_for_save(incoming, &existing);
 
-        assert_eq!(merged.star_reward_offered, Some(true));
         assert_eq!(merged.star_reward_claimed, Some(true));
         assert_eq!(merged.current_provider_codex.as_deref(), Some("provider-1"));
         assert_eq!(

--- a/src-tauri/src/commands/star_reward.rs
+++ b/src-tauri/src/commands/star_reward.rs
@@ -13,8 +13,8 @@
 
 use serde::Serialize;
 
-/// 弹窗邀请的 payload：`ONBOARDING_STAR_REWARD_OFFER` 事件与 `star_reward_offer`
-/// 命令共用；前端 `src/lib/api/starReward.ts` 的 `StarRewardOffer` 与之对应。
+/// Star 对话框的 payload：`star_reward_offer` 命令返回（顶栏红点是唯一入口，
+/// 曾经的主动弹窗事件已删）；前端 `src/lib/api/starReward.ts` 的 `StarRewardOffer` 与之对应。
 ///
 /// 序列化 camelCase（本仓 TS 侧惯例），与 `commands::onboarding` 的
 /// `RegisterCompletedPayload` 同一形状。

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -56,10 +56,6 @@ pub const MODEL_VERIFICATION_CHANGED: &str = "model-verification-changed";
 /// 新人引导注册窗完成（`RelaySection` 监听）：凭据已入库，前端做 toast +
 /// 档位预配 + 列表刷新。payload `{ relayId, siteName }`。
 pub const ONBOARDING_REGISTER_COMPLETED: &str = "onboarding-register-completed";
-/// 新人引导的「点 Star 领注册礼」邀请（`App.tsx` 的 StarRewardDialog 监听）。
-/// Rust 判完资格 + 远端配置后才发，前端拿到即弹；
-/// payload `{ promoCode, amountUsd }`。
-pub const ONBOARDING_STAR_REWARD_OFFER: &str = "onboarding-star-reward-offer";
 
 /// 看板站点余额后台刷新完成（`useTierBoard` 监听，失效看板查询补上新值）。
 /// 站点余额跨 app 共享，不带 payload —— 监听方把所有 app 的看板一起失效。
@@ -167,10 +163,6 @@ mod consistency_tests {
             (
                 "ONBOARDING_REGISTER_COMPLETED",
                 super::ONBOARDING_REGISTER_COMPLETED,
-            ),
-            (
-                "ONBOARDING_STAR_REWARD_OFFER",
-                super::ONBOARDING_STAR_REWARD_OFFER,
             ),
             ("SITE_BALANCES_UPDATED", super::SITE_BALANCES_UPDATED),
         ];

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -495,15 +495,9 @@ pub struct AppSettings {
     /// 「点 Star 领注册礼」的主动邀请**已经弹过**一次（2026-08-17 起挂在首个
     /// 站点接入成功之后，见 `commands::onboarding`）。
     ///
-    /// 一次性标志：置位发生在确认拿到 offer、正要发事件那一刻；弹出去之后
-    /// 无论结局（领了 / 取消）都不再主动弹，未领取的用户回落顶栏红点。
-    /// 没弹成（没网 / 活动下线）不置位，下次接入站点再试。
-    ///
-    /// （历史：2026-08-15~16 曾用 `onboarding_register_prompted` 在首启弹，
-    /// 触发点改到接入成功后换成本字段；旧键不再读，留在老 settings.json 里
-    /// 会被下次全量保存自然挤掉。）
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub star_reward_offered: Option<bool>,
+    // （`star_reward_offered` 一次性标志随 2026-09-06 删除主动弹窗一起移除：
+    // 它存在的唯一意义是防弹窗重复触发，弹窗没了字段就是死状态。旧
+    // settings.json 里的该键会被 serde 忽略并在下次全量保存时自然挤掉。）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
 
@@ -645,7 +639,6 @@ impl Default for AppSettings {
             failover_confirmed: None,
             first_run_notice_confirmed: None,
             common_config_confirmed: None,
-            star_reward_offered: None,
             language: None,
             visible_apps: None,
             claude_config_dir: None,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,6 @@ import {
   settingsApi,
   starRewardApi,
   type StarRewardOffer,
-  ONBOARDING_STAR_REWARD_OFFER,
   PROFILE_APPLIED,
   S3_SYNC_STATUS_UPDATED,
   UNIVERSAL_PROVIDER_SYNCED,
@@ -620,16 +619,9 @@ function App() {
     };
   }, []);
 
-  // 新人引导的邀请事件（后端已过三道闸：资格 + 配置 + 基线）：拿到即弹。
-  // 已领取的极端情形（红点先领了、引导事件才到）直接忽略。事件本身证明活动
-  // 在线，顺手点亮红点 —— 它到达时挂载检查可能刚在空缓存上判过 false。
-  useTauriEvent<StarRewardOffer>(ONBOARDING_STAR_REWARD_OFFER, (payload) => {
-    if (starRewardClaimedRef.current) return;
-    setStarRewardActive(true);
-    setStarRewardOffer(payload);
-  });
-
-  /** 红点按钮点击：活动在且未领取 → 问后端要邀请（纯本地读缓存）弹窗；否则现状开仓库。 */
+  /** 红点按钮点击：活动在且未领取 → 问后端要邀请（纯本地读缓存）弹窗；否则现状开仓库。
+   * （2026-09-06 起这是 Star 礼的唯一入口 —— 首导入成功后的主动弹窗事件已删，
+   * 用户刚接入站点时还没有使用感，此刻弹点赞礼只会被打断。） */
   const handleGitHubStarClick = useCallback(async () => {
     if (starRewardActive !== true) {
       await settingsApi.openExternal(GITHUB_REPO);

--- a/src/lib/api/events.ts
+++ b/src/lib/api/events.ts
@@ -48,7 +48,5 @@ export const MODEL_VERIFICATION_PROGRESS = "model-verification-progress";
 export const MODEL_VERIFICATION_CHANGED = "model-verification-changed";
 /** 新人引导注册窗完成（`RelaySection` 监听）：凭据已入库，前端做 toast + 档位预配 + 列表刷新。 */
 export const ONBOARDING_REGISTER_COMPLETED = "onboarding-register-completed";
-/** 新人引导的「点 Star 领注册礼」邀请（`App.tsx` 的 StarRewardDialog 监听）：Rust 判完资格+配置+基线才发。 */
-export const ONBOARDING_STAR_REWARD_OFFER = "onboarding-star-reward-offer";
 /** 看板站点余额后台刷新完成（`useTierBoard` 监听，失效所有看板查询补值；站点余额跨 app 共享，无 payload）。 */
 export const SITE_BALANCES_UPDATED = "site-balances-updated";

--- a/src/lib/api/starReward.ts
+++ b/src/lib/api/starReward.ts
@@ -8,8 +8,9 @@ import { invoke } from "@tauri-apps/api/core";
  * 界面上每个「$N」都从 `offer.amountUsd` 来，前端不另存数值。
  */
 
-/** 弹窗邀请的 payload（`ONBOARDING_STAR_REWARD_OFFER` 事件与 `star_reward_offer`
- * 命令共用；与 Rust 侧 `commands::star_reward::StarRewardOffer` 对应）。 */
+/** Star 对话框的 payload（`star_reward_offer` 命令返回；与 Rust 侧
+ * `commands::star_reward::StarRewardOffer` 对应。曾经的主动弹窗事件已删，
+ * 顶栏红点是唯一入口）。 */
 export interface StarRewardOffer {
   promoCode: string;
   amountUsd: number;

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -2,10 +2,8 @@
  * 新人引导（前端侧）。后端策略在 `src-tauri/src/relay/onboarding.rs` 与
  * `src-tauri/src/commands/onboarding.rs`，那边说了算。
  *
- * 「点 Star 领注册礼」的主动邀请已不在前端发起（2026-08-17 起）：后端挂在
- * 首个站点接入成功（`import_site` 成功路径）之后直接发
- * `ONBOARDING_STAR_REWARD_OFFER` 事件，App 层的监听照旧弹窗。这里只剩
- * 注册窗完成事件的 payload 类型。
+ * 全程不弹任何邀约（2026-09-06 起，连首导入成功后的 Star 弹窗事件也删了）：
+ * Star 礼的入口只剩顶栏 GitHub 红点。这里只剩注册窗完成事件的 payload 类型。
  */
 
 /** `ONBOARDING_REGISTER_COMPLETED` 事件的 payload（与 Rust 侧


### PR DESCRIPTION
## 动机

用户实测反馈（Linux 真机验证时亲历）：站点刚添加成功的瞬间弹「点 Star 领注册礼」，用户此时还没有任何使用感，不愿意点。原设计注释说「用户有了使用感觉再邀请」，但**导入成功 ≠ 有使用感**——时机还是太早。

## 决策

主动触发整链删除，**顶栏 GitHub 红点成为 Star 礼的唯一入口**（常亮到领取为止，用户自己决定何时点）。

## 变更清单

- `relay.rs`：`import_site` 成功路径的 offer 信号 spawn 删除
- `onboarding.rs`：`offer_star_reward_after_first_import` + `mark_star_reward_offered` 删除；`onboarding_open_register_window`（Star 对话框领取后的注册窗）保留不动
- `ONBOARDING_STAR_REWARD_OFFER` 事件双侧删除：Rust 常量 + events.rs 对账清单行、TS 常量、App.tsx 事件监听
- `settings.star_reward_offered` 字段删除：它存在的唯一意义是防弹窗重复触发，弹窗没了即死状态。serde 宽容旧库残留键（无 deny_unknown_fields），下次全量保存自然挤掉
- 合并保护闸与契约测试同步（`star_reward_claimed` 等后端专有字段保护不变）

## 不受影响

- 红点入口：`GitHubStarButton` 的 `showDot` 只看 `star_reward_claimed`（durable 判据），不依赖 offered 标志
- Star 对话框本体与领取/发码流程（`star_reward_offer` 命令 → 弹窗 → `onboarding_open_register_window`）原样保留
- `ONBOARDING_REGISTER_COMPLETED` 事件保留（注册窗完成 toast/档位预配照旧）

## 验证

- cargo check --all-targets / cargo fmt ✓
- 事件对账 28 测试、settings 合并闸、onboarding 测试 ✓
- pnpm typecheck / format:check ✓