### PR TITLE
feat(star): gh CLI 自动点星回归——后台尽力而为，领取主流程零等待

### DIFF
--- a/src-tauri/src/commands/star_reward.rs
+++ b/src-tauri/src/commands/star_reward.rs
@@ -1,17 +1,27 @@
-//! 「点 Star 领注册礼」的机制层：弹窗邀请 payload 的组装与领取标志落库。
+//! 「点 Star 领注册礼」的机制层：弹窗邀请 payload 的组装、领取标志落库与
+//! gh CLI 自动点星。
 //!
-//! 策略（什么时候弹、弹给谁）在 `commands::onboarding`（首个站点接入后邀请）
-//! 与前端 `GitHubStarButton` / `StarRewardDialog`（红点入口与弹窗状态机）；
+//! 策略（什么时候弹、弹给谁）在 `commands::onboarding` 与前端
+//! `GitHubStarButton` / `StarRewardDialog`（红点入口与弹窗状态机）；
 //! 本模块只提供两端共用的机制：
 //! - 邀请 payload：纯本地组装（读远端配置缓存，不打任何网络）；
-//! - `star_reward_claimed` 的窄命令 RMW 落库。
+//! - `star_reward_claimed` 的窄命令 RMW 落库；
+//! - gh CLI 自动点星：**后台尽力而为**，不参与任何校验。
 //!
-//! 发放语义是**荣誉制**：点击「领取」= 打开浏览器仓库页 + 当场发码，**有意
-//! 不做任何 Star 校验**。校验（gh CLI 代点 / 前后星数比对）都要打 GitHub API，
-//! 国内网络下是长达 20s 的无反馈等待，用户感知就是「卡死」—— 低摩擦换转化，
-//! 不为校验付出这个代价。
+//! 发放语义是**荣誉制**：点击「领取」= 打开浏览器仓库页 + 当场发码，不做
+//! 任何 Star 校验（校验要打 GitHub API，国内网络下是 20s 级无反馈等待，
+//! 用户感知就是「卡死」，331b532f 拆的就是它）。自动点星是同一决策下的
+//! 顺手便利：gh 装了且登录了就替用户点上，**成败都不影响领取** —— 见
+//! [`star_reward_auto_star`] 的三道保险。
 
 use serde::Serialize;
+
+use crate::config::GITHUB_REPO;
+
+/// gh 点星的整条通路预算（含进程启动与网络）。超时即杀：网络再差也只烧
+/// 这么多**后台**时间，主流程本来就零等待，这道闸管的是不留孤儿进程与
+/// 日志噪音。
+const GH_STAR_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 
 /// Star 对话框的 payload：`star_reward_offer` 命令返回（顶栏红点是唯一入口，
 /// 曾经的主动弹窗事件已删）；前端 `src/lib/api/starReward.ts` 的 `StarRewardOffer` 与之对应。
@@ -61,4 +71,89 @@ pub fn star_reward_mark_claimed() -> Result<(), String> {
         settings.star_reward_claimed = Some(true);
     })
     .map_err(|e| e.to_string())
+}
+
+/// gh CLI 自动点星（荣誉制下的顺手便利，不是校验）。命令**立即返回**，
+/// 点星在后台任务里尽力而为，成败只进日志 —— 领取主流程（发码/开浏览器/
+/// 开注册窗）零等待。
+///
+/// ## 三道保险（2026-08-15 版的教训，旧版让用户「点完卡死」的根因复盘）
+///
+/// 旧版 [`github_star_via_gh`] 的问题不在命令本身（它已带超时），而在
+/// **主流程 await 它**：国内网络 gh 打 GitHub API 是 20s 级等待，配合
+/// 当时的星数校验，用户点完领取要干等半分钟。现在的形状把三道保险焊死：
+///
+/// - **后台任务**：本命令 spawn 后立刻 `Ok(())`，前端 fire-and-forget，
+///   任何结局都碰不到领取路径；
+/// - **stdin = null**：gh 缺登录态时会交互式提示（等终端输入 = 真·永久
+///   挂起），关掉 stdin 让它立即以非零退出；
+/// - **3s 超时 + kill_on_drop**：网络黑洞也只烧 3 秒后台预算，不留孤儿进程。
+///
+/// 通路边界沿用 2026-08-15 的决定：**只用 gh 自己的鉴权**，不去碰 git
+/// 凭据（keychain 里的 PAT scope 不可控，用 push 令牌点星信任面太难看）。
+/// PUT starred 幂等，重复调用无害；没装/没登录 gh 就静默跳过，浏览器里
+/// 开着的仓库页仍是荣誉制的最终落点。
+#[tauri::command]
+pub async fn star_reward_auto_star() -> Result<(), String> {
+    tauri::async_runtime::spawn(async move {
+        if let Err(error) = star_via_gh().await {
+            log::info!("gh 自动点星未成（不影响领取，荣誉制不校验）: {error}");
+        }
+    });
+    Ok(())
+}
+
+/// `GITHUB_REPO`（`https://github.com/{owner}/{repo}`）→ REST API 与 gh CLI 用的
+/// `{owner}/{repo}`。从同一个常量派生而不是另写一份 —— 仓库搬家时只改一处。
+fn repo_api_slug() -> &'static str {
+    GITHUB_REPO.trim_start_matches("https://github.com/")
+}
+
+/// 逐个安装位试 `gh api --method PUT /user/starred/{owner}/{repo}`。
+/// spawn 失败（NotFound）= 该位置没装，试下一个；跑起来但失败（没登录 /
+/// scope 不够）= 换路径没意义（同一个 gh），判这条路不通。
+async fn star_via_gh() -> Result<(), String> {
+    // macOS 从 Finder/Dock 启动的 GUI 进程拿到的 PATH 很短，brew 装的 gh
+    // 不在里面 —— 先探测常见安装位，最后才试 PATH（Windows 的 winget
+    // 安装一般进 PATH，`gh` 那一项是给它用的）。
+    let candidates = [
+        "/opt/homebrew/bin/gh",
+        "/usr/local/bin/gh",
+        r"C:\Program Files\GitHub CLI\gh.exe",
+        "gh",
+    ];
+    for candidate in candidates {
+        let mut command = tokio::process::Command::new(candidate);
+        command
+            .args([
+                "api",
+                "--method",
+                "PUT",
+                &format!("/user/starred/{}", repo_api_slug()),
+            ])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            // 超时后（下面 await 那层 drop）顺手杀掉，不留孤儿 gh 进程。
+            .kill_on_drop(true);
+
+        let output = match tokio::time::timeout(GH_STAR_TIMEOUT, command.output()).await {
+            Ok(Ok(output)) => output,
+            Ok(Err(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+                // 这个位置没装，试下一个候选。
+                continue;
+            }
+            Ok(Err(error)) => return Err(format!("gh 启动失败（{candidate}）: {error}")),
+            Err(_) => return Err(format!("gh 超时（{candidate}，>{GH_STAR_TIMEOUT:?}）")),
+        };
+
+        if output.status.success() {
+            return Ok(());
+        }
+        return Err(format!(
+            "gh 退出码非零（{candidate}，没登录/scope 不够都正常）: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Err("没找到 gh（四个安装位都没探测到）".to_string())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1634,6 +1634,7 @@ pub fn run() {
             commands::onboarding_open_register_window,
             commands::star_reward_offer,
             commands::star_reward_mark_claimed,
+            commands::star_reward_auto_star,
             commands::relay_check_session,
             commands::crowd_get_snapshot,
             commands::relay_stats_endpoint_configured,

--- a/src/components/StarRewardDialog.tsx
+++ b/src/components/StarRewardDialog.tsx
@@ -72,6 +72,9 @@ export function StarRewardDialog({
     // 开默认浏览器（系统 handler 自带焦点切换）。打不开也照样发码 ——
     // 用户仍可自己去仓库页点星。
     settingsApi.openExternal(GITHUB_REPO).catch(() => {});
+    // gh 自动点星（后台尽力而为，命令立即返回）：装了且登录了 gh 就替用户
+    // 点上，成败只进日志 —— 荣誉制不校验，浏览器里的仓库页仍是最终落点。
+    starRewardApi.autoStar().catch(() => {});
     grant();
   };
 

--- a/src/components/__tests__/StarRewardDialog.test.tsx
+++ b/src/components/__tests__/StarRewardDialog.test.tsx
@@ -5,15 +5,20 @@ import { describe, expect, it, vi } from "vitest";
 import type { StarRewardOffer } from "@/lib/api";
 import { StarRewardDialog } from "@/components/StarRewardDialog";
 
-const { openRegisterWindow, openExternal, markClaimed } = vi.hoisted(() => ({
-  openRegisterWindow: vi.fn(),
-  openExternal: vi.fn(),
-  markClaimed: vi.fn(),
-}));
+const { openRegisterWindow, openExternal, markClaimed, autoStar } = vi.hoisted(
+  () => ({
+    openRegisterWindow: vi.fn(),
+    openExternal: vi.fn(),
+    markClaimed: vi.fn(),
+    // 默认 resolved：组件对它是 fire-and-forget（.catch 兜底），mock 返回
+    // undefined 会在 .catch 上直接 TypeError。
+    autoStar: vi.fn().mockResolvedValue(undefined),
+  }),
+);
 
 vi.mock("@/lib/api", () => ({
   settingsApi: { openExternal },
-  starRewardApi: { openRegisterWindow, markClaimed },
+  starRewardApi: { openRegisterWindow, markClaimed, autoStar },
 }));
 vi.mock("@/lib/clipboard", () => ({
   copyText: vi.fn().mockResolvedValue(undefined),
@@ -48,6 +53,8 @@ describe("StarRewardDialog", () => {
     expect(openExternal).toHaveBeenCalledWith(
       "https://github.com/SailingLoong/LoongPort",
     );
+    // gh 自动点星在领取时刻 fire-and-forget（后台尽力而为，不参与断言成败）
+    expect(autoStar).toHaveBeenCalled();
     expect(markClaimed).toHaveBeenCalled();
     await waitFor(() =>
       expect(openRegisterWindow).toHaveBeenCalledWith("LOONGPORT5"),

--- a/src/lib/api/starReward.ts
+++ b/src/lib/api/starReward.ts
@@ -31,4 +31,10 @@ export const starRewardApi = {
   async openRegisterWindow(promoCode: string): Promise<void> {
     await invoke("onboarding_open_register_window", { promoCode });
   },
+
+  /** gh CLI 自动点星（领取时刻调用）：命令立即返回，点星在后台尽力而为
+   * （3s 超时 + stdin 关闭 + kill_on_drop），成败只进后端日志、不影响领取。 */
+  async autoStar(): Promise<void> {
+    await invoke("star_reward_auto_star");
+  },
 };


### PR DESCRIPTION
## 背景

维护者要求恢复自动点星（gh 通路，经确认不做 git 凭据通路）。旧版（795f782e，331b532f 拆除）让用户「点完卡死」的根因复盘：**不在 gh 命令本身**（旧命令已带 3s 超时 + stdin null + kill_on_drop），而在**主流程 await 校验结果**——国内网络下 GitHub API 是 20s 级无反馈等待，配合当时的星数比对，用户点完领取要干等半分钟。

## 设计：三道保险

1. **后台任务**：`star_reward_auto_star` 命令 spawn 后立即返回；前端在领取点击处 fire-and-forget。发码/开浏览器/开注册窗零等待，点星任何结局都碰不到主流程
2. **stdin = null**：gh 缺登录态时会交互式提示（等终端输入 = 真·永久挂起），关掉 stdin 让它立即非零退出
3. **3s 超时 + kill_on_drop**：网络黑洞只烧 3 秒后台预算，不留孤儿 gh 进程

命令本体复用旧版实测过的形状（四个安装位探测：homebrew 两处 / Windows Program Files / PATH——macOS GUI 进程 PATH 很短 brew 不在里面）。

## 语义边界

- **荣誉制不变**：点星成败不影响发码，浏览器仓库页仍是最终落点；没装/没登录 gh 静默跳过
- **通路边界**（2026-08-15 决定沿用）：只用 gh 自己的鉴权，**不碰 git 凭据**（keychain PAT scope 不可控、push 令牌点星信任面难看）
- PUT starred 幂等，重复调用无害

## 验证

- cargo check --all-targets / fmt / star_reward 测试 ✓
- pnpm typecheck / format / StarRewardDialog 3 测试（含新增 autoStar 触发断言 + mock 默认 resolved 防 .catch TypeError）✓