### PR TITLE
feat(cli): loongport-cli 独立静态配置工具——无桌面/老发行版 Linux 的最简接入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,20 @@ jobs:
       - name: Run tests
         run: cargo test --manifest-path src-tauri/Cargo.toml
 
+      # loongport-cli（无桌面静态包）的纯净闸：GUI 关掉后库必须仍能编译。
+      # 有人往共享模块里加了 tauri 引用就会在这里红——否则只有 release
+      # 打 musl 包时才炸。警告不拦（no-gui 下大量 gui-only 代码成为死代码，
+      # 属预期），只拦编译错误。
+      - name: Headless build check (no-default-features, musl target)
+        if: runner.os == 'Linux'
+        run: |
+          # 用 musl 目标检查：openssl 等 target 特有依赖问题只在 musl 下暴露
+          # （曾在 VPS 构建时才炸过一次）。GNU 宿主的 no-gui 检查覆盖不了这层。
+          sudo apt-get install -y --no-install-recommends musl-tools >/dev/null
+          rustup target add x86_64-unknown-linux-musl
+          cargo check --no-default-features --manifest-path src-tauri/Cargo.toml \
+            --target x86_64-unknown-linux-musl
+
   backend-windows-wsl2:
     name: Backend Checks (Windows + WSL2 home)
     runs-on: windows-2025

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,8 @@ jobs:
             file \
             patchelf \
             libssl-dev \
+            # loongport-cli 静态包的 musl 工具链（ring/rusqlite 的 C 编译要 musl-gcc）
+            musl-tools \
             rpm \
             elfutils \
             xdg-utils
@@ -428,6 +430,17 @@ jobs:
       - name: Build Tauri App (Linux)
         if: runner.os == 'Linux'
         run: pnpm tauri build --bundles appimage,deb,rpm
+
+      # 无桌面（服务器、Ubuntu 20.04 等老发行版）用户的一次性配置工具。
+      # GUI 三件套在 focal 上不可安装（webkit2gtk-4.1 缺失 + glibc 符号墙），
+      # 静态 musl 是它们唯一的接入路径。不参与 updater。
+      - name: Build Headless CLI (x86_64 musl static)
+        if: runner.os == 'Linux'
+        run: |
+          rustup target add x86_64-unknown-linux-musl
+          cargo build --release --no-default-features \
+            --target x86_64-unknown-linux-musl \
+            --manifest-path src-tauri/Cargo.toml --bin loongport-cli
 
       - name: Prepare macOS Assets
         if: runner.os == 'macOS'
@@ -742,6 +755,17 @@ jobs:
           else
             echo "No .deb found (optional)"
           fi
+          # 无桌面配置工具：静态 musl 单文件，打 tar.gz（保留可执行位）。
+          # 缺它是硬失败——release 清单里宣告了这个下载项，静默缺失等于
+          # 20.04 用户拿着 404 排查自己的问题。
+          CLI_BIN="src-tauri/target/x86_64-unknown-linux-musl/release/loongport-cli"
+          if [ ! -f "$CLI_BIN" ]; then
+            echo "No loongport-cli musl binary found" >&2
+            exit 1
+          fi
+          CLI_TAR="LoongPort-CLI-${VERSION}-Linux-x86_64.tar.gz"
+          tar -C "$(dirname "$CLI_BIN")" -czf "release-assets/$CLI_TAR" loongport-cli
+          echo "Headless CLI copied: $CLI_TAR"
           # 额外上传 .rpm（用于 Fedora/RHEL/openSUSE 等，不参与 Updater）
           RPM=$(find src-tauri/target/release/bundle -name "*.rpm" | head -1 || true)
           if [ -n "$RPM" ]; then

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -753,6 +753,7 @@ dependencies = [
  "objc2",
  "objc2-app-kit",
  "once_cell",
+ "openssl",
  "psl",
  "regex",
  "reqwest 0.12.28",
@@ -3699,6 +3700,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3706,6 +3716,7 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,8 +18,41 @@ name = "cc_switch_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 doctest = false
 
+# GUI 主程序：带 tauri 的构建才有意义（main.rs 调 run()）。显式声明是为了
+# 挂 required-features —— `--no-default-features` 时只构建 loongport-cli。
+[[bin]]
+name = "cc-switch"
+path = "src/main.rs"
+required-features = ["gui"]
+
+[[bin]]
+# 无桌面（服务器/老发行版）用户的一次性配置工具：静态 musl 构建，
+# 不带 tauri/GTK/webkit（见 `gui` feature 注释）。与 GUI 共享同一份
+# 配置写入逻辑（`cli` 模块只是薄编排），唯源不分叉。
+name = "loongport-cli"
+path = "src/bin/loongport_cli.rs"
+
 [features]
-default = []
+default = ["gui"]
+# 图形界面全套：tauri 及其插件、剪贴板/开机自启/WebKitGTK 绑定。
+# 关掉它构建的就是无 GUI 的库（+ loongport-cli），用于静态 musl 包——
+# Ubuntu 20.04 等老发行版跑不了 GUI 二进制（webkit2gtk-4.1 缺失 +
+# glibc 2.35 符号墙），CLI 是它们唯一的接入路径。
+gui = [
+    "tauri",
+    "tauri-plugin-log",
+    "tauri-plugin-opener",
+    "tauri-plugin-process",
+    "tauri-plugin-updater",
+    "tauri-plugin-dialog",
+    "tauri-plugin-store",
+    "tauri-plugin-deep-link",
+    "tauri-plugin-window-state",
+    "tauri-plugin-single-instance",
+    "arboard",
+    "auto-launch",
+    "webkit2gtk",
+]
 test-hooks = []
 
 [build-dependencies]
@@ -30,21 +63,21 @@ serde_json = { version = "1.0", features = ["preserve_order", "raw_value"] }
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
-tauri = { version = "2.8.2", features = ["tray-icon", "protocol-asset", "image-png"] }
-tauri-plugin-log = "2"
-tauri-plugin-opener = "2"
-tauri-plugin-process = "2"
-tauri-plugin-updater = "2"
-tauri-plugin-dialog = "2"
-tauri-plugin-store = "2"
-tauri-plugin-deep-link = "2"
-tauri-plugin-window-state = "2"
+tauri = { version = "2.8.2", features = ["tray-icon", "protocol-asset", "image-png"], optional = true }
+tauri-plugin-log = { version = "2", optional = true }
+tauri-plugin-opener = { version = "2", optional = true }
+tauri-plugin-process = { version = "2", optional = true }
+tauri-plugin-updater = { version = "2", optional = true }
+tauri-plugin-dialog = { version = "2", optional = true }
+tauri-plugin-store = { version = "2", optional = true }
+tauri-plugin-deep-link = { version = "2", optional = true }
+tauri-plugin-window-state = { version = "2", optional = true }
 dirs = "6.0"
 toml = "1.0"
 toml_edit = "0.25"
 reqwest = { version = "0.12", features = ["rustls-tls", "json", "stream", "socks"] }
 cookie = "0.18.1"
-arboard = "3.6"
+arboard = { version = "3.6", optional = true }
 flate2 = "1"
 brotli = "8"
 zstd = "0.13"
@@ -75,7 +108,7 @@ zip = "4.6"
 serde_yaml = "0.9"
 tempfile = "3"
 url = "2.5"
-auto-launch = "0.6"
+auto-launch = { version = "0.6", optional = true }
 once_cell = "1.21.3"
 base64 = "0.23"
 rusqlite = { version = "0.40", features = ["bundled", "backup", "hooks"] }
@@ -99,10 +132,16 @@ sys-locale = "0.3"
 psl = "2.1.229"
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))'.dependencies]
-tauri-plugin-single-instance = "2"
+tauri-plugin-single-instance = { version = "2", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-webkit2gtk = { version = "2.0.1", features = ["v2_16"] }
+webkit2gtk = { version = "2.0.1", features = ["v2_16"], optional = true }
+
+# musl 静态包（loongport-cli）专用：reqwest 的 default-tls（native-tls）在
+# musl 下没有系统 openssl 可链，vendored 让它随包静态编进去。GUI 构建
+# （gnu 目标）不走这段，TLS 行为零变化。
+[target.'cfg(target_env = "musl")'.dependencies]
+openssl = { version = "0.10", features = ["vendored"] }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 libc = "0.2"

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,5 +1,10 @@
 fn main() {
-    tauri_build::build();
+    // GUI 构建才跑 tauri_build（前端资源嵌入、应用 manifest 等）；无 GUI
+    // 构建（loongport-cli 静态包）没有 tauri 依赖，构建脚本必须整个跳过。
+    // build script 里看不到 cfg(feature)，只能读 cargo 注入的环境变量。
+    if std::env::var_os("CARGO_FEATURE_GUI").is_some() {
+        tauri_build::build();
+    }
 
     // Windows: Embed Common Controls v6 manifest for test binaries
     //

--- a/src-tauri/src/app_store.rs
+++ b/src-tauri/src/app_store.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
 use std::path::PathBuf;
 use std::sync::{OnceLock, RwLock};
+#[cfg(feature = "gui")]
 use tauri_plugin_store::StoreExt;
 
 use crate::error::AppError;
@@ -95,6 +96,7 @@ fn tauri_store_path() -> Option<PathBuf> {
     Some(base.join(identifier).join("app_paths.json"))
 }
 
+#[cfg(feature = "gui")]
 fn read_override_from_store(app: &tauri::AppHandle) -> Option<PathBuf> {
     let store = match app.store_builder("app_paths.json").build() {
         Ok(store) => store,
@@ -133,6 +135,7 @@ fn read_override_from_store(app: &tauri::AppHandle) -> Option<PathBuf> {
 }
 
 /// 从 Store 刷新 app_config_dir 覆盖值并更新缓存
+#[cfg(feature = "gui")]
 pub fn refresh_app_config_dir_override(app: &tauri::AppHandle) -> Option<PathBuf> {
     let value = read_override_from_store(app);
     update_cached_override(value.clone());
@@ -140,6 +143,7 @@ pub fn refresh_app_config_dir_override(app: &tauri::AppHandle) -> Option<PathBuf
 }
 
 /// 写入 app_config_dir 到 Tauri Store
+#[cfg(feature = "gui")]
 pub fn set_app_config_dir_to_store(
     app: &tauri::AppHandle,
     path: Option<&str>,
@@ -193,6 +197,7 @@ fn resolve_path(raw: &str) -> PathBuf {
     PathBuf::from(raw)
 }
 
+#[cfg(feature = "gui")]
 /// 从旧的 settings.json 迁移 app_config_dir 到 Store
 pub fn migrate_app_config_dir_from_settings(app: &tauri::AppHandle) -> Result<(), AppError> {
     // app_config_dir 已从 settings.json 移除，此函数保留但不再执行迁移

--- a/src-tauri/src/bin/loongport_cli.rs
+++ b/src-tauri/src/bin/loongport_cli.rs
@@ -1,0 +1,10 @@
+//! `loongport-cli`：无桌面环境（服务器、老发行版）的一次性配置入口。
+//!
+//! 与 GUI 二进制共享同一份库（`cc_switch_lib`），但用 `--no-default-features`
+//! 构建——不带 tauri/GTK/webkit，静态链接（musl）后可在任何 x86_64 Linux 上
+//! 跑，包括 GUI 版无法安装的 Ubuntu 20.04（webkit2gtk-4.1 缺失 + glibc 符号墙）。
+//! 逻辑全部在 [`cc_switch_lib::cli`]，这里只做进程入口。
+
+fn main() {
+    std::process::exit(cc_switch_lib::cli::run_add_site());
+}

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -1,7 +1,8 @@
-//! `--add-site`：一次性 CLI 配置，给无桌面 Linux（服务器）用户的最简接入路径。
+//! `loongport-cli --add-site`：一次性 CLI 配置，给无桌面 Linux（服务器、
+//! Ubuntu 20.04 等跑不了 GUI 二进制的老发行版）用户的最简接入路径。
 //!
 //! ```text
-//! LoongPort --add-site https://example.com --key sk-xxx [--app codex] [--model gpt-5.4]
+//! loongport-cli --add-site https://example.com --key sk-xxx [--app codex] [--model gpt-5.4]
 //! ```
 //!
 //! ## 定位（2026-09-06 立项时的边界，别滑成 daemon 产品线）
@@ -10,6 +11,13 @@
 //! CLI 配置文件写好就退出。不进 LoongPort 自己的数据库（服务器和桌面是两台
 //! 机器，互不影响），不做登录窗/多账号/档位/路由 —— 那些等真实服务器用户
 //! 反馈再议。
+//!
+//! ## 打包形状（为什么是独立 bin 而不是 GUI 二进制的 flag）
+//!
+//! GUI 二进制在 Ubuntu 20.04 上**加载期**就挂（focal 源无 webkit2gtk-4.1、
+//! glibc 2.35 符号墙），挂在 main.rs 的 flag 分流永远轮不到执行。所以这个
+//! 入口做成独立 bin，`--no-default-features --target x86_64-unknown-linux-musl`
+//! 静态构建，零动态依赖，任何 x86_64 Linux 都能跑。
 //!
 //! ## 复用面（几乎零新逻辑）
 //!
@@ -21,11 +29,11 @@
 //! - 落盘：[`write_live_snapshot`](crate::services::provider::write_live_snapshot)
 //!   （GUI 切档走的同一批文件级写入函数）
 //!
-//! ## 分流时机的约束（同 `--mcp-image-gen`）
+//! ## 异步边界
 //!
-//! 必须在 [`crate::run`] **之前**分流：`run()` 挂了 single-instance，GUI 已在跑
-//! 时第二个实例的参数会被转交给它并弹窗。服务器上没有 GUI，但「装着桌面版
-//! 的机器上跑 CLI」同样会被截走 —— 所以这里不碰 Tauri 的任何东西。
+//! 探测/拉模型是异步的，写盘是同步的（复用 GUI 的同步写入函数）。两个阶段
+//! 在 [`run_add_site`] 里先后完成——不在异步上下文里调用写盘路径，避免
+//! [`crate::rt::block_on`] 嵌套。
 
 use std::io::{IsTerminal, Write};
 use std::str::FromStr;
@@ -41,14 +49,18 @@ pub const ADD_SITE_FLAG: &str = "--add-site";
 /// 重复跑 = 覆盖同一 id（last-write-wins），不会堆积残条目。
 const CLI_PROVIDER_ID: &str = "loongport-relay";
 
-pub fn is_add_site_mode() -> bool {
-    std::env::args().any(|a| a == ADD_SITE_FLAG)
-}
-
 /// CLI 入口：返回进程退出码。不初始化 Tauri / GTK / 日志（写路径里的 `log::*`
 /// 在无 logger 时静默丢弃，真实错误都走 `Result` 返回）。
 pub fn run_add_site() -> i32 {
     let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.iter().any(|a| a == "--help" || a == "-h") {
+        println!("{USAGE}");
+        return 0;
+    }
+    if args.iter().any(|a| a == "--version" || a == "-V") {
+        println!("loongport-cli {}", env!("CARGO_PKG_VERSION"));
+        return 0;
+    }
     let options = match parse_args(&args) {
         Ok(options) => options,
         Err(message) => {
@@ -66,7 +78,14 @@ pub fn run_add_site() -> i32 {
             return 1;
         }
     };
-    match runtime.block_on(add_site(options)) {
+    let prepared = match runtime.block_on(prepare(options)) {
+        Ok(prepared) => prepared,
+        Err(message) => {
+            eprintln!("❌ {message}");
+            return 1;
+        }
+    };
+    match write_config(prepared) {
         Ok(()) => 0,
         Err(message) => {
             eprintln!("❌ {message}");
@@ -76,7 +95,7 @@ pub fn run_add_site() -> i32 {
 }
 
 const USAGE: &str = "用法:
-  LoongPort --add-site <站点域名或完整网址> --key <sk-密钥> [--app <codex|claude|gemini|grok|opencode|openclaw|hermes>] [--model <模型id>]
+  loongport-cli --add-site <站点域名或完整网址> --key <sk-密钥> [--app <codex|claude|gemini|grok|opencode|openclaw|hermes>] [--model <模型id>]
 
 说明:
   --app    要配置的 CLI，默认 codex
@@ -88,6 +107,16 @@ struct AddSiteOptions {
     key: String,
     app: AppType,
     model: Option<String>,
+}
+
+/// 异步阶段的产出：探测与模型选择做完，剩下的全是同步写盘。
+struct Prepared {
+    site_origin: String,
+    site_name: String,
+    base_url: String,
+    key: String,
+    app: AppType,
+    model: String,
 }
 
 fn parse_args(args: &[String]) -> Result<AddSiteOptions, String> {
@@ -142,7 +171,8 @@ where
         .ok_or_else(|| format!("{flag} 需要一个值"))
 }
 
-async fn add_site(options: AddSiteOptions) -> Result<(), String> {
+/// 异步阶段：探测站点协议、确定 base_url、选定模型。
+async fn prepare(options: AddSiteOptions) -> Result<Prepared, String> {
     let site_origin =
         api::normalize_site_origin(&options.site).map_err(|e| format!("站点地址无法解析: {e}"))?;
     println!("探测站点 {site_origin} …");
@@ -165,12 +195,32 @@ async fn add_site(options: AddSiteOptions) -> Result<(), String> {
         None => pick_model(&base_url, &options.key).await?,
     };
 
-    let settings =
-        provision::settings_config_for(&options.app, &options.key, &site_name, &base_url, &model)
-            .ok_or_else(|| {
+    Ok(Prepared {
+        site_origin,
+        site_name,
+        base_url,
+        key: options.key,
+        app: options.app,
+        model,
+    })
+}
+
+/// 同步阶段：生成配置并落盘（GUI 切档同批写入函数）。
+fn write_config(prepared: Prepared) -> Result<(), String> {
+    let Prepared {
+        site_origin,
+        site_name,
+        base_url,
+        key,
+        app,
+        model,
+    } = prepared;
+
+    let settings = provision::settings_config_for(&app, &key, &site_name, &base_url, &model)
+        .ok_or_else(|| {
             format!(
                 "无法为 {} 生成配置（该 CLI 暂不支持 CLI 接入）",
-                options.app.as_str()
+                app.as_str()
             )
         })?;
 
@@ -180,16 +230,16 @@ async fn add_site(options: AddSiteOptions) -> Result<(), String> {
         settings,
         Some(site_origin.clone()),
     );
-    crate::services::provider::write_live_snapshot(&options.app, &provider)
+    crate::services::provider::write_live_snapshot(&app, &provider)
         .map_err(|e| format!("写入配置失败: {e}"))?;
 
     println!();
     println!(
         "✅ 已为 {} 配置「{site_name}」（模型 {model}）",
-        options.app.as_str()
+        app.as_str()
     );
     println!("   密钥已写进 CLI 自己的配置文件，无需再设环境变量。");
-    println!("   验证: {}", verify_hint(&options.app));
+    println!("   验证: {}", verify_hint(&app));
     println!("   （本命令只写该 CLI 的配置文件，不涉及 LoongPort 图形界面数据。）");
     Ok(())
 }

--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -42,6 +42,7 @@ use crate::app_config::AppType;
 use crate::error::AppError;
 use crate::events::{emit_provider_switched, PURCHASE_CLOSED};
 use crate::provider::Provider;
+use crate::relay::provision::models_from_settings;
 use crate::relay::{
     api, backend, balance, browser_bridge, chatgpt_app, creds, discovery, imagegen, imagegen_mcp,
     login, model_verification::target as verification_target, newapi, newapi_provision,
@@ -4504,23 +4505,10 @@ fn tiers_of_site(
 // 拿一份不带归属的扁平列表没法渲染。2026-08-04 删掉命令壳，
 // `list_tiers_impl` 留着（`list_relays_impl` 在用它）。
 
-/// 内部版本额外带出每条档位的 `website_url`（= 所属站点的 origin），供
-/// [`list_relays_impl`] 按站分组。命令层把它丢掉 —— 那是实现细节，不进对外契约。
-///
-/// `pub(crate)`：托盘的「模型」子菜单也从这里取目录（同一份 `modelCatalog` 两个消费者）。
-pub(crate) fn models_from_settings(settings: &serde_json::Value) -> Vec<String> {
-    settings
-        .get("modelCatalog")
-        .and_then(|catalog| catalog.get("models"))
-        .and_then(serde_json::Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter_map(|entry| entry.get("model").and_then(serde_json::Value::as_str))
-        .map(str::trim)
-        .filter(|model| !model.is_empty())
-        .map(str::to_string)
-        .collect()
-}
+// 拿一份不带归属的扁平列表没法渲染。2026-08-04 删掉命令壳，
+// `list_tiers_impl` 留着（`list_relays_impl` 在用它）。
+// （托盘「模型」子菜单与自动模式共用的目录解析已搬到
+// `relay::provision::models_from_settings`。）
 
 /// A LoongPort model-chip click is a managed preference, so refreshing the
 /// tier should keep it while the newly fetched catalog still advertises it.

--- a/src-tauri/src/crowd/mod.rs
+++ b/src-tauri/src/crowd/mod.rs
@@ -50,4 +50,5 @@ pub mod bins;
 pub mod bucket;
 pub mod events;
 pub mod snapshot;
+#[cfg(feature = "gui")]
 pub mod uploader;

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -94,7 +94,9 @@ fn register_db_change_hook(conn: &Connection) -> Result<(), AppError> {
     conn.update_hook(Some(
         |action: Action, _database: &str, table: &str, _row_id: i64| match action {
             Action::SQLITE_INSERT | Action::SQLITE_UPDATE | Action::SQLITE_DELETE => {
+                #[cfg(feature = "gui")]
                 crate::services::webdav_auto_sync::notify_db_changed(table);
+                #[cfg(feature = "gui")]
                 crate::services::s3_auto_sync::notify_db_changed(table);
             }
             _ => {}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,15 +1,17 @@
 mod app_config;
 mod app_store;
+#[cfg(feature = "gui")]
 mod auto_launch;
 mod claude_desktop_config;
 mod claude_mcp;
 mod claude_plugin;
-/// `--add-site` 一次性 CLI 配置（无桌面服务器用户）。分流在 `main.rs`，
-/// 必须发生在 [`run`] 之前（single-instance 会把参数转交给 GUI 实例）。
+/// `loongport-cli` 的一次性配置逻辑（无桌面服务器用户）。独立 bin 入口在
+/// `src/bin/loongport_cli.rs`，与 GUI 共享本库——唯源不分叉。
 pub mod cli;
 mod codex_config;
 mod codex_history_migration;
 mod codex_state_db;
+#[cfg(feature = "gui")]
 mod commands;
 mod config;
 mod crowd;
@@ -22,8 +24,9 @@ mod gemini_mcp;
 mod grok_config;
 pub mod hermes_config;
 mod init_status;
+#[cfg(feature = "gui")]
 mod lightweight;
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", feature = "gui"))]
 mod linux_fix;
 mod maintenance;
 mod mcp;
@@ -37,6 +40,8 @@ mod prompt_files;
 mod provider;
 mod proxy;
 mod relay;
+/// 异步执行桥：GUI 走 tauri 全局运行时，无 GUI 构建自建 tokio（见模块注释）。
+mod rt;
 mod services;
 mod session_manager;
 mod settings;
@@ -49,7 +54,9 @@ mod store;
 #[cfg(test)]
 mod support_matrix;
 
+#[cfg(feature = "gui")]
 mod events;
+#[cfg(feature = "gui")]
 mod tray;
 mod usage_events;
 mod usage_script;
@@ -60,7 +67,9 @@ pub use codex_config::{
     get_codex_auth_path, get_codex_config_path, prepare_codex_provider_live_config,
     read_codex_live_settings, write_codex_live_atomic, write_codex_live_config_atomic,
 };
+#[cfg(feature = "gui")]
 pub use commands::open_provider_terminal;
+#[cfg(feature = "gui")]
 pub use commands::*;
 pub use config::{
     get_claude_mcp_path, get_claude_settings_path, read_json_file, APP_DIR_NAME, DB_FILE_NAME,
@@ -88,17 +97,27 @@ pub use services::{
 pub use settings::{update_settings, AppSettings};
 pub use store::AppState;
 
+#[cfg(feature = "gui")]
 use tauri_plugin_deep_link::DeepLinkExt;
+#[cfg(feature = "gui")]
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 
+use std::fmt;
+#[cfg(feature = "gui")]
 #[cfg(target_os = "windows")]
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::{fmt, sync::Arc};
+#[cfg(feature = "gui")]
+use std::sync::Arc;
+#[cfg(feature = "gui")]
 #[cfg(target_os = "macos")]
 use tauri::image::Image;
+#[cfg(feature = "gui")]
 use tauri::tray::{TrayIconBuilder, TrayIconEvent};
+#[cfg(feature = "gui")]
 use tauri::RunEvent;
+#[cfg(feature = "gui")]
 use tauri::{Emitter, Manager};
+#[cfg(feature = "gui")]
 use tauri_plugin_window_state::{AppHandleExt, StateFlags};
 
 /// 主窗口的 label（`tauri.conf.json` 的 `app.windows[0].label`）。
@@ -261,10 +280,12 @@ pub(crate) fn redact_url_origin_for_log(url_str: &str) -> String {
     }
 }
 
+#[cfg(feature = "gui")]
 fn runtime_log_level_allows(level: log::Level, max_level: log::LevelFilter) -> bool {
     max_level.to_level().is_some_and(|maximum| level <= maximum)
 }
 
+#[cfg(feature = "gui")]
 /// 统一处理 ccswitch:// 深链接 URL
 ///
 /// - 解析 URL
@@ -331,6 +352,7 @@ fn handle_deeplink_url(
     true
 }
 
+#[cfg(feature = "gui")]
 /// 更新托盘菜单的Tauri命令
 #[tauri::command]
 async fn update_tray_menu(
@@ -353,6 +375,7 @@ async fn update_tray_menu(
     }
 }
 
+#[cfg(feature = "gui")]
 #[cfg(target_os = "macos")]
 fn macos_tray_icon() -> Option<Image<'static>> {
     const ICON_BYTES: &[u8] = include_bytes!("../icons/tray/macos/statusbar_template_3x.png");
@@ -389,6 +412,7 @@ pub fn run_imagegen_mcp() -> Result<(), String> {
 /// 两处各写一遍字面量迟早分叉，而症状是宿主那边"启动超时"，看不出是拼写问题。
 pub use relay::imagegen_mcp::IMAGEGEN_MCP_FLAG;
 
+#[cfg(feature = "gui")]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // 设置 panic hook，在应用崩溃时记录日志到 <app_config_dir>/crash.log（默认 ~/.loongport/crash.log）
@@ -2198,6 +2222,7 @@ pub fn run() {
 // 应用退出清理
 // ============================================================
 
+#[cfg(feature = "gui")]
 /// 应用退出前的清理工作
 ///
 /// 在应用退出前检查代理服务器状态，如果正在运行则停止代理并恢复 Live 配置。
@@ -2250,6 +2275,7 @@ pub async fn cleanup_before_exit(app_handle: &tauri::AppHandle) {
 /// 触发 tray-icon 内部的 `remove_tray_icon` → `Shell_NotifyIconW(NIM_DELETE)`，
 /// 在进程结束前干净地把图标摘掉。其它平台 `set_visible(false)` 也是
 /// 正常的隐藏/移除语义，作为跨平台兜底也安全。
+#[cfg(feature = "gui")]
 pub(crate) fn remove_tray_icon_before_exit(app_handle: &tauri::AppHandle) {
     if let Some(tray) = app_handle.tray_by_id(tray::TRAY_ID) {
         if let Err(e) = tray.set_visible(false) {
@@ -2264,12 +2290,14 @@ pub(crate) fn remove_tray_icon_before_exit(app_handle: &tauri::AppHandle) {
 // 启动时恢复代理状态
 // ============================================================
 
+#[cfg(feature = "gui")]
 /// 启动时根据 proxy_config 表中的代理状态自动恢复代理服务
 ///
 /// 检查 `proxy_config.enabled` 字段，如果有任一应用的状态为 `true`，
 /// 则自动启动代理服务并接管对应应用的 Live 配置。
 const PROXY_STARTUP_APP_TYPES: [&str; 4] = ["claude", "codex", "gemini", "grokbuild"];
 
+#[cfg(feature = "gui")]
 async fn enabled_proxy_apps_on_startup(db: &database::Database) -> Vec<&'static str> {
     let mut apps = Vec::new();
     for app_type in PROXY_STARTUP_APP_TYPES {
@@ -2284,6 +2312,7 @@ async fn enabled_proxy_apps_on_startup(db: &database::Database) -> Vec<&'static 
     apps
 }
 
+#[cfg(feature = "gui")]
 async fn restore_proxy_state_on_startup(state: &store::AppState) {
     // 收集需要恢复接管的应用列表（从 proxy_config.enabled 读取）
     let apps_to_restore = enabled_proxy_apps_on_startup(&state.db).await;
@@ -2320,6 +2349,7 @@ async fn restore_proxy_state_on_startup(state: &store::AppState) {
     }
 }
 
+#[cfg(feature = "gui")]
 fn initialize_common_config_snippets(state: &store::AppState) {
     // Auto-extract common config snippets from clean live files when snippet is missing.
     // This must run before proxy takeover is restored on startup, otherwise we'd read
@@ -2436,6 +2466,7 @@ fn initialize_common_config_snippets(state: &store::AppState) {
 // 迁移错误对话框辅助函数
 // ============================================================
 
+#[cfg(feature = "gui")]
 /// 检测是否为中文环境
 fn is_chinese_locale() -> bool {
     std::env::var("LANG")
@@ -2445,6 +2476,7 @@ fn is_chinese_locale() -> bool {
         .unwrap_or(false)
 }
 
+#[cfg(feature = "gui")]
 /// 显示迁移错误对话框
 /// 返回 true 表示用户选择重试，false 表示用户选择退出
 fn show_migration_error_dialog(app: &tauri::AppHandle, error: &str) -> bool {
@@ -2496,6 +2528,7 @@ fn show_migration_error_dialog(app: &tauri::AppHandle, error: &str) -> bool {
         .blocking_show()
 }
 
+#[cfg(feature = "gui")]
 /// 进入「数据库版本过新（应用过旧）」恢复模式。
 ///
 /// 记下 init error（前端 `main.tsx` 据 `kind = "db_version_too_new"` 渲染应用内
@@ -2521,6 +2554,7 @@ fn enter_db_version_too_new_recovery(
     }
 }
 
+#[cfg(feature = "gui")]
 /// 显示数据库初始化/Schema 迁移失败对话框
 /// 返回 true 表示用户选择重试，false 表示用户选择退出
 fn show_database_init_error_dialog(
@@ -2590,6 +2624,7 @@ fn show_database_init_error_dialog(
 // 退出请求分类
 // ============================================================
 
+#[cfg(feature = "gui")]
 /// `RunEvent::ExitRequested` 的三类来源，处理方式必须区分。
 ///
 /// 关键约束：重启请求（`code == RESTART_EXIT_CODE`）上 `prevent_exit()` 会被
@@ -2608,6 +2643,7 @@ enum ExitRequestAction {
     CleanupAndExit,
 }
 
+#[cfg(feature = "gui")]
 fn classify_exit_request(code: Option<i32>) -> ExitRequestAction {
     match code {
         None => ExitRequestAction::StayInTray,
@@ -2620,6 +2656,7 @@ fn classify_exit_request(code: Option<i32>) -> ExitRequestAction {
 // 在应用主动退出前显式持久化窗口状态
 // ============================================================
 
+#[cfg(feature = "gui")]
 /// 启动前丢弃**明显坏掉**的窗口状态。
 ///
 /// ## 为什么需要这道防护（2026-08-02 实测踩过）
@@ -2675,10 +2712,12 @@ fn discard_broken_window_state(app_config: &tauri::Config) {
     }
 }
 
+#[cfg(feature = "gui")]
 fn window_state_flags() -> StateFlags {
     StateFlags::POSITION | StateFlags::SIZE | StateFlags::MAXIMIZED
 }
 
+#[cfg(feature = "gui")]
 /// 当前应用的退出路径会拦截 `ExitRequested` 并最终直接 `std::process::exit(0)`，
 /// 这里需要在真正结束进程前手动落盘，避免 window-state 插件的默认退出钩子被绕过。
 pub fn save_window_state_before_exit(app_handle: &tauri::AppHandle) {
@@ -2689,6 +2728,7 @@ pub fn save_window_state_before_exit(app_handle: &tauri::AppHandle) {
     }
 }
 
+#[cfg(feature = "gui")]
 /// 主动释放 single-instance 锁。
 ///
 /// macOS single-instance 使用 `/tmp/{identifier}.sock`。我们有若干路径会直接
@@ -2699,6 +2739,7 @@ pub fn destroy_single_instance_lock(app_handle: &tauri::AppHandle) {
     tauri_plugin_single_instance::destroy(app_handle);
 }
 
+#[cfg(feature = "gui")]
 /// 清理托盘图标、释放 single-instance 锁后重启当前应用。
 ///
 /// 直接走 `tauri::process::restart`（spawn 新进程 + `exit(0)`），不经过事件
@@ -2715,7 +2756,7 @@ pub fn restart_process(app_handle: &tauri::AppHandle) -> ! {
     tauri::process::restart(&app_handle.env());
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "gui"))]
 mod tests {
     use super::{
         classify_exit_request, enabled_proxy_apps_on_startup, redact_url_for_log,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -32,11 +32,9 @@ fn main() {
         return;
     }
 
-    // `--add-site` 一次性配置（无桌面服务器）：同样的分流理由 —— single-instance
-    // 会把参数转交给 GUI 实例并弹窗。CLI 模式不初始化 Tauri/GTK，无 DISPLAY 也能跑。
-    if cc_switch_lib::cli::is_add_site_mode() {
-        std::process::exit(cc_switch_lib::cli::run_add_site());
-    }
+    // `--add-site` 已搬到独立 bin（`loongport-cli`，静态 musl 构建）：GUI 二进制
+    // 在 Ubuntu 20.04 等老发行版上加载期就挂（webkit2gtk-4.1 缺失 + glibc 符号墙），
+    // 挂在 main.rs 的 flag 永远轮不到执行。无桌面用户一律走 loongport-cli。
 
     // 在 Linux 上设置 WebKit 环境变量以解决 DMA-BUF 渲染问题
     // 某些 Linux 系统（如 Debian 13.2、Nvidia GPU）上 WebKitGTK 的 DMA-BUF 渲染器可能导致白屏/黑屏

--- a/src-tauri/src/maintenance/mod.rs
+++ b/src-tauri/src/maintenance/mod.rs
@@ -1,10 +1,13 @@
 pub mod config;
+#[cfg(feature = "gui")]
 pub mod scheduler;
 
+#[cfg(feature = "gui")]
 use tauri::{Emitter, Manager};
 
 pub use config::{APP_UPDATE_CHECKED_EVENT, MODELS_DEV_PRICING_UPDATED_EVENT};
 
+#[cfg(feature = "gui")]
 pub fn start(app: tauri::AppHandle) {
     start_veridrop_directory_refresh(app.clone());
     start_models_dev_pricing_refresh(app.clone());
@@ -14,6 +17,7 @@ pub fn start(app: tauri::AppHandle) {
     start_app_update_check(app);
 }
 
+#[cfg(feature = "gui")]
 /// 广场开关的存量补播种：**一次性**（写-if-None），启动即跑。
 ///
 /// 触发归属（CLAUDE.md §1.4）：播种是数据层自己的初始化动作，挂在启动上；
@@ -42,6 +46,7 @@ fn start_plaza_visibility_seeding(app: tauri::AppHandle) {
     });
 }
 
+#[cfg(feature = "gui")]
 fn start_relay_pricing_refresh(app: tauri::AppHandle) {
     let schedule = scheduler::TaskSchedule::new(
         config::RELAY_PRICING_STARTUP_DELAY,
@@ -53,6 +58,7 @@ fn start_relay_pricing_refresh(app: tauri::AppHandle) {
     });
 }
 
+#[cfg(feature = "gui")]
 /// 站点实测共建：每 15 分钟 flush 已闭合的小时桶。
 ///
 /// 门禁（`crowd_metrics_enabled`）在 `flush_once` 里读 —— 关着时任务是纯空转，
@@ -70,6 +76,7 @@ fn start_crowd_metrics_flush(app: tauri::AppHandle) {
     });
 }
 
+#[cfg(feature = "gui")]
 fn start_app_update_check(app: tauri::AppHandle) {
     let schedule = scheduler::TaskSchedule::new(
         config::UPDATE_CHECK_STARTUP_DELAY,
@@ -92,6 +99,7 @@ fn start_app_update_check(app: tauri::AppHandle) {
     });
 }
 
+#[cfg(feature = "gui")]
 fn start_veridrop_directory_refresh(app: tauri::AppHandle) {
     let schedule = scheduler::TaskSchedule::new(
         config::VERIDROP_STARTUP_DELAY,
@@ -114,6 +122,7 @@ fn start_veridrop_directory_refresh(app: tauri::AppHandle) {
     });
 }
 
+#[cfg(feature = "gui")]
 fn start_models_dev_pricing_refresh(app: tauri::AppHandle) {
     let schedule = scheduler::TaskSchedule::new(
         std::time::Duration::ZERO,

--- a/src-tauri/src/proxy/auto_strategy.rs
+++ b/src-tauri/src/proxy/auto_strategy.rs
@@ -207,7 +207,7 @@ pub fn set_model_pref(
 /// 档位的模型目录（settings_config.modelCatalog）。目前只有 Codex 系托管档位
 /// 在 provision 时写目录；返回空 = 该档位没有目录（不参与模型过滤）。
 pub fn tier_models(tier: &Provider) -> Vec<String> {
-    crate::commands::models_from_settings(&tier.settings_config)
+    crate::relay::provision::models_from_settings(&tier.settings_config)
 }
 
 /// 自动模式的可选模型清单：该应用全部托管档位模型目录的**并集**（去重）。

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -10,11 +10,15 @@ pub(crate) mod content_encoding;
 pub mod copilot_optimizer;
 pub mod error;
 pub mod error_mapper;
+#[cfg(feature = "gui")]
 pub(crate) mod failover_switch;
+#[cfg(feature = "gui")]
 mod forwarder;
 pub mod gemini_url;
 pub mod handler_config;
+#[cfg(feature = "gui")]
 pub mod handler_context;
+#[cfg(feature = "gui")]
 mod handlers;
 pub mod http_client;
 pub mod hyper_client;
@@ -24,7 +28,9 @@ pub mod media_sanitizer;
 pub mod model_mapper;
 pub mod provider_router;
 pub mod providers;
+#[cfg(feature = "gui")]
 pub mod response_processor;
+#[cfg(feature = "gui")]
 pub(crate) mod server;
 pub mod session;
 pub(crate) mod sse;
@@ -37,6 +43,7 @@ pub(crate) mod types;
 pub mod usage;
 
 #[cfg(test)]
+#[cfg(feature = "gui")]
 mod auto_mode_e2e_tests;
 
 #[cfg(test)]

--- a/src-tauri/src/relay/balance.rs
+++ b/src-tauri/src/relay/balance.rs
@@ -416,6 +416,7 @@ static REFRESH_INFLIGHT: std::sync::OnceLock<std::sync::Mutex<std::collections::
 /// 充值窗口持有独占权时后台续期会把用户踢出充值页。本链路只走 sk
 /// （`usage_with_api_key` / `billing_balance_with_api_key`），不携带登录态、
 /// 不碰 cookie。⚠️ 若将来把这条链改走登录态，必须先补「充值窗口活跃站跳过」。
+#[cfg(feature = "gui")]
 pub fn spawn_stale_refresh<R: tauri::Runtime>(
     db: std::sync::Arc<crate::database::Database>,
     app_handle: Option<tauri::AppHandle<R>>,

--- a/src-tauri/src/relay/cc_switch_import.rs
+++ b/src-tauri/src/relay/cc_switch_import.rs
@@ -471,6 +471,7 @@ pub fn execute_import(
         }
     }
 
+    #[cfg(feature = "gui")]
     if let Err(e) = crate::commands::sync_support::run_post_import_sync(&app_state) {
         warnings.push(format!("导入后同步失败: {e}"));
         log::warn!("[cc-switch-import] post-import sync: {e}");

--- a/src-tauri/src/relay/imagegen.rs
+++ b/src-tauri/src/relay/imagegen.rs
@@ -549,6 +549,7 @@ pub(crate) fn gallery_images() -> Vec<GalleryImage> {
     items
 }
 
+#[cfg(feature = "gui")]
 /// 把出图目录加进 asset 协议的运行时白名单，前端画廊才能用 `convertFileSrc` 显示。
 ///
 /// 静态 scope（tauri.conf.json）写不了这里：出图目录跟着「LoongPort 配置目录」

--- a/src-tauri/src/relay/login.rs
+++ b/src-tauri/src/relay/login.rs
@@ -770,6 +770,7 @@ const CF_CLEARANCE_COOKIE_NAME: &str = "cf_clearance";
 /// 不能像 access token 那样从 localStorage 回传。
 ///
 /// 没有该 cookie 是**正常情况**（绝大多数站没开托管挑战），返回 `None`。
+#[cfg(feature = "gui")]
 pub fn extract_cf_clearance(cookies: &[tauri::webview::Cookie<'_>]) -> Option<String> {
     cookies
         .iter()

--- a/src-tauri/src/relay/mod.rs
+++ b/src-tauri/src/relay/mod.rs
@@ -73,6 +73,7 @@ pub mod login;
 pub mod managed;
 pub mod newapi;
 pub mod newapi_provision;
+#[cfg(feature = "gui")]
 pub mod newapi_purchase;
 pub mod onboarding;
 // Phase 1 defines this crate-internal contract before Phase 2 consumes it.

--- a/src-tauri/src/relay/model_verification/coordinator.rs
+++ b/src-tauri/src/relay/model_verification/coordinator.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use futures::future::{AbortHandle, Abortable};
+#[cfg(feature = "gui")]
 use tauri::Emitter;
 
 use crate::{
@@ -39,6 +40,7 @@ pub trait ActiveVerifier: Send + Sync {
 }
 
 pub trait VerificationEventSink: Send + Sync {
+    #[cfg(feature = "gui")]
     fn attach_app_handle(&self, _app_handle: tauri::AppHandle) {}
     fn emit_progress(&self, event: &VerificationProgressEvent) -> Result<(), ()>;
     fn emit_changed(&self, scope: &TargetScope) -> Result<(), ()>;
@@ -56,11 +58,13 @@ impl VerificationEventSink for NoopEventSink {
     }
 }
 
+#[cfg(feature = "gui")]
 #[derive(Default)]
 pub(crate) struct TauriEventSink {
     app_handle: RwLock<Option<tauri::AppHandle>>,
 }
 
+#[cfg(feature = "gui")]
 impl VerificationEventSink for TauriEventSink {
     fn attach_app_handle(&self, app_handle: tauri::AppHandle) {
         *self
@@ -124,7 +128,11 @@ impl ModelVerificationCoordinator {
         let verifier = Arc::new(
             crate::relay::model_verification::active::BalancedActiveVerifier::new(db.clone()),
         );
-        Self::with_dependencies(db, verifier, Arc::new(TauriEventSink::default()))
+        #[cfg(feature = "gui")]
+        let sink: Arc<dyn VerificationEventSink> = Arc::new(TauriEventSink::default());
+        #[cfg(not(feature = "gui"))]
+        let sink: Arc<dyn VerificationEventSink> = Arc::new(NoopEventSink);
+        Self::with_dependencies(db, verifier, sink)
     }
 
     pub fn with_verifier(db: Arc<Database>, verifier: Arc<dyn ActiveVerifier>) -> Self {
@@ -167,7 +175,7 @@ impl ModelVerificationCoordinator {
         >,
     ) {
         let db = Arc::downgrade(db);
-        tauri::async_runtime::spawn(async move {
+        crate::rt::spawn(async move {
             while let Some(batch) = receiver.recv().await {
                 let Some(report) =
                     crate::relay::model_verification::passive::evaluate_passive(&batch)
@@ -216,6 +224,7 @@ impl ModelVerificationCoordinator {
         self.db.clone()
     }
 
+    #[cfg(feature = "gui")]
     pub fn attach_app_handle(&self, app_handle: tauri::AppHandle) {
         self.event_sink.attach_app_handle(app_handle);
     }
@@ -285,7 +294,7 @@ impl ModelVerificationCoordinator {
         let coordinator = Arc::clone(self);
         let spawned_run_id = run_id.clone();
         let spawned_target = target.clone();
-        tauri::async_runtime::spawn(async move {
+        crate::rt::spawn(async move {
             let result = Abortable::new(prepared.future, abort_registration).await;
             coordinator.finish(spawned_target, spawned_run_id, generation, result);
         });

--- a/src-tauri/src/relay/newapi.rs
+++ b/src-tauri/src/relay/newapi.rs
@@ -79,6 +79,7 @@ pub fn session_token_url(site_origin: &str) -> Result<url::Url, AppError> {
     .map_err(|error| AppError::InvalidInput(format!("NewAPI session 地址不对: {error}")))
 }
 
+#[cfg(feature = "gui")]
 pub fn extract_refresh_cookie(cookies: &[tauri::webview::Cookie<'_>]) -> Option<String> {
     cookies
         .iter()
@@ -90,6 +91,7 @@ pub fn extract_refresh_cookie(cookies: &[tauri::webview::Cookie<'_>]) -> Option<
         .map(|cookie| cookie.value().to_string())
 }
 
+#[cfg(feature = "gui")]
 pub fn extract_session_cookie(cookies: &[tauri::webview::Cookie<'_>]) -> Option<String> {
     cookies
         .iter()
@@ -97,6 +99,7 @@ pub fn extract_session_cookie(cookies: &[tauri::webview::Cookie<'_>]) -> Option<
         .map(|cookie| cookie.value().to_string())
 }
 
+#[cfg(feature = "gui")]
 /// 构造充值窗口要种的 refresh cookie（host-scoped、HttpOnly）。
 ///
 /// reqwest 栈过不了 Cloudflare 挑战，进充值页前要把 WebView 登录拿到的 refresh

--- a/src-tauri/src/relay/provision.rs
+++ b/src-tauri/src/relay/provision.rs
@@ -900,7 +900,7 @@ pub fn extract_model(settings_config: &serde_json::Value) -> Option<String> {
 /// `env.ANTHROPIC_MODEL`；gemini 读 `env.GEMINI_MODEL`；grokbuild 读 config TOML 里
 /// 选中模型表的 `model` 字段（[`grok_config::extract_model_config`]，与目录同一
 /// 标识空间）。其余平台（没有「档位选模型」概念）返回 `None`。目录本身统一走
-/// `modelCatalog`（`commands::models_from_settings`，与 codex 同一份形状）。
+/// `modelCatalog`（`models_from_settings`，与 codex 同一份形状）。
 pub fn selected_model(app_type: &AppType, settings: &serde_json::Value) -> Option<String> {
     let env_key = match app_type {
         AppType::Codex | AppType::CodexImage => return extract_model(settings),
@@ -1324,6 +1324,23 @@ pub fn pick_tier_models_with(
 /// [`pick_tier_models_with`] 的内置表形态：主链路走 `_with`（远端合并表），这个入口
 /// 留给测试与「不关心远端覆盖」的调用方 —— 测试钉内置表，选型断言不随本机缓存漂移。
 #[cfg_attr(not(test), allow(dead_code))]
+/// 从档位 settings_config 里读 `modelCatalog.models` 的模型 id 清单。
+///
+/// 托盘子菜单与自动模式策略共用这份解析（同一份 `modelCatalog` 多个消费者）。
+pub(crate) fn models_from_settings(settings: &serde_json::Value) -> Vec<String> {
+    settings
+        .get("modelCatalog")
+        .and_then(|catalog| catalog.get("models"))
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|entry| entry.get("model").and_then(serde_json::Value::as_str))
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
 pub fn pick_tier_models(app_type: &AppType, models: Option<&[String]>) -> TierModels {
     pick_tier_models_with(app_type, models, &ModelSelectionTables::builtin())
 }

--- a/src-tauri/src/rt.rs
+++ b/src-tauri/src/rt.rs
@@ -1,0 +1,34 @@
+//! 异步执行桥：GUI 模式转发 tauri 全局运行时，无 GUI 模式自建 tokio。
+//!
+//! `services::provider` 等桌面/CLI 共享模块在同步上下文里等待异步结果时用它。
+//! GUI 模式下是 [`tauri::async_runtime::block_on`] 的纯 re-export，行为与
+//! 引入本模块之前完全一致；只有无 GUI 构建（`loongport-cli` 静态包）才走
+//! 自建 runtime 的兜底。
+
+#[cfg(feature = "gui")]
+pub(crate) use tauri::async_runtime::{block_on, spawn};
+
+#[cfg(not(feature = "gui"))]
+pub(crate) fn block_on<F: std::future::Future>(future: F) -> F::Output {
+    // 每次调用建短命 runtime：CLI 是一次性进程，这些调用点都是低频操作
+    // （读写配置、备份），不值得为它持有一个全局 runtime。调用方都在同步
+    // 上下文里（CLI 的异步阶段在外层 block_on 之外先完成）。
+    tokio::runtime::Runtime::new()
+        .expect("创建 tokio 运行时失败")
+        .block_on(future)
+}
+
+/// 后台放一把火就走的任务。GUI 模式用 tauri 全局运行时；无 GUI 构建
+/// 兜底开线程跑——CLI 路径实际不会触发这些调用（不构造 AppState），
+/// 这里只为让共享代码（model_verification 协调器等）在两种构建下都编译。
+#[cfg(not(feature = "gui"))]
+pub(crate) fn spawn<F>(future: F)
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    std::thread::spawn(|| {
+        if let Ok(runtime) = tokio::runtime::Runtime::new() {
+            runtime.block_on(future);
+        }
+    });
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "gui")]
 pub mod app_update;
 pub mod balance;
 pub mod codex_oauth_models;
@@ -17,6 +18,7 @@ pub mod prompt;
 pub mod provider;
 pub mod proxy;
 pub mod s3;
+#[cfg(feature = "gui")]
 pub mod s3_auto_sync;
 pub mod s3_sync;
 pub mod session_usage;
@@ -25,6 +27,7 @@ pub mod session_usage_gemini;
 pub mod session_usage_grokbuild;
 pub mod session_usage_opencode;
 pub mod session_usage_pi;
+#[cfg(feature = "gui")]
 pub mod site_balance_refresh;
 pub mod skill;
 pub mod speedtest;
@@ -36,6 +39,7 @@ pub mod sync_protocol;
 pub mod usage_cache;
 pub mod usage_stats;
 pub mod webdav;
+#[cfg(feature = "gui")]
 pub mod webdav_auto_sync;
 pub mod webdav_sync;
 

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -844,7 +844,7 @@ fn get_codex_managed_oauth_live_auth_value(
     account_id: String,
 ) -> Result<Value, AppError> {
     std::thread::spawn(move || {
-        tauri::async_runtime::block_on(async move {
+        crate::rt::block_on(async move {
             if let Some((refresh_token, id_token, last_refresh_ms)) =
                 crate::codex_config::read_codex_live_auth_refresh_for_account(&account_id)
             {
@@ -903,7 +903,7 @@ pub(crate) fn prepare_codex_managed_oauth_live_auth_switch_away(
     account_id: String,
 ) -> Result<Option<String>, AppError> {
     std::thread::spawn(move || {
-        tauri::async_runtime::block_on(async move {
+        crate::rt::block_on(async move {
             manager
                 .prepare_live_auth_for_account_switch_away(&account_id)
                 .await
@@ -2947,7 +2947,7 @@ base_url = "https://a.example/v1"
     fn category_less_managed_codex_binding_with_null_config_uses_selected_account_token() {
         let temp = tempfile::tempdir().expect("tempdir");
         let manager = Arc::new(CodexOAuthManager::new(temp.path().to_path_buf()));
-        tauri::async_runtime::block_on(async {
+        crate::rt::block_on(async {
             manager
                 .add_test_account_with_access_token(
                     "acct-managed",
@@ -3023,7 +3023,7 @@ base_url = "https://a.example/v1"
     fn codex_follow_login_without_binding_keeps_stored_auth() {
         let temp = tempfile::tempdir().expect("tempdir");
         let manager = Arc::new(CodexOAuthManager::new(temp.path().to_path_buf()));
-        tauri::async_runtime::block_on(async {
+        crate::rt::block_on(async {
             manager
                 .add_test_account_with_access_token("acct-managed", "managed-token", None)
                 .await

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -1137,7 +1137,7 @@ mod tests {
     fn update_keeps_official_provider_id_when_binding_and_unbinding() {
         with_test_home(|state, _| {
             crate::settings::reload_settings().expect("reload settings");
-            tauri::async_runtime::block_on(async {
+            crate::rt::block_on(async {
                 state
                     .codex_oauth_manager
                     .add_test_account_with_access_token(
@@ -2649,7 +2649,7 @@ requires_openai_auth = true
     fn add_first_managed_codex_with_reauth_required_account_is_rejected() {
         with_test_home(|state, _| {
             crate::settings::reload_settings().expect("reload settings");
-            tauri::async_runtime::block_on(async {
+            crate::rt::block_on(async {
                 state
                     .codex_oauth_manager
                     .add_test_account_with_access_token("acct-legacy", "managed-token", None)
@@ -2678,7 +2678,7 @@ requires_openai_auth = true
     fn add_first_managed_codex_current_failure_rolls_back_provider_and_live_state() {
         with_test_home(|state, _| {
             crate::settings::reload_settings().expect("reload settings");
-            tauri::async_runtime::block_on(async {
+            crate::rt::block_on(async {
                 state
                     .codex_oauth_manager
                     .add_test_account_with_access_token(
@@ -2745,7 +2745,7 @@ requires_openai_auth = true
     fn switch_from_managed_codex_official_to_unbound_clears_live_without_backfilling_token() {
         with_test_home(|state, _| {
             crate::settings::reload_settings().expect("reload settings");
-            tauri::async_runtime::block_on(async {
+            crate::rt::block_on(async {
                 state
                     .codex_oauth_manager
                     .add_test_account_with_access_token(
@@ -2832,7 +2832,7 @@ requires_openai_auth = true
                 "switching to an unbound official provider should clear the recorded managed live auth"
             );
             assert_eq!(
-                tauri::async_runtime::block_on(
+                crate::rt::block_on(
                     state
                         .codex_oauth_manager
                         .test_refresh_token_for_account("acct-managed")
@@ -2860,7 +2860,7 @@ requires_openai_auth = true
     fn managed_codex_switch_adopts_outgoing_cli_rotation_before_account_or_key_overwrite() {
         with_test_home(|state, _| {
             crate::settings::reload_settings().expect("reload settings");
-            tauri::async_runtime::block_on(async {
+            crate::rt::block_on(async {
                 state
                     .codex_oauth_manager
                     .add_test_account_with_access_token(
@@ -2922,7 +2922,7 @@ wire_api = "responses"
             ProviderService::switch(state, AppType::Codex, &provider_b.id)
                 .expect("switch managed A to managed B");
             assert_eq!(
-                tauri::async_runtime::block_on(
+                crate::rt::block_on(
                     state
                         .codex_oauth_manager
                         .test_refresh_token_for_account("acct-a")
@@ -2953,7 +2953,7 @@ wire_api = "responses"
             ProviderService::switch(state, AppType::Codex, &third_party.id)
                 .expect("switch managed B to API-key provider");
             assert_eq!(
-                tauri::async_runtime::block_on(
+                crate::rt::block_on(
                     state
                         .codex_oauth_manager
                         .test_refresh_token_for_account("acct-b")
@@ -2979,7 +2979,7 @@ wire_api = "responses"
     fn managed_codex_direct_update_adopts_outgoing_cli_rotation_and_commits_target_binding() {
         with_test_home(|state, _| {
             crate::settings::reload_settings().expect("reload settings");
-            tauri::async_runtime::block_on(async {
+            crate::rt::block_on(async {
                 state
                     .codex_oauth_manager
                     .add_test_account_with_access_token(
@@ -3008,7 +3008,7 @@ wire_api = "responses"
             ProviderService::switch(state, AppType::Codex, &provider.id)
                 .expect("activate managed account A");
             assert!(
-                tauri::async_runtime::block_on(state.db.get_live_backup(AppType::Codex.as_str()))
+                crate::rt::block_on(state.db.get_live_backup(AppType::Codex.as_str()))
                     .expect("read initial live backup")
                     .is_none(),
                 "direct update precondition requires no takeover backup"
@@ -3039,7 +3039,7 @@ wire_api = "responses"
                 .expect("directly update managed binding from A to B");
 
             assert_eq!(
-                tauri::async_runtime::block_on(
+                crate::rt::block_on(
                     state
                         .codex_oauth_manager
                         .test_refresh_token_for_account("acct-a")
@@ -3075,7 +3075,7 @@ wire_api = "responses"
                 "clearing outgoing account A must not remove account B's marker"
             );
             assert!(
-                tauri::async_runtime::block_on(state.db.get_live_backup(AppType::Codex.as_str()))
+                crate::rt::block_on(state.db.get_live_backup(AppType::Codex.as_str()))
                     .expect("read live backup after direct update")
                     .is_none(),
                 "direct update must not create a takeover backup"
@@ -3088,7 +3088,7 @@ wire_api = "responses"
     fn same_account_managed_codex_update_rejects_equal_timestamp_refresh_conflict() {
         with_test_home(|state, _| {
             crate::settings::reload_settings().expect("reload settings");
-            tauri::async_runtime::block_on(async {
+            crate::rt::block_on(async {
                 state
                     .codex_oauth_manager
                     .add_test_account_with_access_token(
@@ -3112,7 +3112,7 @@ wire_api = "responses"
             // timestamp is ambiguous at millisecond precision. A same-account
             // update has no outgoing-account guard, so its managed bundle
             // preflight itself must refuse to overwrite this CLI generation.
-            tauri::async_runtime::block_on(
+            crate::rt::block_on(
                 state
                     .codex_oauth_manager
                     .test_set_token_updated_at_ms("acct-managed", 1_700_000_000_000),
@@ -3145,7 +3145,7 @@ wire_api = "responses"
                 "same-account managed update must not overwrite ambiguous CLI token material"
             );
             assert_eq!(
-                tauri::async_runtime::block_on(
+                crate::rt::block_on(
                     state
                         .codex_oauth_manager
                         .test_refresh_token_for_account("acct-managed")
@@ -3172,7 +3172,7 @@ wire_api = "responses"
     fn switch_away_rejects_legacy_refresh_conflict_on_every_retry() {
         with_test_home(|state, _| {
             crate::settings::reload_settings().expect("reload settings");
-            tauri::async_runtime::block_on(async {
+            crate::rt::block_on(async {
                 state
                     .codex_oauth_manager
                     .add_test_account_with_access_token(
@@ -3204,7 +3204,7 @@ wire_api = "responses"
             ProviderService::switch(state, AppType::Codex, &managed.id)
                 .expect("activate managed provider");
 
-            tauri::async_runtime::block_on(
+            crate::rt::block_on(
                 state
                     .codex_oauth_manager
                     .test_set_token_updated_at_ms("acct-legacy", 0),
@@ -3246,7 +3246,7 @@ wire_api = "responses"
             }
 
             assert_eq!(
-                tauri::async_runtime::block_on(
+                crate::rt::block_on(
                     state
                         .codex_oauth_manager
                         .test_refresh_token_for_account("acct-legacy")
@@ -3263,7 +3263,7 @@ wire_api = "responses"
     fn codex_auth_center_remove_and_logout_clear_live_credentials_and_marker() {
         with_test_home(|state, _| {
             crate::settings::reload_settings().expect("reload settings");
-            tauri::async_runtime::block_on(async {
+            crate::rt::block_on(async {
                 state
                     .codex_oauth_manager
                     .add_test_account_with_access_token(
@@ -3284,10 +3284,8 @@ wire_api = "responses"
             assert!(crate::codex_config::get_codex_auth_path().exists());
             assert!(crate::codex_config::codex_managed_oauth_live_auth_marker_exists());
 
-            tauri::async_runtime::block_on(
-                state.codex_oauth_manager.remove_account("acct-managed"),
-            )
-            .expect("remove managed account");
+            crate::rt::block_on(state.codex_oauth_manager.remove_account("acct-managed"))
+                .expect("remove managed account");
             assert!(
                 !crate::codex_config::get_codex_auth_path().exists(),
                 "removing the active account must delete its refreshable live auth"
@@ -3308,7 +3306,7 @@ wire_api = "responses"
                 "the binding is retained so re-login with the same account can recover it"
             );
 
-            tauri::async_runtime::block_on(async {
+            crate::rt::block_on(async {
                 state
                     .codex_oauth_manager
                     .add_test_account_with_access_token(
@@ -3323,14 +3321,11 @@ wire_api = "responses"
                 .expect("reactivate managed provider after re-login");
             assert!(crate::codex_config::get_codex_auth_path().exists());
 
-            tauri::async_runtime::block_on(state.codex_oauth_manager.clear_auth())
+            crate::rt::block_on(state.codex_oauth_manager.clear_auth())
                 .expect("logout all managed accounts");
             assert!(!crate::codex_config::get_codex_auth_path().exists());
             assert!(!crate::codex_config::codex_managed_oauth_live_auth_marker_exists());
-            assert!(
-                tauri::async_runtime::block_on(state.codex_oauth_manager.list_accounts())
-                    .is_empty()
-            );
+            assert!(crate::rt::block_on(state.codex_oauth_manager.list_accounts()).is_empty());
         });
     }
 
@@ -3339,7 +3334,7 @@ wire_api = "responses"
     fn codex_auth_center_removal_waits_for_provider_switch_lock() {
         with_test_home(|state, _| {
             crate::settings::reload_settings().expect("reload settings");
-            tauri::async_runtime::block_on(async {
+            crate::rt::block_on(async {
                 state
                     .codex_oauth_manager
                     .add_test_account_with_access_token(
@@ -3351,7 +3346,7 @@ wire_api = "responses"
                     .expect("seed managed account");
             });
 
-            let switch_guard = tauri::async_runtime::block_on(
+            let switch_guard = crate::rt::block_on(
                 state
                     .proxy_service
                     .lock_switch_for_app(AppType::Codex.as_str()),
@@ -3361,7 +3356,7 @@ wire_api = "responses"
             std::thread::scope(|scope| {
                 scope.spawn(|| {
                     started_tx.send(()).expect("signal removal start");
-                    let result = tauri::async_runtime::block_on(
+                    let result = crate::rt::block_on(
                         crate::commands::remove_codex_oauth_account_with_switch_lock(
                             state,
                             "acct-managed",
@@ -3382,10 +3377,7 @@ wire_api = "responses"
                     .expect("removal should finish after lock release")
                     .expect("remove managed account");
             });
-            assert!(
-                tauri::async_runtime::block_on(state.codex_oauth_manager.list_accounts())
-                    .is_empty()
-            );
+            assert!(crate::rt::block_on(state.codex_oauth_manager.list_accounts()).is_empty());
         });
     }
 
@@ -3394,7 +3386,7 @@ wire_api = "responses"
     fn codex_auth_center_logout_waits_for_provider_switch_lock() {
         with_test_home(|state, _| {
             crate::settings::reload_settings().expect("reload settings");
-            tauri::async_runtime::block_on(async {
+            crate::rt::block_on(async {
                 state
                     .codex_oauth_manager
                     .add_test_account_with_access_token(
@@ -3415,7 +3407,7 @@ wire_api = "responses"
             assert!(crate::codex_config::get_codex_auth_path().exists());
             assert!(crate::codex_config::codex_managed_oauth_live_auth_marker_exists());
 
-            let switch_guard = tauri::async_runtime::block_on(
+            let switch_guard = crate::rt::block_on(
                 state
                     .proxy_service
                     .lock_switch_for_app(AppType::Codex.as_str()),
@@ -3425,7 +3417,7 @@ wire_api = "responses"
             std::thread::scope(|scope| {
                 scope.spawn(|| {
                     started_tx.send(()).expect("signal logout start");
-                    let result = tauri::async_runtime::block_on(
+                    let result = crate::rt::block_on(
                         crate::commands::logout_codex_oauth_with_switch_lock(state),
                     );
                     done_tx.send(result).expect("send logout result");
@@ -3444,10 +3436,7 @@ wire_api = "responses"
                     .expect("logout managed accounts");
             });
 
-            assert!(
-                tauri::async_runtime::block_on(state.codex_oauth_manager.list_accounts())
-                    .is_empty()
-            );
+            assert!(crate::rt::block_on(state.codex_oauth_manager.list_accounts()).is_empty());
             assert!(
                 !crate::codex_config::get_codex_auth_path().exists(),
                 "logout must clear the active managed live auth"
@@ -3464,7 +3453,7 @@ wire_api = "responses"
     fn managed_codex_switch_db_current_failure_restores_live_bundle_and_current() {
         with_test_home(|state, _| {
             crate::settings::reload_settings().expect("reload settings");
-            tauri::async_runtime::block_on(async {
+            crate::rt::block_on(async {
                 state
                     .codex_oauth_manager
                     .add_test_account_with_access_token(
@@ -3596,7 +3585,7 @@ wire_api = "responses"
     fn managed_codex_takeover_update_db_failure_restores_backup_live_and_binding() {
         with_test_home(|state, _| {
             crate::settings::reload_settings().expect("reload settings");
-            tauri::async_runtime::block_on(async {
+            crate::rt::block_on(async {
                 state
                     .codex_oauth_manager
                     .add_test_account_with_access_token(
@@ -3646,7 +3635,7 @@ wire_api = "responses"
             crate::settings::set_current_provider(&AppType::Codex, Some(&provider.id))
                 .expect("set local current");
 
-            tauri::async_runtime::block_on(async {
+            crate::rt::block_on(async {
                 state
                     .db
                     .update_proxy_config(ProxyConfig {
@@ -3674,7 +3663,7 @@ wire_api = "responses"
             });
 
             let backup_before =
-                tauri::async_runtime::block_on(state.db.get_live_backup(AppType::Codex.as_str()))
+                crate::rt::block_on(state.db.get_live_backup(AppType::Codex.as_str()))
                     .expect("read baseline backup")
                     .expect("baseline backup exists");
             let live_before = crate::codex_config::CodexLiveStateSnapshot::capture()
@@ -3728,7 +3717,7 @@ wire_api = "responses"
             );
 
             let backup_after =
-                tauri::async_runtime::block_on(state.db.get_live_backup(AppType::Codex.as_str()))
+                crate::rt::block_on(state.db.get_live_backup(AppType::Codex.as_str()))
                     .expect("read backup after rollback")
                     .expect("backup still exists");
             assert_eq!(backup_after.original_config, backup_before.original_config);
@@ -3746,7 +3735,7 @@ wire_api = "responses"
     fn managed_codex_update_rechecks_current_after_waiting_for_switch_lock() {
         with_test_home(|state, _| {
             crate::settings::reload_settings().expect("reload settings");
-            tauri::async_runtime::block_on(async {
+            crate::rt::block_on(async {
                 state
                     .codex_oauth_manager
                     .add_test_account_with_access_token(
@@ -3821,7 +3810,7 @@ wire_api = "responses"
                 .expect("managed binding")
                 .account_id = Some("acct-managed-b".to_string());
 
-            let switch_guard = tauri::async_runtime::block_on(
+            let switch_guard = crate::rt::block_on(
                 state
                     .proxy_service
                     .lock_switch_for_app(AppType::Codex.as_str()),

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -8,6 +8,7 @@ use crate::database::Database;
 use crate::diagnostics::{DiagnosticEvent, ResultLogExt};
 use crate::provider::Provider;
 use crate::proxy::providers::codex_oauth_auth::CodexOAuthManager;
+#[cfg(feature = "gui")]
 use crate::proxy::server::ProxyServer;
 use crate::proxy::switch_lock::SwitchLockManager;
 use crate::proxy::types::*;
@@ -19,6 +20,7 @@ use crate::services::provider::{
 use serde_json::{json, Map, Value};
 use std::str::FromStr;
 use std::sync::Arc;
+#[cfg(feature = "gui")]
 use tauri::Emitter;
 use tokio::sync::RwLock;
 
@@ -389,8 +391,11 @@ impl Drop for CodexAuthFileTransaction {
 #[derive(Clone)]
 pub struct ProxyService {
     db: Arc<Database>,
+    #[cfg(feature = "gui")]
+    #[cfg(feature = "gui")]
     server: Arc<RwLock<Option<ProxyServer>>>,
     /// AppHandle，用于传递给 ProxyServer 以支持故障转移时的 UI 更新
+    #[cfg(feature = "gui")]
     app_handle: Arc<RwLock<Option<tauri::AppHandle>>>,
     switch_locks: SwitchLockManager,
     /// 被动模型监控入口（从 ModelVerificationCoordinator 单向流入，随 server 组装传下去）
@@ -423,7 +428,9 @@ impl ProxyService {
             db,
             passive_ingress,
             codex_oauth_manager,
+            #[cfg(feature = "gui")]
             server: Arc::new(RwLock::new(None)),
+            #[cfg(feature = "gui")]
             app_handle: Arc::new(RwLock::new(None)),
             switch_locks: SwitchLockManager::new(),
         }
@@ -845,6 +852,7 @@ impl ProxyService {
         let Ok(Some(provider)) = self.get_current_provider_for_app(app_type) else {
             return;
         };
+        #[cfg(feature = "gui")]
         if let Some(server) = self.server.read().await.as_ref() {
             server
                 .set_active_target(app_type.as_str(), &provider.id, &provider.name)
@@ -922,6 +930,7 @@ impl ProxyService {
             .ok_or_else(|| format!("{app_type:?} 当前供应商不存在，无法接管 Live 配置"))
     }
 
+    #[cfg(feature = "gui")]
     /// 设置 AppHandle（在应用初始化时调用）
     pub fn set_app_handle(&self, handle: tauri::AppHandle) {
         futures::executor::block_on(async {
@@ -936,6 +945,7 @@ impl ProxyService {
         self.switch_locks.lock_for_app(app_type).await
     }
 
+    #[cfg(feature = "gui")]
     /// 启动代理服务器
     pub async fn start(&self) -> Result<ProxyServerInfo, String> {
         // 1. 启动时自动设置 proxy_enabled = true
@@ -1019,19 +1029,28 @@ impl ProxyService {
     }
 
     async fn start_before_takeover_if_ephemeral_port(&self) -> Result<bool, String> {
-        let config = self
-            .db
-            .get_proxy_config()
-            .await
-            .map_err(|e| format!("获取代理配置失败: {e}"))?;
-        if config.listen_port != 0 || self.is_running().await {
-            return Ok(false);
-        }
+        #[cfg(feature = "gui")]
+        {
+            let config = self
+                .db
+                .get_proxy_config()
+                .await
+                .map_err(|e| format!("获取代理配置失败: {e}"))?;
+            if config.listen_port != 0 || self.is_running().await {
+                return Ok(false);
+            }
 
-        self.start().await?;
-        Ok(true)
+            self.start().await?;
+            Ok(true)
+        }
+        #[cfg(not(feature = "gui"))]
+        {
+            // 无 GUI 构建没有代理服务器可启动（loongport-cli 不做路由）。
+            Ok(false)
+        }
     }
 
+    #[cfg(feature = "gui")]
     /// 启动代理服务器（带 Live 配置接管）
     pub async fn start_with_takeover(&self) -> Result<ProxyServerInfo, String> {
         // 1. 备份各应用的 Live 配置
@@ -1188,6 +1207,7 @@ impl ProxyService {
 
         if enabled {
             // 1) 代理服务未运行则自动启动
+            #[cfg(feature = "gui")]
             if !self.is_running().await {
                 self.start().await?;
             }
@@ -1336,6 +1356,7 @@ impl ProxyService {
                             &app, &provider,
                         )
                     {
+                        #[cfg(feature = "gui")]
                         if let Some(handle) = self.app_handle.read().await.as_ref() {
                             handle
                                 .emit(
@@ -1779,6 +1800,7 @@ impl ProxyService {
 
     /// 停止代理服务器
     pub async fn stop(&self) -> Result<(), String> {
+        #[cfg(feature = "gui")]
         if let Some(server) = self.server.write().await.take() {
             server
                 .stop()
@@ -1800,10 +1822,9 @@ impl ProxyService {
             }
 
             log::info!("代理服务器已停止");
-            Ok(())
-        } else {
-            Err("代理服务器未运行".to_string())
+            return Ok(());
         }
+        Err("代理服务器未运行".to_string())
     }
 
     /// 停止代理服务器（恢复 Live 配置，用户手动关闭时使用）
@@ -2013,6 +2034,7 @@ impl ProxyService {
         };
 
         let mut listen_port = config.listen_port;
+        #[cfg(feature = "gui")]
         if let Some(server) = self.server.read().await.as_ref() {
             let status = server.get_status().await;
             if status.running {
@@ -3305,6 +3327,7 @@ impl ProxyService {
             return Err(format!("更新当前供应商失败: {error}"));
         }
 
+        #[cfg(feature = "gui")]
         if let Some(server) = self.server.read().await.as_ref() {
             server
                 .set_active_target(app_type_enum.as_str(), &provider.id, &provider.name)
@@ -3963,15 +3986,15 @@ impl ProxyService {
 
     /// 获取服务器状态
     pub async fn get_status(&self) -> Result<ProxyStatus, String> {
+        #[cfg(feature = "gui")]
         if let Some(server) = self.server.read().await.as_ref() {
-            Ok(server.get_status().await)
-        } else {
-            // 服务器未运行时返回默认状态
-            Ok(ProxyStatus {
-                running: false,
-                ..Default::default()
-            })
+            return Ok(server.get_status().await);
         }
+        // 服务器未运行时返回默认状态
+        Ok(ProxyStatus {
+            running: false,
+            ..Default::default()
+        })
     }
 
     /// 获取代理配置
@@ -3982,6 +4005,7 @@ impl ProxyService {
             .map_err(|e| format!("获取代理配置失败: {e}"))
     }
 
+    #[cfg(feature = "gui")]
     /// 更新代理配置
     pub async fn update_config(&self, config: &ProxyConfig) -> Result<(), String> {
         // 记录旧配置用于判定是否需要重启
@@ -4074,9 +4098,17 @@ impl ProxyService {
 
     /// 检查服务器是否正在运行
     pub async fn is_running(&self) -> bool {
-        self.server.read().await.is_some()
+        #[cfg(feature = "gui")]
+        {
+            self.server.read().await.is_some()
+        }
+        #[cfg(not(feature = "gui"))]
+        {
+            false
+        }
     }
 
+    #[cfg(feature = "gui")]
     /// 热更新熔断器配置
     ///
     /// 如果代理服务器正在运行，将新配置应用到所有已创建的熔断器实例
@@ -4093,6 +4125,7 @@ impl ProxyService {
         Ok(())
     }
 
+    #[cfg(feature = "gui")]
     /// 热更新指定应用的熔断器配置
     pub async fn update_circuit_breaker_config_for_app(
         &self,
@@ -4110,6 +4143,7 @@ impl ProxyService {
         Ok(())
     }
 
+    #[cfg(feature = "gui")]
     /// 重置指定 Provider 的熔断器
     ///
     /// 如果代理服务器正在运行，立即重置内存中的熔断器状态
@@ -4127,6 +4161,7 @@ impl ProxyService {
         result
     }
 
+    #[cfg(feature = "gui")]
     pub async fn reset_provider_circuit_breaker(
         &self,
         provider_id: &str,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -520,7 +520,7 @@ fn tier_model_choices(
     if !crate::relay::is_managed(&provider.id) {
         return None;
     }
-    let models = crate::commands::models_from_settings(&provider.settings_config);
+    let models = crate::relay::provision::models_from_settings(&provider.settings_config);
     if models.is_empty() {
         return None;
     }

--- a/src-tauri/src/usage_events.rs
+++ b/src-tauri/src/usage_events.rs
@@ -14,13 +14,15 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
 use std::time::Duration;
 
-use tauri::{AppHandle, Emitter};
-
+#[cfg(feature = "gui")]
 use crate::events::USAGE_LOG_RECORDED;
+#[cfg(feature = "gui")]
+use tauri::{AppHandle, Emitter};
 
 /// 防抖窗口：合并 200ms 内的多次通知。
 const DEBOUNCE_WINDOW: Duration = Duration::from_millis(200);
 
+#[cfg(feature = "gui")]
 static APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();
 
 /// 防抖标记：true 表示已有调度任务在等待 emit，后续通知合并到该任务。
@@ -30,6 +32,7 @@ static EMIT_SCHEDULED: AtomicBool = AtomicBool::new(false);
 ///
 /// 重复调用是无害的（OnceLock 仅首次写入生效），但应用启动期只该被
 /// `lib.rs::run` 调一次。
+#[cfg(feature = "gui")]
 pub fn init(handle: AppHandle) {
     if APP_HANDLE.set(handle).is_err() {
         log::debug!("usage_events::init 重复调用，已忽略");
@@ -42,6 +45,7 @@ pub fn init(handle: AppHandle) {
 ///
 /// 调用方**不**需要持有 AppHandle，可以从任意线程/任意写入路径调用。
 /// 内部 200ms 防抖合并，绝不阻塞调用线程。
+#[cfg(feature = "gui")]
 pub fn notify_log_recorded() {
     #[cfg(test)]
     TEST_NOTIFY_COUNT.with(|count| count.set(count.get().saturating_add(1)));
@@ -78,3 +82,7 @@ thread_local! {
 pub(crate) fn take_test_notify_count() -> u32 {
     TEST_NOTIFY_COUNT.with(|count| count.replace(0))
 }
+
+/// 无 GUI 构建：没有前端可通知，记录路径照常落库，通知为空操作。
+#[cfg(not(feature = "gui"))]
+pub fn notify_log_recorded() {}

--- a/src-tauri/src/vendor/opencode.rs
+++ b/src-tauri/src/vendor/opencode.rs
@@ -182,6 +182,7 @@ fn decode_signal(url: &url::Url) -> Result<crate::vendor::VendorSession, AppErro
     })
 }
 
+#[cfg(feature = "gui")]
 /// 从窗口 cookie 里抽出 opencode 会话（`auth`）。`None` = 没拿到（报错由调用方定）。
 pub fn extract_session_cookie(cookies: &[tauri::webview::Cookie<'_>]) -> Option<String> {
     cookies


### PR DESCRIPTION
## 背景：#304 的 flag 版已合入，但 20.04 真机实测证明它救不了目标受众

#304 把 `--add-site` 做成 main.rs 前置分流。**Ubuntu 20.04 真机实测（腾讯云 focal）**证明这条路对无桌面用户无效：

- deb 安装即失败：`Depends: libwebkit2gtk-4.1-0 but it is not installable`（focal 源永远只有 4.0，soname 不同装 4.0 也无用）
- AppImage 补齐 libgbm/libEGL 后撞 glibc 符号墙：`version 'GLIBC_2.35' not found`（focal 是 2.31，glibc 无法就地升级）

GUI 二进制在 focal 上**加载期**就挂——挂在 main.rs 的 flag 永远轮不到执行。本 PR 把同一套编排重做成**独立静态 bin**。

## 用法

```bash
loongport-cli --add-site https://example.com --key sk-xxx [--app codex] [--model gpt-5.4]
```

`--app` 覆盖 8 个 CLI（codex/claude/gemini/grok/opencode/openclaw/hermes/pi）；claude-desktop/codex-image 显式拒绝。`--model` 缺省拉站点 `/v1/models`（TTY 交互选、非 TTY 列清单要求带 `--model` 重跑）。GUI 二进制上的 `--add-site` flag 移除（一个功能一个入口）。

## 打包形状：同 crate 双 bin + `gui` feature 门控

- 新增默认开启的 `gui` feature，tauri 系依赖/剪贴板/开机自启/WebKitGTK 绑定全部 optional 化；`loongport-cli` 用 `--no-default-features --target x86_64-unknown-linux-musl` 出**静态单文件**（reqwest 本就是 rustls，无 openssl 障碍）
- **上游文件零搬家**：fork 合并协议不受影响。GUI 专属模块整模块门控（commands/tray/deeplink/proxy server 侧等）；共享文件做函数/语句级外科（newapi/login 的 WebView Cookie 提取器、coordinator 的 TauriEventSink、ProxyService 的 server 字段族、usage_events 的 AppHandle 注入）
- `tauri::async_runtime::block_on/spawn` 收进 `rt.rs` 桥——GUI 模式是纯 re-export，行为零变化
- `models_from_settings` 从 commands/relay.rs 搬到 `relay/provision.rs`（纯解析器，托盘/自动策略/CLI 三方共用，自动模式的 tier_models 不再反向依赖 commands）

## 复用面与边界（同 #304，不变）

探针（probe_site）/ per-CLI base 约定（api::base_url_for）/ 配置生成（settings_config_for）/ 落盘（write_live_snapshot，GUI 切档同批函数）全链路复用——唯源不分叉。只写目标 CLI 配置文件、不进 LoongPort 库；固定 provider id `loongport-relay`（last-write-wins）；不做登录窗/多账号/档位/路由。

## CI / Release

- backend job 新增 `--no-default-features` 纯净闸（Linux 腿）：防止有人往共享模块塞回 tauri 引用，把问题拖到 release 打 musl 包才炸
- release 新增 `LoongPort-CLI-<版本>-Linux-x86_64.tar.gz` 静态资产（musl-tools + tar.gz 保可执行位；缺产物=硬失败）。**发版时 release notes 下载清单需补 CLI 行**

## 验证

- 双模式 `cargo check`/`clippy --all-targets` 全绿；定向单测（cli/provision/newapi/login/coordinator）全过；本机 e2e（CC_SWITCH_TEST_HOME 隔离 + 真实站点）：codex 写 `config.toml`（/v1 根 + wire_api=responses + experimental_bearer_token）、claude 写 `settings.json` env 块（站点根 + AUTH_TOKEN + 三角色别名）
- **Ubuntu 20.04 真机烟雾（focal / glibc 2.31 / 腾讯云 VPS）：静态二进制 `not a dynamic executable`，探针+写入全链路跑通** ✅
