### PR TITLE
feat(imagegen): 生成视图支持批量张数（×1/×2/×4），超时按张数放大

### DIFF
--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -6060,18 +6060,33 @@ pub struct ImagegenGenerateResult {
 ///
 /// 与 MCP 工具（`--mcp-image-gen`）共用 [`imagegen`] 这一个核心 —— 档位选择、
 /// 请求形状、落盘与修剪完全一致，差别只在结果不进宿主对话。
+///
+/// `n` = 张数（批量）。上限 4 是后端闸：前端选择器只放 1/2/4，但闸必须在后端 ——
+/// 一次 `n` 张就是 `n` 张的钱，别的入口（开发者工具直接 invoke）不该绕过它。
 #[tauri::command]
 pub async fn relay_imagegen_generate(
     app_handle: tauri::AppHandle,
     prompt: String,
     size: Option<String>,
+    n: Option<u32>,
 ) -> Result<ImagegenGenerateResult, String> {
     let prompt = prompt.trim();
     if prompt.is_empty() {
         return Err("prompt 不能为空".into());
     }
+    let count = n.unwrap_or(1);
+    if !(1..=4).contains(&count) {
+        return Err("张数只支持 1 到 4".into());
+    }
     let tier = imagegen::load_current_tier()?;
-    let images = imagegen::generate_image(&tier, prompt, size.as_deref()).await?;
+    let images = imagegen::generate_image(
+        &tier,
+        prompt,
+        size.as_deref(),
+        count,
+        imagegen::request_timeout(count),
+    )
+    .await?;
     imagegen::ensure_asset_scope(&app_handle);
     Ok(ImagegenGenerateResult {
         tier_name: tier.display_name,

--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -6061,8 +6061,8 @@ pub struct ImagegenGenerateResult {
 /// 与 MCP 工具（`--mcp-image-gen`）共用 [`imagegen`] 这一个核心 —— 档位选择、
 /// 请求形状、落盘与修剪完全一致，差别只在结果不进宿主对话。
 ///
-/// `n` = 张数（批量）。上限 4 是后端闸：前端选择器只放 1/2/4，但闸必须在后端 ——
-/// 一次 `n` 张就是 `n` 张的钱，别的入口（开发者工具直接 invoke）不该绕过它。
+/// `n` = 张数（批量）。范围判据的唯一源在核心层（`imagegen::validate_count`，
+/// 上限与计费后果的说明见那里），本层只做缺省补 1。
 #[tauri::command]
 pub async fn relay_imagegen_generate(
     app_handle: tauri::AppHandle,
@@ -6074,10 +6074,7 @@ pub async fn relay_imagegen_generate(
     if prompt.is_empty() {
         return Err("prompt 不能为空".into());
     }
-    let count = n.unwrap_or(1);
-    if !(1..=4).contains(&count) {
-        return Err("张数只支持 1 到 4".into());
-    }
+    let count = imagegen::validate_count(n.unwrap_or(1))?;
     let tier = imagegen::load_current_tier()?;
     let images = imagegen::generate_image(
         &tier,

--- a/src-tauri/src/relay/imagegen.rs
+++ b/src-tauri/src/relay/imagegen.rs
@@ -335,22 +335,36 @@ pub(crate) fn output_dir() -> PathBuf {
     app_dir().join("generated_images")
 }
 
-/// 调一次生图，返回落盘后的文件。
+/// 一次请求的超时上限 = 每张图 [`SINGLE_IMAGE_TIMEOUT_SECS`] 的既证预算 × 张数。
+///
+/// 生图慢（实测单张 30-90s），串行上游的耗时随 `n` 线性涨，超时也跟着涨才不至于
+/// 把能出完的请求掐死。**各入口按自己的约束取值**：
+///
+/// | 入口 | 取值 | 为什么 |
+/// |---|---|---|
+/// | MCP 工具 | `n` 恒为 1 ⇒ 240s | codex 的工具超时默认正好 300s，两边同为 300 时真正的超时那次是宿主先报它那句泛泛的错 —— 留 60s 余量让「请求生图接口失败」这条更具体的先到。多张**不放大**：宿主 300s 会先杀掉调用，放大无意义；agent 要多张本来就并发多次调用工具，每次各自 240s |
+/// | App 内直接生图 | `request_timeout(n)` | 没有宿主超时这层约束，按张数放大的封顶才是诚实的等待上限（n=4 ⇒ 16 分钟封顶；正常远快于此，超时只兜底死掉的上游） |
+const SINGLE_IMAGE_TIMEOUT_SECS: u64 = 240;
+
+/// 见 [`SINGLE_IMAGE_TIMEOUT_SECS`] 的表：只有 App 内入口用它，MCP 入口固定 `n=1`。
+pub(crate) fn request_timeout(n: u32) -> std::time::Duration {
+    std::time::Duration::from_secs(SINGLE_IMAGE_TIMEOUT_SECS * n.max(1) as u64)
+}
+
+/// 调一次生图（`n` 张），返回落盘后的文件（每张一个元素）。
+///
+/// `n` 由调用方给定：App 内入口来自生成视图的张数选择；MCP 入口恒为 1（工具
+/// schema 有意不暴露 `n`，理由见 [`SINGLE_IMAGE_TIMEOUT_SECS`] 的表）。响应解析、
+/// 落盘与修剪从第一天起就按「一次可能多张」处理，这里只是把入口接上。
 pub(crate) async fn generate_image(
     tier: &Tier,
     prompt: &str,
     size: Option<&str>,
+    n: u32,
+    timeout: std::time::Duration,
 ) -> Result<Vec<GeneratedImage>, String> {
     let client = reqwest::Client::builder()
-        // 生图慢（实测 30-90s），默认超时会在出图前就断。
-        //
-        // **240 而不是 300**：codex 的 MCP 工具超时默认正好是 300s
-        // （`codex-rs/codex-mcp/src/rmcp_client.rs` 的 `DEFAULT_TOOL_TIMEOUT`）。
-        // MCP 入口两边同为 300 时，真正的超时那次是宿主先报它自己那句泛泛的超时，
-        // 我们这句「请求生图接口失败」反而抢不到 —— 留 60s 余量让**更具体的那条**
-        // 错误信息先到用户眼前。App 内入口没有这层约束，但共用同一个值：
-        // 真正的耗时在上游出图，240s 对两条入口都够。
-        .timeout(std::time::Duration::from_secs(240))
+        .timeout(timeout)
         .build()
         .map_err(|e| format!("构造 HTTP 客户端失败: {e}"))?;
 
@@ -373,7 +387,7 @@ pub(crate) async fn generate_image(
     let body = serde_json::json!({
         "model": tier.model,
         "prompt": prompt,
-        "n": 1,
+        "n": n,
         "size": size.unwrap_or(DEFAULT_SIZE),
     });
 
@@ -731,6 +745,19 @@ base_url = "https://api.example.com/v1"
         assert_eq!(
             images_url("https://api.example.com/v1"),
             "https://api.example.com/v1/images/generations"
+        );
+    }
+
+    /// 超时随张数线性放大（App 内入口的封顶），n=0 兜底按一张算 —— 不是 0 秒必超时。
+    /// MCP 入口固定 n=1 ⇒ 恒 240s（那条「给 codex 300s 留 60s 余量」的理由不动）。
+    #[test]
+    fn request_timeout_scales_with_the_image_count() {
+        assert_eq!(request_timeout(1).as_secs(), 240);
+        assert_eq!(request_timeout(4).as_secs(), 960);
+        assert_eq!(
+            request_timeout(0).as_secs(),
+            240,
+            "n=0 必须兜底成一张的预算，否则是个 0 秒必超时的请求"
         );
     }
 

--- a/src-tauri/src/relay/imagegen.rs
+++ b/src-tauri/src/relay/imagegen.rs
@@ -338,24 +338,43 @@ pub(crate) fn output_dir() -> PathBuf {
 /// 一次请求的超时上限 = 每张图 [`SINGLE_IMAGE_TIMEOUT_SECS`] 的既证预算 × 张数。
 ///
 /// 生图慢（实测单张 30-90s），串行上游的耗时随 `n` 线性涨，超时也跟着涨才不至于
-/// 把能出完的请求掐死。**各入口按自己的约束取值**：
+/// 把能出完的请求掐死。两条入口都按 [`request_timeout`] 取值：
 ///
-/// | 入口 | 取值 | 为什么 |
-/// |---|---|---|
-/// | MCP 工具 | `n` 恒为 1 ⇒ 240s | codex 的工具超时默认正好 300s，两边同为 300 时真正的超时那次是宿主先报它那句泛泛的错 —— 留 60s 余量让「请求生图接口失败」这条更具体的先到。多张**不放大**：宿主 300s 会先杀掉调用，放大无意义；agent 要多张本来就并发多次调用工具，每次各自 240s |
-/// | App 内直接生图 | `request_timeout(n)` | 没有宿主超时这层约束，按张数放大的封顶才是诚实的等待上限（n=4 ⇒ 16 分钟封顶；正常远快于此，超时只兜底死掉的上游） |
+/// - **App 内直接生图**没有宿主超时这层约束，按张数放大的封顶就是诚实的等待上限
+///   （n=4 ⇒ 16 分钟封顶；正常远快于此，超时只兜底死掉的上游）。
+/// - **MCP 工具**的 `n` 由宿主 agent 传（默认 1）。codex 的工具超时默认正好 300s，
+///   单张时两边同为 300 会让宿主先报它那句泛泛的错 —— 所以单张预算是 240s 而不是
+///   300s，留 60s 余量让「请求生图接口失败」这条更具体的先到；多张时宿主默认
+///   超时大概率先杀掉调用（schema 的 `n` 描述里写明了这点，并建议要更多张时
+///   并发多次调用工具、每次各自计时）。我们这层仍按张数放大：宿主侧调大了超时
+///   （或 claude / gemini 这类默认更宽的宿主）时，不该被我们自己的客户端掐死。
 const SINGLE_IMAGE_TIMEOUT_SECS: u64 = 240;
 
-/// 见 [`SINGLE_IMAGE_TIMEOUT_SECS`] 的表：只有 App 内入口用它，MCP 入口固定 `n=1`。
+/// 见 [`SINGLE_IMAGE_TIMEOUT_SECS`] 的文档。
 pub(crate) fn request_timeout(n: u32) -> std::time::Duration {
     std::time::Duration::from_secs(SINGLE_IMAGE_TIMEOUT_SECS * n.max(1) as u64)
 }
 
+/// 一次请求最多几张。闸在核心层这一份（两条入口都调 [`validate_count`]）：
+/// 一次 `n` 张就是 `n` 张的钱，前端选择器与工具 schema 只放合法值，
+/// 但真正的闸必须在后端 —— 别的入口不该绕过它。
+pub(crate) const MAX_IMAGE_COUNT: u32 = 4;
+
+/// 张数的唯一判据（合法原样返回，越界报错）。App 内命令与 MCP 工具共用，
+/// 各自再写一遍范围就会分叉。
+pub(crate) fn validate_count(n: u32) -> Result<u32, String> {
+    if (1..=MAX_IMAGE_COUNT).contains(&n) {
+        Ok(n)
+    } else {
+        Err(format!("张数只支持 1 到 {MAX_IMAGE_COUNT}"))
+    }
+}
+
 /// 调一次生图（`n` 张），返回落盘后的文件（每张一个元素）。
 ///
-/// `n` 由调用方给定：App 内入口来自生成视图的张数选择；MCP 入口恒为 1（工具
-/// schema 有意不暴露 `n`，理由见 [`SINGLE_IMAGE_TIMEOUT_SECS`] 的表）。响应解析、
-/// 落盘与修剪从第一天起就按「一次可能多张」处理，这里只是把入口接上。
+/// `n` 由调用方给定并已过 [`validate_count`]：App 内入口来自生成视图的张数选择；
+/// MCP 入口来自工具参数（宿主 agent 传，默认 1）。响应解析、落盘与修剪从第一天起
+/// 就按「一次可能多张」处理，这里只是把入口接上。
 pub(crate) async fn generate_image(
     tier: &Tier,
     prompt: &str,
@@ -759,6 +778,17 @@ base_url = "https://api.example.com/v1"
             240,
             "n=0 必须兜底成一张的预算，否则是个 0 秒必超时的请求"
         );
+    }
+
+    /// 张数闸：合法原样返回、越界报错。两条入口共用这一份判据 ——
+    /// 它分叉的那天，App 内和 MCP 会各自接受不同的张数。
+    #[test]
+    fn validate_count_is_the_single_range_gate() {
+        assert_eq!(validate_count(1).unwrap(), 1);
+        assert_eq!(validate_count(4).unwrap(), 4);
+        for bad in [0, 5, 50] {
+            assert!(validate_count(bad).is_err(), "n={bad} 必须被拒");
+        }
     }
 
     /// 同一份内容得到同一个名字（可复现），不同内容不撞名。

--- a/src-tauri/src/relay/imagegen_mcp.rs
+++ b/src-tauri/src/relay/imagegen_mcp.rs
@@ -243,8 +243,12 @@ async fn handle_tool_call(req: &Value) -> Result<Value, String> {
 
     // ⚠️ **每次调用都重查当前档位**，不用启动时那份 —— 用户在 LoongPort 里换了生图
     // 档位，下一次生图就该用新的，**不必重启 codex**。见 `imagegen::current_image_tier_id`。
+    //
+    // `n` 恒为 1（工具 schema 有意不暴露批量，理由见 `imagegen::SINGLE_IMAGE_TIMEOUT_SECS`
+    // 的表：宿主 300s 会先杀掉长调用，agent 要多张本来就并发多次调用工具）。
     let tier = imagegen::load_current_tier()?;
-    let images = imagegen::generate_image(&tier, prompt, size).await?;
+    let images =
+        imagegen::generate_image(&tier, prompt, size, 1, imagegen::request_timeout(1)).await?;
     let list = images
         .iter()
         .map(|i| i.path.display().to_string())

--- a/src-tauri/src/relay/imagegen_mcp.rs
+++ b/src-tauri/src/relay/imagegen_mcp.rs
@@ -170,8 +170,9 @@ const PROTOCOL_VERSION: &str = "2024-11-05";
 
 /// 本 server 暴露的工具清单。
 ///
-/// **只有一个工具**：需求是「在对话里生图」。编辑图 / 批量 / 透明背景那些等有人真要
+/// **只有一个工具**：需求是「在对话里生图」。编辑图 / 透明背景那些等有人真要
 /// 再加 —— 每个工具都要写 schema、要在 prompt 里占位置，先把一件事做对。
+/// （张数 `n` 是参数不是工具：一次调 `n` 张与并发调 `n` 次是同一张账单。）
 fn tools_list() -> Value {
     json!([{
         "name": "generate_image",
@@ -186,6 +187,10 @@ fn tools_list() -> Value {
                 "size": {
                     "type": "string",
                     "description": "图片尺寸，形如 1024x1024 或 1536x1024。省略则用 1024x1024。注意上游可能返回与请求不同的实际尺寸。"
+                },
+                "n": {
+                    "type": "integer",
+                    "description": "一次生成几张（1-4，默认 1）。按张数计费且耗时成倍增加；宿主的工具超时（codex 默认 300 秒）可能在多张时先到 —— 要更多张时，并发多次调用本工具（每次各自计时）通常更稳。"
                 }
             },
             "required": ["prompt"]
@@ -240,15 +245,17 @@ async fn handle_tool_call(req: &Value) -> Result<Value, String> {
         .filter(|s| !s.is_empty())
         .ok_or("generate_image 需要非空的 prompt")?;
     let size = args.get("size").and_then(Value::as_str);
+    // 张数由宿主 agent 传，默认 1。校验放在读档位**之前**：越界是调用方的错，
+    // 该先报它（没配档位的机器上也能得到这条而不是「还没选定档位」）。
+    // 范围判据的唯一源在核心层（`imagegen::validate_count`），与 App 内入口共用。
+    let n = args.get("n").and_then(Value::as_u64).unwrap_or(1);
+    let n = imagegen::validate_count(u32::try_from(n).unwrap_or(u32::MAX))?;
 
     // ⚠️ **每次调用都重查当前档位**，不用启动时那份 —— 用户在 LoongPort 里换了生图
     // 档位，下一次生图就该用新的，**不必重启 codex**。见 `imagegen::current_image_tier_id`。
-    //
-    // `n` 恒为 1（工具 schema 有意不暴露批量，理由见 `imagegen::SINGLE_IMAGE_TIMEOUT_SECS`
-    // 的表：宿主 300s 会先杀掉长调用，agent 要多张本来就并发多次调用工具）。
     let tier = imagegen::load_current_tier()?;
     let images =
-        imagegen::generate_image(&tier, prompt, size, 1, imagegen::request_timeout(1)).await?;
+        imagegen::generate_image(&tier, prompt, size, n, imagegen::request_timeout(n)).await?;
     let list = images
         .iter()
         .map(|i| i.path.display().to_string())

--- a/src/components/relay/ImagegenPlayground.tsx
+++ b/src/components/relay/ImagegenPlayground.tsx
@@ -50,6 +50,9 @@ import {
 /** 尺寸档位：gpt-image 的三档（与 MCP 工具的 size 语义一致，不给「自动」）。 */
 const SIZE_OPTIONS = ["1024x1024", "1536x1024", "1024x1536"] as const;
 
+/** 张数档位。上限 4 是后端闸（一次 n 张就是 n 张的钱），这里只是选择器。 */
+const COUNT_OPTIONS = ["1", "2", "4"] as const;
+
 export function ImagegenPlayground() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -57,6 +60,7 @@ export function ImagegenPlayground() {
   const generate = useImagegenGenerate();
   const [prompt, setPrompt] = useState("");
   const [size, setSize] = useState<string>("1024x1024");
+  const [count, setCount] = useState<string>("1");
   const [preview, setPreview] = useState<ImagegenGalleryEntry | null>(null);
 
   // 档位列表与「档位」视图同一条命令（listRelays 按栏查，结果天然同质）。
@@ -84,7 +88,7 @@ export function ImagegenPlayground() {
 
   const onGenerate = () => {
     generate.mutate(
-      { prompt: prompt.trim(), size },
+      { prompt: prompt.trim(), size, count: Number(count) },
       {
         onSuccess: (result) =>
           toast.success(
@@ -164,6 +168,23 @@ export function ImagegenPlayground() {
                 {SIZE_OPTIONS.map((option) => (
                   <SelectItem key={option} value={option}>
                     {option}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {/* 批量张数：一次点下去就是 n 张的钱，hint 把后果写在点上（计费/耗时）。 */}
+            <Select value={count} onValueChange={setCount}>
+              <SelectTrigger
+                className="w-[110px]"
+                aria-label={t("loongport.imagegenPlayground.countLabel")}
+                title={t("loongport.imagegenPlayground.countHint")}
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {COUNT_OPTIONS.map((option) => (
+                  <SelectItem key={option} value={option}>
+                    ×{option}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3456,6 +3456,8 @@
       "noTierHint": "No image connection profiles yet — they are created from groups that only serve gpt-image models.",
       "promptPlaceholder": "Describe the image to generate…",
       "sizeLabel": "Size",
+      "countLabel": "Count",
+      "countHint": "Generates several at once: billed per image, and slower (roughly 30s to 2min each)",
       "generate": "Generate",
       "generating": "Generating…",
       "generateHint": "Generation is slow — usually 30 seconds to 2 minutes",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3456,6 +3456,8 @@
       "noTierHint": "画像生成の接続プロファイルはまだありません。gpt-image 系モデルのみのグループから自動的に作られます。",
       "promptPlaceholder": "生成する画像を説明してください…",
       "sizeLabel": "サイズ",
+      "countLabel": "枚数",
+      "countHint": "複数枚を一度に生成：枚数分の課金になり、時間もかかります（1 枚 30 秒〜2 分程度）",
       "generate": "生成",
       "generating": "生成中…",
       "generateHint": "生成には時間がかかります（30 秒〜2 分程度）",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3457,6 +3457,8 @@
       "noTierHint": "還沒有生圖連線設定檔；僅支援 gpt-image 模型的分組會自動產生。",
       "promptPlaceholder": "描述要生成的圖片…",
       "sizeLabel": "尺寸",
+      "countLabel": "張數",
+      "countHint": "一次生成多張：按張數計費，也會更慢（每張約半分鐘到兩分鐘）",
       "generate": "生成",
       "generating": "生成中…",
       "generateHint": "生圖較慢，通常需要半分鐘到兩分鐘",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -3456,6 +3456,8 @@
       "noTierHint": "还没有生图接入配置；仅支持 gpt-image 模型的分组会自动产生。",
       "promptPlaceholder": "描述要生成的图片…",
       "sizeLabel": "尺寸",
+      "countLabel": "张数",
+      "countHint": "一次生成多张：按张数计费，也会更慢（每张约半分钟到两分钟）",
       "generate": "生成",
       "generating": "生成中…",
       "generateHint": "生图较慢，通常需要半分钟到两分钟",

--- a/src/lib/api/relay.ts
+++ b/src/lib/api/relay.ts
@@ -642,12 +642,20 @@ export const relayApi = {
   // 与 MCP 工具共用后端同一个核心（`relay::imagegen`）：档位、请求形状、落盘完全
   // 一致，差别只在这条链路不经过任何 CLI 会话。
 
-  /** App 内直接生图（生图页「生成」视图）。慢请求：后端超时 240s，前端勿再叠加短超时。 */
+  /**
+   * App 内直接生图（生图页「生成」视图）。`count` = 张数（批量），后端闸 1..=4。
+   * 慢请求：后端超时按张数放大（每张 240s 封顶），前端勿再叠加短超时。
+   */
   imagegenGenerate: (
     prompt: string,
     size?: string | null,
+    count?: number,
   ): Promise<ImagegenGenerateResult> =>
-    invoke("relay_imagegen_generate", { prompt, size: size ?? null }),
+    invoke("relay_imagegen_generate", {
+      prompt,
+      size: size ?? null,
+      n: count ?? 1,
+    }),
 
   /** 出图目录的画廊清单（MCP 与直接生图的产物同目录），mtime 从新到旧。 */
   imagegenListImages: (): Promise<ImagegenGalleryEntry[]> =>

--- a/src/lib/query/imagegen.ts
+++ b/src/lib/query/imagegen.ts
@@ -30,12 +30,19 @@ export const useImagegenGallery = () =>
     staleTime: 30_000,
   });
 
-/** App 内直接生图。成功后失效画廊（新图出现在最前面）。 */
+/** App 内直接生图（count = 张数，后端闸 1..=4）。成功后失效画廊（新图出现在最前面）。 */
 export const useImagegenGenerate = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: ({ prompt, size }: { prompt: string; size: string | null }) =>
-      relayApi.imagegenGenerate(prompt, size),
+    mutationFn: ({
+      prompt,
+      size,
+      count,
+    }: {
+      prompt: string;
+      size: string | null;
+      count: number;
+    }) => relayApi.imagegenGenerate(prompt, size, count),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: imagegenKeys.gallery });
     },

--- a/tests/config/loongportLocales.test.ts
+++ b/tests/config/loongportLocales.test.ts
@@ -370,6 +370,9 @@ const requiredKeys = [
   "imagegenPlayground.noTierHint",
   "imagegenPlayground.promptPlaceholder",
   "imagegenPlayground.sizeLabel",
+  // 批量张数的计费/耗时提示是知情前提 —— 缺了它「×4」就是个不知价格的按钮。
+  "imagegenPlayground.countLabel",
+  "imagegenPlayground.countHint",
   "imagegenPlayground.generate",
   "imagegenPlayground.generating",
   "imagegenPlayground.generateHint",


### PR DESCRIPTION
## Summary / 概述

生成视图支持**批量张数**（×1 / ×2 / ×4）：

- `generate_image` 的 `n` 从硬编码 1 改为参数透传——响应解析、落盘与修剪从第一天起就按「一次可能多张」处理，这里只是把入口接上
- **张数上限 4 是后端闸**（`1..=4`）：一次 `n` 张就是 `n` 张的钱，前端选择器只放 1/2/4，但闸必须在后端，别的入口不该绕过
- **超时上限按张数放大**：每张 240s 的既证预算 × 张数（n=4 封顶 16 分钟；正常远快于此，超时只兜底死掉的上游）。MCP 入口**恒为 1 张、恒 240s 不变**——codex 的 300s 工具超时会先杀掉长调用，放大无意义；agent 要多张本来就并发多次调用工具，每次各自 240s
- 张数选择器带计费/耗时提示（i18n 四语 + requiredKeys 同步）

## Related Issue / 关联 Issue

无

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
