### PR TITLE
chore(release): v6.17.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -877,6 +877,7 @@ jobs:
             - **Windows (x86_64)**: `LoongPort-${{ github.ref_name }}-Windows-Setup.exe`（安装版）或 `LoongPort-${{ github.ref_name }}-Windows-Portable.zip`（绿色版）
             - **Windows (ARM64)**: `LoongPort-${{ github.ref_name }}-Windows-arm64-Setup.exe`（安装版）或 `LoongPort-${{ github.ref_name }}-Windows-arm64-Portable.zip`（绿色版）
             - **Linux (x86_64)**: `LoongPort-${{ github.ref_name }}-Linux-x86_64.AppImage`（推荐）或 `LoongPort-${{ github.ref_name }}-Linux-x86_64.deb` / `.rpm`（手动安装，不参与应用内自动更新）
+            - **Linux 服务器/老发行版 (x86_64)**: `LoongPort-CLI-${{ github.ref_name }}-Linux-x86_64.tar.gz`（静态单文件零依赖，Ubuntu 20.04 / 纯服务器可用：`loongport-cli --add-site <域名> --key <sk> [--app codex] [--model <id>]`）
 
             > 应用内会自动检查更新（启动后几秒，失败静默）；也可在「设置 → 关于」手动检查。
             > 免安装版不做原地更新 —— 它会带你回本页下载新版。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-switch",
-  "version": "6.16.0",
+  "version": "6.17.0",
   "description": "All-in-One Assistant for Claude Code, Codex & Gemini CLI",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "cc-switch"
-version = "6.16.0"
+version = "6.17.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@
 # （裁决见 CLAUDE.md「三点五」）。面向用户的二进制名走 tauri.conf.json 的
 # `mainBinaryName`（已是 `LoongPort`）。
 name = "cc-switch"
-version = "6.16.0"
+version = "6.17.0"
 description = "同样的 Codex，成本省 95% 以上 —— 填一个域名、登录一次，其余自动配好"
 authors = ["SailingLoong", "Jason Young"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LoongPort",
   "mainBinaryName": "LoongPort",
-  "version": "6.16.0",
+  "version": "6.17.0",
   "identifier": "dev.loongport.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
版本号 bump：6.17.0（生图直连 playground+批量张数、广场 v2 回归、loongport-cli 静态配置工具、Linux 包正式发布）。纯版本号变更。