### PR TITLE
refactor(ssot): 跨语言事实补闸 + 逐字复制收拢（架构审查第一批）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,8 +247,10 @@ pub fn is_official_proxy_provider_id(id: &str) -> bool { /* 认新旧两个 */ }
 | `relay::managed::prefix_matches_the_frontend_copy` | `MANAGED_ID_PREFIX` 必须与 `src/config/constants.ts` 一致 |
 
 **新增任何「跨语言/跨文件的同一事实」时，一并加闸** —— 否则它迟早分叉，
-而分叉那天没人会收到通知。已知还有一处同类：`OFFICIAL_WEBSITE`
-（`tray.rs` 与 `constants.ts` 各一份，改一边记得改另一边）。
+而分叉那天没人会收到通知。同类闸如今还有：`config.rs::brand_constant_consistency`
+（`OFFICIAL_WEBSITE` / `GITHUB_REPO` 与 `constants.ts` 比对）、`events.rs` 的
+事件名主表、`vendor::frontend_catalog_matches_the_rust_registry`
+（厂商 id + 展示名）、`relay` 两个状态枚举的线上名钉死测试。
 
 ### 前端只展示后端定义的业务事实
 

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -94,6 +94,8 @@ pub fn run_add_site() -> i32 {
     }
 }
 
+// USAGE 里的 app 清单与 `cli_supported` 的穷尽 match 保持一致（新增 CLI 支持时
+// 两边都要动；解析与拒绝行为有测试兜着，这里只是帮助文本）。
 const USAGE: &str = "用法:
   loongport-cli --add-site <站点域名或完整网址> --key <sk-密钥> [--app <codex|claude|gemini|grok|opencode|openclaw|hermes>] [--model <模型id>]
 

--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -17,11 +17,12 @@ use crate::services::{
 use crate::store::AppState;
 use std::str::FromStr;
 
-// 常量定义
+// 常量定义。`official_subscription` 是跨模块的 wire 值（tray 托盘用量后缀也按它分档，
+// 前端 UsageScriptModal 写进 provider meta），所以 pub(crate)；其余只在本文件用。
 const TEMPLATE_TYPE_GITHUB_COPILOT: &str = "github_copilot";
 const TEMPLATE_TYPE_TOKEN_PLAN: &str = "token_plan";
 const TEMPLATE_TYPE_BALANCE: &str = "balance";
-const TEMPLATE_TYPE_OFFICIAL_SUBSCRIPTION: &str = "official_subscription";
+pub(crate) const TEMPLATE_TYPE_OFFICIAL_SUBSCRIPTION: &str = "official_subscription";
 const COPILOT_UNIT_PREMIUM: &str = "requests";
 
 #[derive(Debug, serde::Serialize)]

--- a/src-tauri/src/commands/relay.rs
+++ b/src-tauri/src/commands/relay.rs
@@ -7,7 +7,7 @@
 //! | [`relay_status`] | 首启该弹哪个弹窗、当前是什么状态 |
 //! | [`relay_import_site`] | 发现协议；必要时让用户在可见 WebView 完成网页验证，并在同一会话登录 |
 //! | [`relay_login`] | 开登录 WebView，等凭据回来 |
-//! | [`relay_provision`] | 拉分组 → 每组备好 sk → 写成 codex provider |
+//! | [`relay_refresh`] | 探活 + 重拉分组（每组备好 sk → 写成 provider） |
 //! | [`relay_switch_tier`] | 选分组 → 退 ChatGPT → 切换 → 重开 |
 //!
 //! ## 为什么切换编排在 Rust 侧而不是前端
@@ -289,10 +289,10 @@ pub struct TierInfo {
     ///
     /// ## 为什么必须有它
     ///
-    /// [`do_provision`] 一次探**全部平台**，返回的 `tiers` 是全平台的，而 UI 那一行
-    /// 只显示当前 app 的档位。没有这个字段，前端拿到一堆档位却分不出哪条是自己的
-    /// ⇒ 「这个站没有该平台的分组」与「拉取失败」在界面上长得一样（都是零档位），
-    /// 而前者重试一百次也不会有、后者重试有意义。
+    /// provision 链路（[`refresh_relay_provision`]）一次探**全部平台**，返回的 `tiers`
+    /// 是全平台的，而 UI 那一行只显示当前 app 的档位。没有这个字段，前端拿到一堆档位
+    /// 却分不出哪条是自己的 ⇒ 「这个站没有该平台的分组」与「拉取失败」在界面上长得一样
+    /// （都是零档位），而前者重试一百次也不会有、后者重试有意义。
     ///
     /// [`list_tiers_impl`] 那条路填的是它被查询的那个 app（那条命令按 app 查，
     /// 结果天然同质），所以两条路的语义一致：**这条档位属于哪个 CLI**。
@@ -2719,7 +2719,7 @@ fn persist_new_relay_newapi_session(
 ///
 /// 界面是多行并列的，「当前站」这个概念在这里不成立 —— 靠它定位会让
 /// 「给 A 获取密钥」静默作用到 B 上（那是 review 抓出过的真实并发正确性问题，
-/// 见 [`relay_provision`] 的文档）。2026-08-04 连带 `is_current` 一起删掉了
+/// 见 [`refresh_relay_provision`] 的文档）。2026-08-04 连带 `is_current` 一起删掉了
 /// 那条 `Option` 分支。
 async fn usable_relay<R: tauri::Runtime>(
     app_handle: &tauri::AppHandle<R>,
@@ -3009,65 +3009,6 @@ fn persist_refreshed_session_with_identity_writer(
     }
 
     Ok(renewed)
-}
-
-/// 拉分组、为每组备好 sk、写成 provider 记录。
-///
-/// ## 一次探全部平台，各归各的 tab（2026-08-03 改）
-///
-/// **不吃 `app` 参数** —— 每个分组落到哪个 CLI 由它自己的 `platform` 决定
-/// （`openai → codex`、`anthropic → claude`、`gemini → gemini`、`grok → grokbuild`），
-/// 见 [`provision::provision`]。用户在任何一个 tab 登录一次，全部平台的档位都备好了。
-///
-/// ### 为什么去掉那个参数（它曾经是 bug 的根源）
-///
-/// 原来签名吃 `app`，于是「拉哪些分组」和「写成什么形状」都由调用方决定 ——
-/// 在 claude tab 点「获取密钥」时**拉的是 openai 分组、却写成 claude 的配置形状**
-/// （openai 的 sk 配在 `ANTHROPIC_BASE_URL` 上，调用必失败），
-/// 而用户看到的是「claude 页出现了 chatgpt 的分组」。
-///
-/// 根因是把「分组属于哪个 CLI」的决定权交给了调用方，而那是分组自身的属性。
-/// 现在 `provision` 返回 [`provision::TargetedTier`]（分组 + 它该落到的 app_type），
-/// 调用方不需要知道 platform 映射规则 —— 那才是低耦合。
-///
-/// 认不出配置形状的 CLI（`settings_config_for` 返回 `None`）在循环里跳过并计入
-/// `failures`，不让整批失败。
-///
-/// ## `relay_id`：显式指定作用于哪个中转站（2026-08-03 加）
-///
-/// 原来它只吃 `AppHandle`，靠 `creds::load()` 读「`is_current = 1` 的那一行」。
-/// 于是多行并列的页面必须先 `set_current(id)` 才能让它作用到对的账号上
-/// （前端那个 `focusRelay`）—— 而 `is_current` 是**全局单例状态**：
-///
-/// 两个中转站同时 provision 时，B 的 `set_current(B)` 会改掉 A 那次操作的目标，
-/// A 后续的 balance / refresh 全串到 B 上。前端当时是用「任一操作进行中就禁用所有行」
-/// 兜住的 —— **那是拿全局禁用换正确性，修的是症状**：中转站之间本来毫无依赖，
-/// 用户点 A 的按钮却发现 B、C 的按钮全灰了。
-///
-/// 现在把目标变成参数，全局状态不再参与定位 ⇒ 各行真正独立、可并发。
-/// 这也正是「中转站（登录态）一个模块、分组（sk）一个模块」该有的样子：
-/// 分组操作显式说明「给哪个中转站」，而不是去读一个由 UI 顺手改掉的全局变量。
-///
-/// `None` 保留给单站流程（LoongPort 页首启引导，全程只有一个站）。
-#[tauri::command]
-pub async fn relay_provision(
-    app_handle: tauri::AppHandle,
-    relay_id: i64,
-) -> Result<ProvisionSummary, String> {
-    do_provision(&app_handle, relay_id)
-        .await
-        // ⚠️ **失败必须落日志**（维护者实测抓出）。
-        //
-        // 这条路径原来一个字都不记，而前端「刷新」那处又把 `Promise.allSettled` 的
-        // `reason` 丢掉、只显示「<站名> 刷新失败」⇒ 两处一叠，**用户和维护者都拿不到
-        // 真实错误** —— 定位一次要手工从 DB 里取 token、逐个端点 curl 一遍。
-        //
-        // 带上 `relay_id`：多行并列时「哪一行失败了」本身就是信息，
-        // 而错误文案里未必有站名。
-        .inspect_err(|e| {
-            log::error!("provision 失败（relay_id={relay_id}）：{e}");
-        })
-        .map_err(|e| e.to_string())
 }
 
 #[derive(Clone)]
@@ -3380,14 +3321,44 @@ async fn provision_backend(
     }
 }
 
-async fn do_provision(
-    app_handle: &tauri::AppHandle,
-    relay_id: i64,
-) -> Result<ProvisionSummary, AppError> {
-    let op = usable_relay(app_handle, relay_id).await?;
-    provision_relay(app_handle, &op).await
-}
-
+/// 拉分组、为每组备好 sk、写成 provider 记录 —— provision 的唯一入口
+/// （`relay_refresh` 命令在探活后调它；曾经的独立 `relay_provision` 命令前端零调用，
+/// 2026-09-07 删除，见 git 历史）。
+///
+/// ## 一次探全部平台，各归各的 tab（2026-08-03 改）
+///
+/// **不吃 `app` 参数** —— 每个分组落到哪个 CLI 由它自己的 `platform` 决定
+/// （`openai → codex`、`anthropic → claude`、`gemini → gemini`、`grok → grokbuild`），
+/// 见 [`provision::provision`]。用户在任何一个 tab 登录一次，全部平台的档位都备好了。
+///
+/// ### 为什么去掉那个参数（它曾经是 bug 的根源）
+///
+/// 原来签名吃 `app`，于是「拉哪些分组」和「写成什么形状」都由调用方决定 ——
+/// 在 claude tab 点「获取密钥」时**拉的是 openai 分组、却写成 claude 的配置形状**
+/// （openai 的 sk 配在 `ANTHROPIC_BASE_URL` 上，调用必失败），
+/// 而用户看到的是「claude 页出现了 chatgpt 的分组」。
+///
+/// 根因是把「分组属于哪个 CLI」的决定权交给了调用方，而那是分组自身的属性。
+/// 现在 `provision` 返回 [`provision::TargetedTier`]（分组 + 它该落到的 app_type），
+/// 调用方不需要知道 platform 映射规则 —— 那才是低耦合。
+///
+/// 认不出配置形状的 CLI（`settings_config_for` 返回 `None`）在循环里跳过并计入
+/// `failures`，不让整批失败。
+///
+/// ## `relay_id`：显式指定作用于哪个中转站（2026-08-03 加）
+///
+/// 原来它只吃 `AppHandle`，靠 `creds::load()` 读「`is_current = 1` 的那一行」。
+/// 于是多行并列的页面必须先 `set_current(id)` 才能让它作用到对的账号上
+/// （前端那个 `focusRelay`）—— 而 `is_current` 是**全局单例状态**：
+///
+/// 两个中转站同时 provision 时，B 的 `set_current(B)` 会改掉 A 那次操作的目标，
+/// A 后续的 balance / refresh 全串到 B 上。前端当时是用「任一操作进行中就禁用所有行」
+/// 兜住的 —— **那是拿全局禁用换正确性，修的是症状**：中转站之间本来毫无依赖，
+/// 用户点 A 的按钮却发现 B、C 的按钮全灰了。
+///
+/// 现在把目标变成参数，全局状态不再参与定位 ⇒ 各行真正独立、可并发。
+/// 这也正是「中转站（登录态）一个模块、分组（sk）一个模块」该有的样子：
+/// 分组操作显式说明「给哪个中转站」，而不是去读一个由 UI 顺手改掉的全局变量。
 async fn refresh_relay_provision(
     app_handle: &tauri::AppHandle,
     relay_id: i64,
@@ -3758,7 +3729,7 @@ fn persist_provision_batch(
 /// 而且用户没有自救手段 —— UI 认为这个档位已经是当前项（`isCurrent` 为 true），
 /// 前端 `if (tier.isCurrent) return;` 会让「再点它一次」什么也不做。
 ///
-/// 两个调用方：[`do_provision`]（sk 被撤销后重建了一把）与
+/// 两个调用方：[`provision_relay`]（sk 被撤销后重建了一把）与
 /// [`reset_tier_config_impl`]（把被改坏的配置恢复成默认）。
 ///
 /// ## 为什么走 `sync_current_provider_for_app` 而不是 `switch`
@@ -4018,8 +3989,8 @@ fn prune_stale_tiers(
                 continue;
             }
             // 判据是 **(app_type, id) 组合**，不是光看 id ——
-            // 见 `do_provision` 里 `keep.insert` 那处的说明（同一个分组在两个 app
-            // 下是同一个 id，只看 id 会让串台的脏记录永远删不掉）。
+            // 见 `persist_provision_batch` 里 `keep.insert` 那处的说明（同一个分组
+            // 在两个 app 下是同一个 id，只看 id 会让串台的脏记录永远删不掉）。
             if keep.contains(&(app_type.as_str().to_string(), provider.id.clone())) {
                 continue;
             }
@@ -4184,7 +4155,7 @@ fn list_relays_impl(state: &AppState, app_type: AppType) -> Result<Vec<RelayRow>
 /// `OpenAI`（那会让会话历史分家）。这些改动都不会报错，只会让调用静默失败。
 ///
 /// 所以给一条回头路。**它是唯一会重写用户编辑的入口** —— 重复 provision 不再覆盖
-/// （见 `do_provision` 里那段），改配置的责任明确落在用户显式点这个按钮上。
+/// （见 `persist_provision_batch` 里那段），改配置的责任明确落在用户显式点这个按钮上。
 ///
 /// **sk 保留不变**：从现有配置里读出来再塞回去。恢复默认是「修配置」不是「换密钥」，
 /// 顺手换掉 sk 会让用户的其它设备上那把 key 失效（虽然认领逻辑会重新拿到，
@@ -4400,7 +4371,7 @@ fn reset_tier_config_in_state(
     // 默认配置，而 CLI 用的仍是那份坏配置 —— 且用户没有自救手段：UI 认为它已经是
     // 当前项，再点一次不会触发切换（前端 `if (tier.isCurrent) return;`）。
     //
-    // 与 `do_provision` 同一条路（见那边关于为什么用 `sync_current_provider_for_app`
+    // 与 `provision_relay` 同一条路（见那边关于为什么用 `sync_current_provider_for_app`
     // 而不是 `switch` 的说明）。失败只 warn：DB 已经是对的，切一次即生效，
     // 不该因为落地文件写不下去就报「恢复失败」。
     let is_current = ProviderService::current(state, app_type.clone())
@@ -5118,10 +5089,10 @@ fn remove_site_impl(
 
     // 生图工具跟着对齐一次 —— **这条路必须自己调**（review 抓出）。
     //
-    // 另一个调用点在 `do_provision` 收尾，但那条路依赖「还会再 provision 一次」。
-    // 删掉的正是拥有生图档位的那个账号时，**不会再有下一次** ⇒ `loongport-imagegen`
-    // 这条 MCP 记录永久留在用户的 CLI 配置里，而它每次被调用都报「还没有选定用哪个
-    // 档位生图」—— 一个删不掉的坏工具。
+    // 另一个调用点在 `mark_pricing_after_success`（provision 收尾），但那条路依赖
+    // 「还会再 provision 一次」。删掉的正是拥有生图档位的那个账号时，**不会再有
+    // 下一次** ⇒ `loongport-imagegen` 这条 MCP 记录永久留在用户的 CLI 配置里，
+    // 而它每次被调用都报「还没有选定用哪个档位生图」—— 一个删不掉的坏工具。
     //
     // 失败只 warn：站点记录马上就删了，不该因为一个 MCP 记录撤不掉而让「删站点」失败
     // （与上面那段清理档位同一条原则）。
@@ -5221,7 +5192,7 @@ fn relay_balance_inputs(state: &AppState, relay: &creds::Relay) -> (String, Vec<
 
 /// 余额。`relay_id` 指定查**哪一行**的。
 ///
-/// 与 [`relay_login`] / [`relay_provision`] 同一套纪律：显式指定查不到就报错，绝不
+/// 与 [`relay_login`] / [`relay_refresh`] 同一套纪律：显式指定查不到就报错，绝不
 /// 回落到其它站点 —— 那会把 B 的余额显示在 A 那一行上，比报错更糟。
 ///
 /// ## 一行一次请求是安全的
@@ -6643,6 +6614,29 @@ mod tests {
         }
     }
 
+    /// `RelayRowStatus` 的线上名由 `RelayRow.tsx` 的 `RowStatus` switch 直接消费
+    /// （裸字符串比较，无编译器把守）。这里把每个变体的 serde 输出钉死 ——
+    /// 改枚举变体名 / 改 rename 规则时这条会红，提醒同步前端 union。
+    #[test]
+    fn relay_row_statuses_serialize_to_the_wire_names_the_frontend_matches() {
+        for (status, wire) in [
+            (RelayRowStatus::NotLoggedIn, "\"notLoggedIn\""),
+            (RelayRowStatus::SessionExpired, "\"sessionExpired\""),
+            (
+                RelayRowStatus::SessionExpiredUsable,
+                "\"sessionExpiredUsable\"",
+            ),
+            (RelayRowStatus::NoTiers, "\"noTiers\""),
+            (RelayRowStatus::Ready, "\"ready\""),
+        ] {
+            assert_eq!(
+                serde_json::to_string(&status).expect("status 可序列化"),
+                wire,
+                "{status:?} 的线上名变了，src/lib/api/relay.ts 的 union 与 RowStatus 要跟着改"
+            );
+        }
+    }
+
     #[test]
     fn new_site_import_discovery_stays_in_memory_until_authentication() {
         let context = browser_login_context(
@@ -7060,10 +7054,10 @@ mod tests {
     ///
     /// ## 它守的是什么缺陷（TODO 债 11）
     ///
-    /// [`do_provision`] 一次探**全部平台**，`tiers` 收的是全平台的结果，而 UI 那一行
-    /// 只显示**当前 app** 的档位。于是「这个站没有 anthropic 分组」与「拉取失败」
-    /// 在界面上长得一样（都是零档位 + 「该账号在此平台下没有可用分组」）——
-    /// 而前者重试一百次也不会有，后者重试有意义。
+    /// provision 链路（`refresh_relay_provision`）一次探**全部平台**，`tiers` 收的是
+    /// 全平台的结果，而 UI 那一行只显示**当前 app** 的档位。于是「这个站没有
+    /// anthropic 分组」与「拉取失败」在界面上长得一样（都是零档位 +
+    /// 「该账号在此平台下没有可用分组」）—— 而前者重试一百次也不会有，后者重试有意义。
     ///
     /// 区分它们所需的信息 provision 时**本来就在手上**（每个分组的 `app_type`），
     /// 少的只是把它发给前端。没有这个字段，前端拿到一堆 tiers 却分不出哪条是自己的。
@@ -9848,7 +9842,7 @@ mod tests {
     ///
     /// ## 为什么这条测试读源码而不是调函数
     ///
-    /// `do_provision` 仍吃 `&tauri::AppHandle`；reset 的数据库与协调器路径已经下沉到
+    /// provision 入口仍吃 `&tauri::AppHandle`；reset 的数据库与协调器路径已经下沉到
     /// `reset_tier_config_in_state` 并由真实行为测试覆盖，但“当前项刷新 live 文件”会触碰
     /// 用户配置，单元测试不能安全执行。第二路 review 实测证明了这条接线盲区的代价：
     /// 把那两处调用注释掉，2578 条测试**全绿**——
@@ -9862,11 +9856,11 @@ mod tests {
     fn refresh_live_for_current_tiers_is_wired_into_both_commands() {
         let src = include_str!("relay.rs");
 
-        // 取 `do_provision` 到 `prune_stale_tiers` 调用之间那段（provision 那条路）。
+        // 取 `refresh_relay_provision` 到 `prune_stale_tiers` 调用之间那段（provision 那条路）。
         let provision = {
             let start = src
-                .find("async fn do_provision")
-                .expect("do_provision 还在吗");
+                .find("async fn refresh_relay_provision")
+                .expect("refresh_relay_provision 还在吗");
             let end = src[start..]
                 .find("let removed = prune_stale_tiers")
                 .expect("provision 末尾那段清理还在吗");
@@ -9874,7 +9868,7 @@ mod tests {
         };
         assert!(
             provision.contains("refresh_live_for_current_tiers(state, &refresh_live)"),
-            "⭐ `do_provision` 不再刷新当前档位的 live config —— \
+            "⭐ provision 链路不再刷新当前档位的 live config —— \
              sk 被撤销重建后，CLI 会一直用旧密钥，而用户点不动那个档位（UI 认为它已是当前项）"
         );
 

--- a/src-tauri/src/commands/vendor.rs
+++ b/src-tauri/src/commands/vendor.rs
@@ -1421,6 +1421,29 @@ fn with_conn<T>(
 mod tests {
     use super::*;
 
+    /// `VendorAccountStatus` 的线上名由 `VendorRow.tsx` 的 `VendorStatus` switch 直接
+    /// 消费（裸字符串比较，无编译器把守）。这里把每个变体的 serde 输出钉死 ——
+    /// 改枚举变体名 / 改 rename 规则时这条会红，提醒同步前端 union。
+    #[test]
+    fn vendor_account_statuses_serialize_to_the_wire_names_the_frontend_matches() {
+        for (status, wire) in [
+            (VendorAccountStatus::NotLoggedIn, "\"notLoggedIn\""),
+            (VendorAccountStatus::SessionExpired, "\"sessionExpired\""),
+            (
+                VendorAccountStatus::SessionExpiredUsable,
+                "\"sessionExpiredUsable\"",
+            ),
+            (VendorAccountStatus::Ready, "\"ready\""),
+            (VendorAccountStatus::NoKey, "\"noKey\""),
+        ] {
+            assert_eq!(
+                serde_json::to_string(&status).expect("status 可序列化"),
+                wire,
+                "{status:?} 的线上名变了，src/lib/api/vendor.ts 的 union 与 VendorStatus 要跟着改"
+            );
+        }
+    }
+
     fn row(auth_token: &str, api_key: &str, account_id: Option<&str>) -> creds::VendorRow {
         creds::VendorRow {
             id: 1,

--- a/src-tauri/src/crowd/bucket.rs
+++ b/src-tauri/src/crowd/bucket.rs
@@ -504,10 +504,9 @@ pub fn build_hour_buckets(
             anomalies_by_site.get(&(bucket.hour_epoch, bucket.site.clone(), bucket.app.clone()))
         {
             for model_row in &mut bucket.models {
-                model_row.anomalies = per_model
-                    .get(&model_row.model)
-                    .copied()
-                    .unwrap_or(model_row.anomalies);
+                // 此处 `model_row.anomalies` 尚未被写过（初值 0），缺项就是 0 ——
+                // 明写出来，别用自引用的 `unwrap_or(model_row.anomalies)` 装作有状态。
+                model_row.anomalies = per_model.get(&model_row.model).copied().unwrap_or(0);
             }
         }
     }

--- a/src-tauri/src/deeplink/mod.rs
+++ b/src-tauri/src/deeplink/mod.rs
@@ -3,8 +3,8 @@
 //! scheme 是 `loongport://`（`tauri.conf.json` 的 `plugins.deep-link`）。
 //!
 //! **LoongPort 的主流程不走这里**：拿到 sk 与 endpoint 之后直接写 provider 记录
-//! （见 `commands::relay::relay_provision`），不经 deeplink 导入。这条链路是从上游
-//! 继承下来的通用导入能力，留着不碍事。
+//! （见 `commands::relay::refresh_relay_provision`，`relay_refresh` 命令的内部路径），
+//! 不经 deeplink 导入。这条链路是从上游继承下来的通用导入能力，留着不碍事。
 //!
 //! Supports importing:
 //! - Provider configurations (Claude/Codex/Gemini)

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -152,6 +152,7 @@ mod consistency_tests {
             ("S3_SYNC_STATUS_UPDATED", super::S3_SYNC_STATUS_UPDATED),
             ("PURCHASE_CLOSED", super::PURCHASE_CLOSED),
             ("VENDOR_LOGIN_ERROR", super::VENDOR_LOGIN_ERROR),
+            ("VENDOR_ACCOUNTS_CHANGED", super::VENDOR_ACCOUNTS_CHANGED),
             (
                 "MODEL_VERIFICATION_PROGRESS",
                 super::MODEL_VERIFICATION_PROGRESS,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1673,7 +1673,6 @@ pub fn run() {
             commands::relay_login,
             commands::relay_refresh,
             commands::relay_refresh_all,
-            commands::relay_provision,
             commands::relay_list_relays,
             commands::relay_reorder,
             commands::relay_reset_tier_config,

--- a/src-tauri/src/relay/api.rs
+++ b/src-tauri/src/relay/api.rs
@@ -45,8 +45,8 @@ use crate::app_config::AppType;
 use crate::error::AppError;
 use crate::provider::{UsageData, UsageResult};
 use crate::relay::backend::{
-    BackendKind, DetectedSite, ProbeAdapter, ProbeCandidate, AUTH_DEAD_MARKER, AUTH_EXPIRED_MARKER,
-    RELOGIN_MARKER,
+    describe_send_error, BackendKind, DetectedSite, ProbeAdapter, ProbeCandidate, AUTH_DEAD_MARKER,
+    AUTH_EXPIRED_MARKER, RELOGIN_MARKER,
 };
 use crate::relay::platform_map::{parse_platform, Platform};
 
@@ -1299,47 +1299,6 @@ fn idempotency_key_for(account_id: Option<i64>, name: &str) -> String {
     hex::encode(h.finalize())
 }
 
-/// 把一个 `reqwest` 发送错误描述成**能定位问题**的一行。
-///
-/// ## 为什么不能直接 `{e}`
-///
-/// `reqwest::Error` 的 `Display` 只打印最外层，形如
-/// `error sending request for url (https://…)` —— **超时、DNS 解析失败、连接被拒、
-/// TLS 握手失败、代理不可达打印出来完全一样**，真实原因在 `std::error::Error::source()`
-/// 链里（hyper → 系统错误）。
-///
-/// 2026-08-03 的实测代价：用户报「获取分组列表失败: error sending request for url
-/// (https://bestapi.store/api/v1/groups/available)」，日志里就这一句。为判断是哪一类，
-/// 只能专门写一个最小复现程序传到那台 Windows 上，逐层验证 DNS / TCP / TLS / 5 种 client
-/// 变体 —— 而那本该是日志里现成的一行。
-///
-/// 所以这里做两件事：**给出失败类别**（`is_timeout` / `is_connect` 这些谓词，比原始
-/// 措辞更适合展示给用户），以及**展开整条 source 链**（给维护者定位用）。
-fn describe_send_error(e: &reqwest::Error) -> String {
-    // 类别前缀：用户看得懂的话术。判定顺序按「越具体越先」——
-    // 超时优先于连接：连接阶段超时时两个谓词可能同时为真，而「超时」对用户更有指导性
-    // （等一下重试），「连不上」会让人以为是地址错了。
-    let kind = if e.is_timeout() {
-        "请求超时"
-    } else if e.is_connect() {
-        "连不上服务器"
-    } else if e.is_request() {
-        "请求发送失败"
-    } else {
-        "网络错误"
-    };
-
-    let mut out = format!("{kind}（{e}）");
-    // 整条链都带上：真实原因常在第 2-3 层（hyper 之下的系统错误）。
-    // 首层往往就是判据本身（超时是 `operation timed out`、连接被拒是系统 errno）。
-    let mut src: Option<&(dyn std::error::Error + 'static)> = std::error::Error::source(e);
-    while let Some(s) = src {
-        out.push_str(&format!(" cause: {s}"));
-        src = s.source();
-    }
-    out
-}
-
 pub(crate) fn build_client_with_user_agent(
     user_agent: Option<&str>,
 ) -> Result<reqwest::Client, AppError> {
@@ -2271,113 +2230,6 @@ mod tests {
         assert!(
             !error.contains(RESPONSE_MARKER),
             "error leaked authenticated response body: {error}"
-        );
-    }
-
-    /// **传输错误必须带上 `source()` 链**。
-    ///
-    /// 2026-08-03 实测代价：用户报「获取分组列表失败: error sending request for url
-    /// (https://bestapi.store/api/v1/groups/available)」，而那串正是 `{e}` 对
-    /// `reqwest::Error` 的全部输出 —— 超时 / DNS / 连接被拒 / TLS 失败**打印出来一模一样**，
-    /// 真实原因在 `source()` 链里被丢掉了。结果：为了知道是哪一种，只能专门编一个最小
-    /// 复现程序传到那台机器上跑（DNS、TCP、TLS、5 个 client 变体逐层验证），
-    /// 而这本该是日志里的一行。
-    ///
-    /// 这条钉住「链被展开了」，不钉具体措辞（那是 reqwest 的措辞，会随版本变）。
-    ///
-    /// ## 两处刻意的写法
-    ///
-    /// **1. 用本机 listener 制造失败，不打任何外部地址。** 起初用的是保留地址
-    /// `192.0.2.1`（RFC 5737）+ 1ms 超时，但那不由本进程说了算：CI 的网络命名空间可能
-    /// 立即回 network-unreachable（那是 connect 而非 timeout）、透明代理也可能把它接走
-    /// 变成一个 HTTP 响应 ⇒ 拿到 `Ok` 而不是错误。现在连一个**接受连接但永不回应**的
-    /// 本机 listener，超时由我们自己的 timeout 决定，与外网和 CI 网络配置无关。
-    ///
-    /// **2. 断言比对首层 source 的原文**，而不是「长度变长了」或「包含某个词」——
-    /// 那两种都能被类别前缀单独满足，把 source 遍历整段删掉测试照样过（codex review
-    /// 抓到的正是这一点）。
-    #[tokio::test]
-    async fn transport_errors_carry_their_source_chain() {
-        // 接受连接后什么都不做（连 listener 都不 drop）⇒ 客户端等响应等到超时。
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind listener");
-        let addr = listener.local_addr().expect("local addr");
-        tokio::spawn(async move {
-            // 握住连接不放：一 drop 就变成「连接被对端关闭」，那是另一类错误。
-            let mut held = Vec::new();
-            while let Ok((stream, _)) = listener.accept().await {
-                held.push(stream);
-            }
-        });
-
-        // `.no_proxy()` 不可省，理由见下一条测试。
-        let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_millis(200))
-            .no_proxy()
-            .build()
-            .expect("build client");
-        let err = client
-            .get(format!("http://{addr}/whatever"))
-            .send()
-            .await
-            .expect_err("对端永不回应，必须超时");
-
-        let bare = format!("{err}");
-        let described = describe_send_error(&err);
-
-        // 前提一：`{e}` 真的什么都没说 —— 这正是 bug 的形状。
-        assert!(
-            !bare.contains("cause"),
-            "`{{e}}` 不该带 cause，否则这条测试的前提不成立: {bare}"
-        );
-        // 前提二：这个错误确实有 source 可展开（没有的话下面的断言就是空转）。
-        let first = std::error::Error::source(&err).expect("传输错误必须有 source 可展开");
-
-        // 本体：首层 source 的原文必须出现在描述里。删掉 source 遍历这条就会红。
-        assert!(
-            described.contains(&format!("cause: {first}")),
-            "描述必须带上首层 source 的原文\n  source: {first}\n  desc: {described}"
-        );
-    }
-
-    /// 分类前缀不能张冠李戴：连接失败不该被说成超时。
-    #[tokio::test]
-    async fn describe_send_error_labels_connect_failures_as_connect() {
-        // 先绑一个端口再立即释放 ⇒ 拿到一个**确定没人监听**的地址。
-        // 不用写死的 `127.0.0.1:1`：没有哪条规矩保证它在所有 CI 上都空着。
-        let addr = {
-            let probe = tokio::net::TcpListener::bind("127.0.0.1:0")
-                .await
-                .expect("bind probe");
-            probe.local_addr().expect("local addr")
-            // probe 在这里 drop，端口回到无人监听状态。
-        };
-
-        // `.no_proxy()` 不可省：维护者机器上开着 Clash，系统代理会把这个请求接走并回
-        // **503**（`proxy-connection: close`）⇒ 拿到的是 `Ok(response)` 而不是传输错误，
-        // 测试会以「这个端口竟然有人监听」的形式失败。这里要的是「连接失败」这个事件本身，
-        // 不该受运行环境有没有代理影响。
-        let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(5))
-            .no_proxy()
-            .build()
-            .expect("build client");
-        let err = client
-            .get(format!("http://{addr}/whatever"))
-            .send()
-            .await
-            .expect_err("刚释放的端口不该有人监听");
-
-        // 前提：这确实是一个连接类失败、且不是超时。否则下面在验别的东西。
-        assert!(err.is_connect(), "前提不成立，这不是连接类错误: {err:?}");
-        assert!(!err.is_timeout(), "前提不成立，这是超时错误: {err:?}");
-
-        // 本体：分类前缀必须如实说「连不上」，不能标成超时或含糊的兜底措辞。
-        let described = describe_send_error(&err);
-        assert!(
-            described.starts_with("连不上服务器"),
-            "连接类失败的分类前缀必须是「连不上服务器」: {described}"
         );
     }
 }

--- a/src-tauri/src/relay/backend.rs
+++ b/src-tauri/src/relay/backend.rs
@@ -71,6 +71,47 @@ pub fn browser_login_script(
     }
 }
 
+/// 把一个 `reqwest` 发送错误描述成**能定位问题**的一行。api / newapi 两条协议侧共用。
+///
+/// ## 为什么不能直接 `{e}`
+///
+/// `reqwest::Error` 的 `Display` 只打印最外层，形如
+/// `error sending request for url (https://…)` —— **超时、DNS 解析失败、连接被拒、
+/// TLS 握手失败、代理不可达打印出来完全一样**，真实原因在 `std::error::Error::source()`
+/// 链里（hyper → 系统错误）。
+///
+/// 2026-08-03 的实测代价：用户报「获取分组列表失败: error sending request for url
+/// (https://bestapi.example/api/v1/groups/available)」，日志里就这一句。为判断是哪一类，
+/// 只能专门写一个最小复现程序传到那台 Windows 上，逐层验证 DNS / TCP / TLS / 5 种 client
+/// 变体 —— 而那本该是日志里现成的一行。
+///
+/// 所以这里做两件事：**给出失败类别**（`is_timeout` / `is_connect` 这些谓词，比原始
+/// 措辞更适合展示给用户），以及**展开整条 source 链**（给维护者定位用）。
+pub(crate) fn describe_send_error(e: &reqwest::Error) -> String {
+    // 类别前缀：用户看得懂的话术。判定顺序按「越具体越先」——
+    // 超时优先于连接：连接阶段超时时两个谓词可能同时为真，而「超时」对用户更有指导性
+    // （等一下重试），「连不上」会让人以为是地址错了。
+    let kind = if e.is_timeout() {
+        "请求超时"
+    } else if e.is_connect() {
+        "连不上服务器"
+    } else if e.is_request() {
+        "请求发送失败"
+    } else {
+        "网络错误"
+    };
+
+    let mut out = format!("{kind}（{e}）");
+    // 整条链都带上：真实原因常在第 2-3 层（hyper 之下的系统错误）。
+    // 首层往往就是判据本身（超时是 `operation timed out`、连接被拒是系统 errno）。
+    let mut src: Option<&(dyn std::error::Error + 'static)> = std::error::Error::source(e);
+    while let Some(s) = src {
+        out.push_str(&format!(" cause: {s}"));
+        src = s.source();
+    }
+    out
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeAccount {
     pub id: i64,
@@ -321,6 +362,113 @@ mod tests {
                 "commands::relay must not own protocol detail {protocol_detail:?}"
             );
         }
+    }
+
+    /// **传输错误必须带上 `source()` 链**。
+    ///
+    /// 2026-08-03 实测代价：用户报「获取分组列表失败: error sending request for url
+    /// (https://panel.example/api/v1/groups/available)」，而那串正是 `{e}` 对
+    /// `reqwest::Error` 的全部输出 —— 超时 / DNS / 连接被拒 / TLS 失败**打印出来一模一样**，
+    /// 真实原因在 `source()` 链里被丢掉了。结果：为了知道是哪一种，只能专门编一个最小
+    /// 复现程序传到那台机器上跑（DNS、TCP、TLS、5 个 client 变体逐层验证），
+    /// 而这本该是日志里的一行。
+    ///
+    /// 这条钉住「链被展开了」，不钉具体措辞（那是 reqwest 的措辞，会随版本变）。
+    ///
+    /// ## 两处刻意的写法
+    ///
+    /// **1. 用本机 listener 制造失败，不打任何外部地址。** 起初用的是保留地址
+    /// `192.0.2.1`（RFC 5737）+ 1ms 超时，但那不由本进程说了算：CI 的网络命名空间可能
+    /// 立即回 network-unreachable（那是 connect 而非 timeout）、透明代理也可能把它接走
+    /// 变成一个 HTTP 响应 ⇒ 拿到 `Ok` 而不是错误。现在连一个**接受连接但永不回应**的
+    /// 本机 listener，超时由我们自己的 timeout 决定，与外网和 CI 网络配置无关。
+    ///
+    /// **2. 断言比对首层 source 的原文**，而不是「长度变长了」或「包含某个词」——
+    /// 那两种都能被类别前缀单独满足，把 source 遍历整段删掉测试照样过（codex review
+    /// 抓到的正是这一点）。
+    #[tokio::test]
+    async fn transport_errors_carry_their_source_chain() {
+        // 接受连接后什么都不做（连 listener 都不 drop）⇒ 客户端等响应等到超时。
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind listener");
+        let addr = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            // 握住连接不放：一 drop 就变成「连接被对端关闭」，那是另一类错误。
+            let mut held = Vec::new();
+            while let Ok((stream, _)) = listener.accept().await {
+                held.push(stream);
+            }
+        });
+
+        // `.no_proxy()` 不可省，理由见下一条测试。
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_millis(200))
+            .no_proxy()
+            .build()
+            .expect("build client");
+        let err = client
+            .get(format!("http://{addr}/whatever"))
+            .send()
+            .await
+            .expect_err("对端永不回应，必须超时");
+
+        let bare = format!("{err}");
+        let described = describe_send_error(&err);
+
+        // 前提一：`{e}` 真的什么都没说 —— 这正是 bug 的形状。
+        assert!(
+            !bare.contains("cause"),
+            "`{{e}}` 不该带 cause，否则这条测试的前提不成立: {bare}"
+        );
+        // 前提二：这个错误确实有 source 可展开（没有的话下面的断言就是空转）。
+        let first = std::error::Error::source(&err).expect("传输错误必须有 source 可展开");
+
+        // 本体：首层 source 的原文必须出现在描述里。删掉 source 遍历这条就会红。
+        assert!(
+            described.contains(&format!("cause: {first}")),
+            "描述必须带上首层 source 的原文\n  source: {first}\n  desc: {described}"
+        );
+    }
+
+    /// 分类前缀不能张冠李戴：连接失败不该被说成超时。
+    #[tokio::test]
+    async fn describe_send_error_labels_connect_failures_as_connect() {
+        // 先绑一个端口再立即释放 ⇒ 拿到一个**确定没人监听**的地址。
+        // 不用写死的 `127.0.0.1:1`：没有哪条规矩保证它在所有 CI 上都空着。
+        let addr = {
+            let probe = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind probe");
+            probe.local_addr().expect("local addr")
+            // probe 在这里 drop，端口回到无人监听状态。
+        };
+
+        // `.no_proxy()` 不可省：维护者机器上开着 Clash，系统代理会把这个请求接走并回
+        // **503**（`proxy-connection: close`）⇒ 拿到的是 `Ok(response)` 而不是传输错误，
+        // 测试会以「这个端口竟然有人监听」的形式失败。这里要的是「连接失败」这个事件本身，
+        // 不该受运行环境有没有代理影响。
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .no_proxy()
+            .build()
+            .expect("build client");
+        let err = client
+            .get(format!("http://{addr}/whatever"))
+            .send()
+            .await
+            .expect_err("刚释放的端口不该有人监听");
+
+        // 前提：这确实是一个连接类失败、且不是超时。否则下面在验别的东西。
+        assert!(err.is_connect(), "前提不成立，这不是连接类错误: {err:?}");
+        assert!(!err.is_timeout(), "前提不成立，这是超时错误: {err:?}");
+
+        // 本体：分类前缀必须如实说「连不上」，不能标成超时或含糊的兜底措辞。
+        let described = describe_send_error(&err);
+        assert!(
+            described.starts_with("连不上服务器"),
+            "连接类失败的分类前缀必须是「连不上服务器」: {described}"
+        );
     }
 
     use super::*;

--- a/src-tauri/src/relay/imagegen.rs
+++ b/src-tauri/src/relay/imagegen.rs
@@ -769,7 +769,8 @@ base_url = "https://api.example.com/v1"
     }
 
     /// 超时随张数线性放大（App 内入口的封顶），n=0 兜底按一张算 —— 不是 0 秒必超时。
-    /// MCP 入口固定 n=1 ⇒ 恒 240s（那条「给 codex 300s 留 60s 余量」的理由不动）。
+    /// 两个入口（App 内 / MCP）都按张数放大；n=1 时即那条「给 codex 300s 留 60s 余量」
+    /// 的基线 240s。
     #[test]
     fn request_timeout_scales_with_the_image_count() {
         assert_eq!(request_timeout(1).as_secs(), 240);

--- a/src-tauri/src/relay/imagegen_mcp.rs
+++ b/src-tauri/src/relay/imagegen_mcp.rs
@@ -400,6 +400,16 @@ mod tests {
             "`get_imagegen_mcp_enabled` 的回落不再是「默认开」—— \
              这是个产品行为决定（升级用户的注册行为不变），改它要连着文档一起改"
         );
+
+        // 前端那份默认值（`?? true`）也必须与后端回落一致：分叉的症状是开关显示
+        // 「开」而后端行为是「关」（或反过来），跨语言编译器管不到 `.ts`。
+        let notice_tsx = include_str!("../../../src/components/relay/ImageTabNotice.tsx");
+        assert!(
+            notice_tsx.contains("settings?.imagegenMcpEnabled ?? true"),
+            "src/components/relay/ImageTabNotice.tsx 的开关默认值不再是 `?? true` —— \
+             它必须与 settings.rs 的 `imagegen_mcp_enabled.unwrap_or(true)` 保持一致，\
+             两边要一起改"
+        );
     }
 
     /// ⚠️ **这个 crate 的 logger 写 stdout，而 stdout 是 MCP 的协议通道。**

--- a/src-tauri/src/relay/model_verification/active.rs
+++ b/src-tauri/src/relay/model_verification/active.rs
@@ -7,7 +7,7 @@ use crate::{
         capability_profiles::CapabilityProfile,
         coordinator::{ActiveVerifier, PreparedVerification, ProbeProgress},
         protocols::{self, RunFailure},
-        target::ResolvedTarget,
+        target::{supports_app_type, ResolvedTarget},
         types::{RunFailureKind, TargetKey, VerificationReport, RULES_VERSION},
         verdict,
     },
@@ -35,7 +35,7 @@ impl ActiveVerifier for BalancedActiveVerifier {
     ) -> Result<PreparedVerification, RunFailureKind> {
         let app_type = AppType::from_str(&target.app_type)
             .ok()
-            .filter(|app_type| matches!(app_type, AppType::Codex | AppType::Claude))
+            .filter(supports_app_type)
             .ok_or(RunFailureKind::InvalidResponse)?;
         let resolved = ResolvedTarget::resolve(&self.db, target.clone())
             .map_err(|_| RunFailureKind::InvalidResponse)?;

--- a/src-tauri/src/relay/model_verification/mod.rs
+++ b/src-tauri/src/relay/model_verification/mod.rs
@@ -27,6 +27,24 @@ mod live_sweep_tests;
 
 #[cfg(test)]
 mod tests {
+    /// 总开关在 Rust 与 TS 各有一份（两侧模块唯一收口处）。跨语言编译器管不到
+    /// `.ts`：只翻一边时另一侧照常渲染入口/徽章而数据恒空（或反过来），不报错。
+    /// v6.14.1 下线、v2 规则恢复时都是两边各改一遍才没出事 —— 这道闸把「忘了
+    /// 另一边」从静默失效变成测试红。形状照 `events.rs` 的跨语言闸。
+    #[test]
+    fn model_verification_enabled_matches_the_frontend_copy() {
+        const ENABLED: bool = super::MODEL_VERIFICATION_ENABLED;
+        let ts =
+            include_str!("../../../../src/components/relay/model-verification/availability.ts");
+        let expected = format!("export const MODEL_VERIFICATION_ENABLED = {ENABLED};");
+        assert!(
+            ts.contains(&expected),
+            "src/components/relay/model-verification/availability.ts 的总开关与 Rust 侧不一致\n  \
+             Rust 侧的值: {ENABLED}\n  \
+             期望 TS 里出现: {expected}"
+        );
+    }
+
     use super::{
         store::{
             clear_scope, list_for_provider_ids, list_for_providers, upsert_active, upsert_passive,

--- a/src-tauri/src/relay/newapi.rs
+++ b/src-tauri/src/relay/newapi.rs
@@ -11,7 +11,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::AppError;
 use crate::relay::backend::{
-    BackendKind, DetectedSite, ProbeAdapter, ProbeCandidate, AUTH_DEAD_MARKER, RELOGIN_MARKER,
+    describe_send_error, BackendKind, DetectedSite, ProbeAdapter, ProbeCandidate, AUTH_DEAD_MARKER,
+    RELOGIN_MARKER,
 };
 
 /// refresh cookie 的名字。`pub(crate)`：commands 层的命令级测试要按它构造 fake
@@ -33,13 +34,11 @@ const SESSION_TOKEN_PATH: &str = "/api/user/token";
 const NEWAPI_USER_HEADER: &str = "New-Api-User";
 const SESSION_SCHEME: &str = "loongport-newapi-session";
 
-pub fn login_url(site_origin: &str, login_identifier: &str) -> String {
-    if login_identifier.is_empty() {
-        format!("{site_origin}/register")
-    } else {
-        format!("{site_origin}/login")
-    }
-}
+/// 「新站落 `/register`、老站落 `/login`」这条约定与 sub2api 完全相同 —— 实现只有
+/// 一份，在 [`crate::relay::login::login_url`]（那边的文档记录了为什么按
+/// `login_identifier` 分流）。这里 re-export 而不是再抄一份：两份逐字相同的实现
+/// 只会各自漂移。
+pub use crate::relay::login::login_url;
 
 pub fn login_script() -> String {
     format!(
@@ -622,26 +621,6 @@ fn extract_rotated_refresh_cookie(
     Err(AppError::Config(
         "newapi refresh 响应缺少 rotated new_api_refresh cookie".into(),
     ))
-}
-
-fn describe_send_error(error: &reqwest::Error) -> String {
-    let kind = if error.is_timeout() {
-        "请求超时"
-    } else if error.is_connect() {
-        "连不上服务器"
-    } else if error.is_request() {
-        "请求发送失败"
-    } else {
-        "网络错误"
-    };
-
-    let mut output = format!("{kind}（{error}）");
-    let mut source = std::error::Error::source(error);
-    while let Some(next) = source {
-        output.push_str(&format!(" cause: {next}"));
-        source = next.source();
-    }
-    output
 }
 
 fn classify_authenticated_http_status(operation: &str, status: reqwest::StatusCode) -> AppError {

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -14,7 +14,9 @@ use crate::store::AppState;
 
 use crate::config::OFFICIAL_WEBSITE;
 
-const TEMPLATE_TYPE_OFFICIAL_SUBSCRIPTION: &str = "official_subscription";
+// 唯一源在 commands/provider.rs（provider meta 的 wire 值），经 commands 的
+// glob re-export 引用，这里只消费。
+use crate::commands::TEMPLATE_TYPE_OFFICIAL_SUBSCRIPTION;
 const H_TIER_NAMES: &[&str] = &[crate::services::subscription::TIER_FIVE_HOUR];
 const W_TIER_NAMES: &[&str] = &[
     crate::services::subscription::TIER_WEEKLY_LIMIT,

--- a/src-tauri/src/vendor/bigmodel.rs
+++ b/src-tauri/src/vendor/bigmodel.rs
@@ -104,10 +104,8 @@ fn parse_envelope<T: DeserializeOwned>(body: &str, what: &str) -> Result<T, Vend
 }
 
 fn build_client() -> Result<reqwest::Client, AppError> {
-    reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .map_err(|e| AppError::Config(format!("创建 HTTP 客户端失败: {e}")))
+    // 复用 relay 层的共享构造器（30s 超时、无会话特征），平凡构造器不各写一份。
+    crate::relay::api::build_client()
 }
 
 /// 发一次请求，带齐三个鉴权头。HTTP 401/403 视为登录态过期。

--- a/src-tauri/src/vendor/deepseek.rs
+++ b/src-tauri/src/vendor/deepseek.rs
@@ -482,13 +482,10 @@ fn round_decimal_string(raw: &str) -> Option<String> {
 
 // ─────────────────────────── HTTP ───────────────────────────
 
-/// 鉴权只要 Bearer（见模块文档），所以是个普通 HTTP 客户端。
-///
+/// 鉴权只要 Bearer（见模块文档），复用 relay 层的共享客户端构造器（30s 超时、
+/// 无会话特征）—— 平凡构造器各写一份只会各自漂。
 fn build_client() -> Result<reqwest::Client, AppError> {
-    reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .map_err(|e| AppError::Config(format!("创建 HTTP 客户端失败: {e}")))
+    crate::relay::api::build_client()
 }
 
 /// 一次 GET，返回响应体文本。

--- a/src-tauri/src/vendor/mod.rs
+++ b/src-tauri/src/vendor/mod.rs
@@ -52,9 +52,9 @@ impl Vendor {
 
     pub fn from_id(id: &str) -> Option<Self> {
         match id {
-            "deepseek" => Some(Vendor::DeepSeek),
-            "bigmodel" => Some(Vendor::BigModel),
-            "opencode" => Some(Vendor::OpenCode),
+            deepseek::VENDOR_ID => Some(Vendor::DeepSeek),
+            bigmodel::VENDOR_ID => Some(Vendor::BigModel),
+            opencode::VENDOR_ID => Some(Vendor::OpenCode),
             _ => None,
         }
     }
@@ -82,16 +82,15 @@ pub struct PlanInfo {
 /// 单 plan 厂商的档位清单：段 = `vendor_id`、名字 = 厂商名 —— 与「一个账号一个
 /// endpoint」的旧世界完全一致（provider id 派生结果一个字节都没变）。
 ///
-/// `display_name` 在这里各写一份字面量（const 上下文调不了 `Vendor::display_name`），
-/// 一致性由测试 `single_plan_segments_mirror_the_vendor_identity` 钉住 —— 同
-/// `MANAGED_ID_PREFIX` 那道跨文件闸的模式。
+/// 两个都从 [`Vendor`] 的身份**派生**（`display_name` 是 const fn），不再各写字面量；
+/// 一致性另有测试 `single_plan_segments_mirror_the_vendor_identity` 钉住。
 const DEEPSEEK_PLANS: &[PlanInfo] = &[PlanInfo {
     id_segment: deepseek::VENDOR_ID,
-    display_name: "DeepSeek",
+    display_name: Vendor::DeepSeek.display_name(),
 }];
 const BIGMODEL_PLANS: &[PlanInfo] = &[PlanInfo {
     id_segment: bigmodel::VENDOR_ID,
-    display_name: "智谱 BigModel",
+    display_name: Vendor::BigModel.display_name(),
 }];
 
 /// 这个厂商账号展开出的全部 plan。数组序即展示序。
@@ -468,6 +467,32 @@ mod tests {
         assert_eq!(Vendor::from_id("deepseek"), Some(Vendor::DeepSeek));
         assert_eq!(Vendor::from_id("kimi"), None);
         assert_eq!(Vendor::DeepSeek.vendor_id(), "deepseek");
+    }
+
+    /// 前端 `VENDOR_CATALOG` 与本枚举是同一事实（厂商 id + 展示名）的两份拷贝。
+    /// 跨语言编译器管不到 `.ts`，分叉不报错：id 错了后端报「不认识的厂商」，
+    /// 名字错了「官方 API」页与账号行两个名字。形状照 `events.rs` 的跨语言闸。
+    #[test]
+    fn frontend_catalog_matches_the_rust_registry() {
+        let ts = include_str!("../../../src/lib/api/vendor.ts");
+        for (ts_const, vendor) in [
+            ("DEEPSEEK_VENDOR_ID", Vendor::DeepSeek),
+            ("BIGMODEL_VENDOR_ID", Vendor::BigModel),
+            ("OPENCODE_VENDOR_ID", Vendor::OpenCode),
+        ] {
+            let id = vendor.vendor_id();
+            assert!(
+                ts.contains(&format!("{ts_const} = \"{id}\"")),
+                "src/lib/api/vendor.ts 的 {ts_const} 与 Rust 侧 vendor_id 不一致\n  \
+                 Rust 侧的值: {id}"
+            );
+            let display = vendor.display_name();
+            assert!(
+                ts.contains(&format!("displayName: \"{display}\"")),
+                "src/lib/api/vendor.ts VENDOR_CATALOG 的 displayName 与 Rust 侧不一致\n  \
+                 Rust 侧的值: {display}"
+            );
+        }
     }
 
     /// 单 plan 厂商的档位段与名字必须与 `Vendor` 的身份一致 —— 段错了存量

--- a/src/components/relay/AddHubPage.tsx
+++ b/src/components/relay/AddHubPage.tsx
@@ -4,7 +4,7 @@ import { ArrowLeft, Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import type { AppId } from "@/lib/api";
+import { PLAZA_VISIBLE_DEFAULT, type AppId } from "@/lib/api";
 import { useSettingsQuery } from "@/lib/query";
 import { useVendorSupportedQuery } from "@/lib/query/vendor";
 import {
@@ -58,7 +58,7 @@ export function AddHubPage({
   // 未加载/未播种都按「展示」处理（未归因默认），且用派生值而非初值快照，
   // 设置晚到也能把已落在「广场」上的选中态拨回「手动添加」。
   const { data: settings } = useSettingsQuery();
-  const plazaVisible = settings?.plazaVisible ?? true;
+  const plazaVisible = settings?.plazaVisible ?? PLAZA_VISIBLE_DEFAULT;
   const [tab, setTab] = useState<AddHubTab>(initialTab);
   const effectiveTab: AddHubTab =
     !plazaVisible && tab === "directory" ? "manual" : tab;

--- a/src/components/relay/ImagegenPlayground.tsx
+++ b/src/components/relay/ImagegenPlayground.tsx
@@ -17,6 +17,7 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
+import { fmtBytes } from "@/lib/format";
 import { convertFileSrc } from "@tauri-apps/api/core";
 import { FolderOpen, Loader2, Sparkles } from "lucide-react";
 import { toast } from "sonner";
@@ -288,11 +289,4 @@ export function ImagegenPlayground() {
       </Dialog>
     </div>
   );
-}
-
-/** 字节数的展示格式化（纯展示，本地就够了）。 */
-function fmtBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/src/components/relay/directory/crowdDisplay.ts
+++ b/src/components/relay/directory/crowdDisplay.ts
@@ -5,6 +5,7 @@
  */
 
 import { formatLatency } from "./transitDisplay";
+import { fmtUsd } from "@/components/usage/format";
 
 export { formatLatency };
 
@@ -14,9 +15,9 @@ export function formatErrRate(rate: number): string {
   return `${percent >= 1 ? percent.toFixed(1) : percent.toFixed(2)}%`;
 }
 
-/** 花费参考值：$1.25 / 百万 token。 */
+/** 花费参考值：$1.25 / 百万 token。美元金额走全仓唯源 fmtUsd，不手拼 $ 串。 */
 export function formatCostPerMTok(usd: number): string {
-  return `$${usd.toFixed(2)}`;
+  return fmtUsd(usd, 2);
 }
 
 /**

--- a/src/components/relay/useRowBusy.ts
+++ b/src/components/relay/useRowBusy.ts
@@ -9,7 +9,7 @@ import { useCallback, useState } from "react";
  * 进行中，所有行的按钮都 `disabled={busy !== null}` ⇒ **用户点 A 的「获取密钥」，
  * B / C 的按钮全灰了**（他明确指出过：中转站之间、账号之间本来没有依赖）。
  *
- * 那个全局禁用当时是在兜一个**真实的并发正确性问题**：后端 `relay_provision`
+ * 那个全局禁用当时是在兜一个**真实的并发正确性问题**：后端 provision 命令
  * 靠 `creds::load()` 读「`is_current = 1` 的那一行」，前端得先 `set_current(id)`
  * 才能让它作用到对的账号上 —— 而 `is_current` 是全局单例，两个 provision 并发时
  * 会互相改写对方的目标。

--- a/src/components/settings/BackupListSection.tsx
+++ b/src/components/settings/BackupListSection.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Pencil, RotateCcw, Check, X, Download, Trash2 } from "lucide-react";
+import { fmtBytes } from "@/lib/format";
 import {
   Dialog,
   DialogContent,
@@ -30,12 +31,6 @@ interface BackupListSectionProps {
     backupIntervalHours?: number;
     backupRetainCount?: number;
   }) => void;
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 function formatBackupDate(isoString: string): string {
@@ -351,7 +346,7 @@ export function BackupListSection({
                       </div>
                       <div className="text-xs text-muted-foreground">
                         {formatBackupDate(backup.createdAt)} &middot;{" "}
-                        {formatBytes(backup.sizeBytes)}
+                        {fmtBytes(backup.sizeBytes)}
                       </div>
                     </>
                   )}

--- a/src/components/settings/PlazaSettings.tsx
+++ b/src/components/settings/PlazaSettings.tsx
@@ -4,7 +4,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 
 import { ToggleRow } from "@/components/ui/toggle-row";
-import { settingsApi } from "@/lib/api";
+import { PLAZA_VISIBLE_DEFAULT, settingsApi } from "@/lib/api";
 import { useSettingsQuery } from "@/lib/query";
 
 /**
@@ -19,7 +19,7 @@ export function PlazaSettings() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const { data: settings } = useSettingsQuery();
-  const checked = settings?.plazaVisible ?? true;
+  const checked = settings?.plazaVisible ?? PLAZA_VISIBLE_DEFAULT;
 
   const toggle = (visible: boolean) => {
     settingsApi

--- a/src/components/workspace/DailyMemoryPanel.tsx
+++ b/src/components/workspace/DailyMemoryPanel.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { Calendar, Trash2, Plus, Search, X, FolderOpen } from "lucide-react";
 import { AnimatePresence, motion } from "framer-motion";
+import { fmtBytes } from "@/lib/format";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { FullScreenPanel } from "@/components/common/FullScreenPanel";
@@ -31,12 +32,6 @@ function getTodayFilename(): string {
   const m = String(now.getMonth() + 1).padStart(2, "0");
   const d = String(now.getDate()).padStart(2, "0");
   return `${y}-${m}-${d}.md`;
-}
-
-function formatFileSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 const DailyMemoryPanel: React.FC<DailyMemoryPanelProps> = ({
@@ -455,7 +450,7 @@ const DailyMemoryPanel: React.FC<DailyMemoryPanelProps> = ({
                           {result.date}
                         </span>
                         <span className="text-xs text-muted-foreground">
-                          {formatFileSize(result.sizeBytes)}
+                          {fmtBytes(result.sizeBytes)}
                         </span>
                         {result.matchCount > 0 && (
                           <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-primary/10 text-primary font-medium">
@@ -511,7 +506,7 @@ const DailyMemoryPanel: React.FC<DailyMemoryPanelProps> = ({
                         {file.date}
                       </span>
                       <span className="text-xs text-muted-foreground">
-                        {formatFileSize(file.sizeBytes)}
+                        {fmtBytes(file.sizeBytes)}
                       </span>
                     </div>
                     {file.preview && (

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -2,7 +2,7 @@ export type { AppId } from "./types";
 export * from "./events";
 export { piApi } from "./pi";
 export { providersApi, universalProvidersApi } from "./providers";
-export { settingsApi } from "./settings";
+export { PLAZA_VISIBLE_DEFAULT, settingsApi } from "./settings";
 export { starRewardApi, type StarRewardOffer } from "./starReward";
 export { backupsApi } from "./settings";
 export { mcpApi } from "./mcp";

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -33,6 +33,13 @@ export interface WebDavSyncResult {
 
 export type FrontendSettings = Settings & { visibleApps: VisibleApps };
 
+/**
+ * `plazaVisible` 为 null/undefined（未播种 / 未加载）时的展示侧默认值 = 展示。
+ * 语义 owner 在后端（`relay::plaza` 的未归因默认），这里只收拢前端那几处
+ * `?? PLAZA_VISIBLE_DEFAULT`，别再各写一个裸 `true`。
+ */
+export const PLAZA_VISIBLE_DEFAULT = true;
+
 export const settingsApi = {
   async get(): Promise<FrontendSettings> {
     return await invoke("get_settings");

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,10 @@
+/**
+ * 字节数的展示格式化（`1.2 KB` / `3.4 MB`）。原先三处各写一份（备份列表、
+ * 工作区内存面板、生图画廊），KB 精度已经分叉 —— 收成一份，美元/整数同理走
+ * `components/usage/format` 的 fmtUsd/fmtInt，别再手拼单位串。
+ */
+export function fmtBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/tests/components/SettingsDialog.test.tsx
+++ b/tests/components/SettingsDialog.test.tsx
@@ -134,6 +134,8 @@ vi.mock("@/lib/api", () => ({
   settingsApi: {
     restart: vi.fn().mockResolvedValue(true),
   },
+  // PlazaSettings 从这里取展示侧默认值；mock 里给真值即可。
+  PLAZA_VISIBLE_DEFAULT: true,
 }));
 
 const TabsContext = createContext<{


### PR DESCRIPTION
## 背景

09-06 全仓架构审查（三把尺子）第一批落地：跨语言事实补闸 + 逐字复制收拢。全部是机械改动，无行为变化（唯一删掉的是前端零调用的 `relay_provision` 命令）。

## 唯一数据源

- **events.rs 闸补 `VENDOR_ACCOUNTS_CHANGED` 一行**：该事件 Rust emit / TS listen 各一份，但比对表漏了它——改任一边测试照绿，官网账号块静默不刷新。
- **新增 MODEL_VERIFICATION_ENABLED 前后端闸**：两侧各一份 `= true`，只翻一边时徽章照常渲染而数据恒空。v6.14.1 下线时就是两边各改一遍才没出事。
- **新增 vendor 注册表闸**：id + displayName 与 `lib/api/vendor.ts` 的 VENDOR_CATALOG 比对；Rust 内部 `from_id` 字面量改用 VENDOR_ID 常量、单 plan 名字改派生。
- **新增两个状态枚举线上名钉死测试**（`RelayRowStatus` / `VendorAccountStatus`）：前端裸字符串消费、无编译器把守，形状照 ImportErrorKind 那道既有闸。
- **imagegen MCP 开关默认值闸扩到 TS 侧**：`?? true` 与 `unwrap_or(true)` 分叉的症状是开关显示与后端行为相反。
- tray 的 TEMPLATE_TYPE 常量改引用 provider 那份；前端 `fmtBytes` 三份合一（KB 精度已分叉）；`formatCostPerMTok` 走 fmtUsd；`plazaVisible ?? true` 两处收成 `PLAZA_VISIBLE_DEFAULT`。

## 复制收拢

- `describe_send_error` / `login_url` 两处逐字复制各收成一份（前者归 `relay/backend.rs`——api/newapi 都已依赖的中立共享层，连同两条传输错误测试搬家；后者收进 login.rs，newapi re-export）。
- vendor 两份平凡 client 构造器改用 `relay::api::build_client`；active.rs 内联 `matches!` 改调 `target::supports_app_type`。

## 死代码与文档腐化

- **删 `relay_provision` 命令**：前端零调用方（「获取密钥」实走 `relay_refresh`），内部真链路 `refresh_relay_provision` 是其严格超集；有价值的过程文档（relay_id 并发正确性那段）移到存活函数上，源码闸同步改锚点。
- 修 imagegen.rs「MCP 固定 n=1」过期注释（已被批量张数推翻）、bucket.rs 自引用 `unwrap_or` 改明写 `0`、cli USAGE 加清单同步注释、CLAUDE.md 的 OFFICIAL_WEBSITE 闸状态陈旧句更新（闸早已存在）。

## 验证

六道闸本地全绿：cargo test / clippy --all-targets -D warnings / fmt --check + tsc --noEmit / prettier / vitest（190 文件 1302 通过）。九道新闸逐一确认通过。

后续第二批（平台名单唯源 + 恢复默认保留目录修根）另行 PR。
