### PR TITLE
fix(release): 修 Linux 依赖清单续行被打断的问题

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,8 @@ jobs:
         run: |
           set -euxo pipefail
           sudo apt-get update
-          # Core build tools and pkg-config
+          # Core build tools and pkg-config；musl-tools 供 loongport-cli 静态包
+          # （ring/rusqlite 的 C 编译要 musl-gcc）——注意别把注释插进续行中间
           sudo apt-get install -y --no-install-recommends \
             build-essential \
             pkg-config \
@@ -126,7 +127,6 @@ jobs:
             file \
             patchelf \
             libssl-dev \
-            # loongport-cli 静态包的 musl 工具链（ring/rusqlite 的 C 编译要 musl-gcc）
             musl-tools \
             rpm \
             elfutils \


### PR DESCRIPTION
上一提交把注释行插进 apt-get install 的反斜杠续行中间，musl-tools 被当独立命令执行（exit 127），v6.17.0 首次 release 跑挂在 Linux 腿。本修复：注释挪到续行块外。纯 workflow 配置变更。