### PR TITLE
refactor(imagegen): MCP 注册同步触发点收归数据层（删视图读路径触发）

### DIFF
--- a/src-tauri/src/commands/relay/imagegen.rs
+++ b/src-tauri/src/commands/relay/imagegen.rs
@@ -8,11 +8,10 @@ use crate::relay::imagegen;
 // 生图（MCP 注册 + App 内直接生图）
 // ============================================================================
 
-/// 重新对齐生图 MCP。进入生图页时调用，用来修复应用运行期间被外部改掉的投影。
-#[tauri::command]
-pub fn relay_sync_imagegen_mcp(state: State<'_, AppState>) -> Result<(), AppError> {
-    imagegen_mcp::sync_registration(&state)
-}
+// MCP 注册同步的触发点全部在数据层（2026-09-07 收口）：启动（lib.rs 无条件对齐
+// 一次）、provision 收尾（mark_pricing_after_success）、设置写入
+// （relay_set_imagegen_mcp_enabled）与删站点/账号。曾经还有「进入生图页时同步」
+// 的前端入口 —— 那是视图读路径驱动数据层行为，已删（命令与 App.tsx effect 一并）。
 
 /// 一张生成图片（App 内直接生图的结果条目）。
 #[derive(Serialize, Debug, Clone)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1057,8 +1057,9 @@ pub fn run() {
 
             // 生图 MCP 是「生图栏里是否有托管档位」的派生状态。启动时无条件对齐一次，
             // 覆盖升级后已有档位但从未再次 provision、以及应用升级后可执行路径变化的情况。
+            // 其余触发点：provision 收尾、生图开关写入、删站点/账号（都在数据层）。
             if let Err(e) = crate::relay::imagegen_mcp::sync_registration(&app_state) {
-                log::warn!("启动时同步生图 MCP 失败（进入生图页时会重试）: {e}");
+                log::warn!("启动时同步生图 MCP 失败（下次 provision 或重启会重试）: {e}");
             }
 
             // 2. OMO 配置导入（当数据库中无 OMO provider 时，从本地文件导入）
@@ -1676,7 +1677,6 @@ pub fn run() {
             commands::relay_list_relays,
             commands::relay_reorder,
             commands::relay_reset_tier_config,
-            commands::relay_sync_imagegen_mcp,
             commands::relay_imagegen_generate,
             commands::relay_imagegen_list_images,
             commands::relay_imagegen_reveal_image,

--- a/src-tauri/src/relay/imagegen_mcp.rs
+++ b/src-tauri/src/relay/imagegen_mcp.rs
@@ -412,6 +412,31 @@ mod tests {
         );
     }
 
+    /// ⭐ **注册同步的触发点全在数据层**（2026-09-07 收口，删掉了「进入生图页时
+    /// 同步」的前端入口——那是视图读路径驱动数据层行为）。
+    ///
+    /// 这道闸钉住**启动**那一处接线：其余触发点（provision 收尾、开关写入、删站点）
+    /// 各有行为测试或在源码闸里被顺带覆盖，启动这处在 lib.rs 的初始化闭包里，
+    /// 没有任何行为测试会碰它 —— 删掉它的症状是静默的：升级后不再对齐注册，
+    /// 用户的 CLI 里残留（或缺失）生图工具，直到下次 provision。
+    #[test]
+    fn startup_wires_the_registration_sync() {
+        let lib_rs = include_str!("../lib.rs");
+        assert!(
+            lib_rs.contains("imagegen_mcp::sync_registration(&app_state)"),
+            "lib.rs 的启动初始化不再调用 imagegen_mcp::sync_registration —— \
+             这是注册同步在数据层的启动触发点，删它要有替代方案（见触发点清单），\
+             别只是把断言改绿"
+        );
+        // 前端读路径不再有直接触发（那是这轮收口删掉的形状，别让它回来）。
+        let app_tsx = include_str!("../../../src/App.tsx");
+        assert!(
+            !app_tsx.contains("relay_sync_imagegen_mcp"),
+            "App.tsx 又出现了生图 MCP 同步的直接触发 —— 视图读路径不驱动数据层行为，\
+             触发点归数据层（启动/provision/设置写入/删除）"
+        );
+    }
+
     /// ⚠️ **这个 crate 的 logger 写 stdout，而 stdout 是 MCP 的协议通道。**
     ///
     /// 当前安全**只是因为 logger 在 [`crate::run`] 里才初始化**

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -290,14 +290,6 @@ function App() {
     [saveSettingsMutation, settingsData, visibleApps],
   );
 
-  useEffect(() => {
-    if (activeApp !== "codex-image") return;
-
-    void invoke("relay_sync_imagegen_mcp").catch((error) => {
-      console.error("[App] Failed to sync image generation MCP", error);
-    });
-  }, [activeApp]);
-
   // Fallback from sessions view when switching to an app without session support
   useEffect(() => {
     if (currentView === "mcp" && sharedFeatureApp === "pi") {

--- a/tests/integration/App.test.tsx
+++ b/tests/integration/App.test.tsx
@@ -246,45 +246,6 @@ describe("App integration with MSW", () => {
     expect(await screen.findAllByText("switch-codex-image")).toHaveLength(1);
   });
 
-  it("restores the image page and reconciles its MCP registration on startup", async () => {
-    let syncCalls = 0;
-    server.use(
-      http.post("http://tauri.local/relay_sync_imagegen_mcp", () => {
-        syncCalls += 1;
-        return HttpResponse.json(null);
-      }),
-    );
-    localStorage.setItem(LAST_APP_STORAGE_KEY, "codex-image");
-
-    renderApp();
-
-    await waitFor(() => {
-      expect(screen.getByTestId("app-switcher")).toHaveTextContent(
-        "codex-image",
-      );
-      expect(syncCalls).toBe(1);
-    });
-  });
-
-  it("reconciles the image MCP registration when switching to the image page", async () => {
-    let syncCalls = 0;
-    server.use(
-      http.post("http://tauri.local/relay_sync_imagegen_mcp", () => {
-        syncCalls += 1;
-        return HttpResponse.json(null);
-      }),
-    );
-
-    renderApp();
-    fireEvent.click(await screen.findByText("switch-codex-image"));
-
-    await waitFor(() => expect(syncCalls).toBe(1));
-    skillsPanelMocks.checkUpdates.mockReset();
-    skillsPanelMocks.openDiscovery.mockReset();
-    localStorage.removeItem(LAST_VIEW_STORAGE_KEY);
-    localStorage.removeItem(LAST_APP_STORAGE_KEY);
-  });
-
   it("covers basic provider flows via real hooks", async () => {
     renderApp();
 

--- a/tests/lib/providerSwitchedEventContract.test.ts
+++ b/tests/lib/providerSwitchedEventContract.test.ts
@@ -56,10 +56,11 @@ describe("provider-switched 的跨页面契约", () => {
         "中转站区里那个档位会一直显示「使用中」、删除按钮一直是灰的",
     ).toMatch(/emit_provider_switched\(&emit_handle/);
 
-    // `relay_switch_tier`（中转站区切档位）—— 镜像方向。
-    const relayRs = read("src-tauri/src/commands/relay.rs");
+    // `relay_switch_tier`（中转站区切档位）—— 镜像方向。commands::relay 已按领域
+    // 拆成目录（2026-09-07），切换路径在 switch.rs。
+    const switchRs = read("src-tauri/src/commands/relay/switch.rs");
     expect(
-      relayRs,
+      switchRs,
       "relay_switch_tier 没有广播 —— 切完档位之后 provider 列表会陈旧",
     ).toMatch(/emit_provider_switched\(/);
   });


### PR DESCRIPTION
## 背景

09-06 架构审查遗留项、也是「视图不驱动底层数据刷新」原则的最后存量：`App.tsx` 在进入生图 tab 时直接 `invoke("relay_sync_imagegen_mcp")` —— 全前端唯一的视图读路径挂后台动作。

## 事实核查

数据层触发点**已经在位**，前端入口是重复且归属错误的：

| 触发点 | 位置 |
|---|---|
| 启动 | `lib.rs` 初始化闭包无条件对齐一次（注释写明覆盖升级/路径变化场景） |
| provision 收尾 | `mark_pricing_after_success` → `sync_registration` |
| 设置写入 | `relay_set_imagegen_mcp_enabled` 切开关立刻对齐 |
| 删站点/账号 | `remove_site_impl`（曾有 review 记录：这条路必须自己调） |

## 改动

- 删 `App.tsx` 的 effect；删 `relay_sync_imagegen_mcp` 命令包装与注册（前端零调用后即死入口）。
- 删两条集成测试（它们测的正是被删的视图驱动行为）。
- 修正 lib.rs 启动日志「进入生图页时会重试」的过期指引 → 「下次 provision 或重启会重试」。
- **新增接线闸**（`startup_wires_the_registration_sync`）：钉住启动调用不被顺手删掉（症状静默：升级后 CLI 里残留/缺失生图工具）+ `App.tsx` 不得再出现直接触发。

## 行为影响

会话内外部改动 codex 配置文件后、不发任何业务事件的场景，MCP 记录不再因「切到生图 tab」而被修复 —— 由下次 provision/重启覆盖。这正是触发归属该有的语义（外部改文件不是我们的事件）。

## 验证

六道闸全绿；新接线闸通过；App.test.tsx 7 项通过。
