### PR TITLE
chore(release): v6.17.1 —— 修复 v6.17.0 打包事故

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-switch",
-  "version": "6.17.0",
+  "version": "6.17.1",
   "description": "All-in-One Assistant for Claude Code, Codex & Gemini CLI",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "cc-switch"
-version = "6.17.0"
+version = "6.17.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3120,7 +3120,7 @@ checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "loongport-cli"
-version = "6.17.0"
+version = "6.17.1"
 dependencies = [
  "cc-switch",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,7 +9,7 @@ members = ["cli"]
 [workspace.package]
 # 版本唯源：两个 crate 都从这里继承（`version.workspace = true`）。
 # 发版 bump 时改这一处 + package.json + tauri.conf.json。
-version = "6.17.0"
+version = "6.17.1"
 
 [package]
 # ⚠️ crate name 保持上游的 `cc-switch`，别改 —— 118 处引用、改了收益为零

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LoongPort",
   "mainBinaryName": "LoongPort",
-  "version": "6.17.0",
+  "version": "6.17.1",
   "identifier": "dev.loongport.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
版本 bump 三处（workspace.package / package.json / tauri.conf.json）+ Cargo.lock。

v6.17.1 内容：**修复 v6.17.0 打包事故**（PR #318）——macOS/Windows 包整包打成了 loongport-cli，用户更新后双击即退；修根为 loongport-cli 拆独立成员 crate + 主 crate 回归单 bin + 一致性闸。

> ⚠️ **tag 待维护者确认后打**（惯例：发布说明写 annotated tag 正文，`--cleanup=whitespace` 不能省）。建议正文：
>
> LoongPort v6.17.1
>
> 紧急修复：v6.17.0 的 macOS 与 Windows 安装包在打包时误装了命令行配置工具而非主程序，升级后应用无法启动。本版重新打包，并从结构上杜绝该问题再次发生。Linux 包不受影响。
