### PR TITLE
fix(relay): prune 收口单一删除通道（delete_stale）+ directoryState 镜像闸

### DIFF
--- a/src-tauri/src/commands/relay/directory.rs
+++ b/src-tauri/src/commands/relay/directory.rs
@@ -233,4 +233,25 @@ mod tests {
             "别把 snake_case 键发给前端（TS 那边按 camelCase 读）"
         );
     }
+
+    /// `directoryState.ts` 的 `defaultDirectoryKind` 是「app → 榜单分组」的 TS 镜像，
+    /// 分组键是后端 `LeaderboardKind` 的 serde 线上名。跨语言编译器管不到 `.ts`：
+    /// 后端改分键（或前端改默认分组）时两边各自漂移，症状是 tab 切过去查了一个
+    /// 不存在的榜单（空列表，不报错）。这道闸把映射钉住，形状照 events.rs 的跨语言闸。
+    #[test]
+    fn frontend_default_directory_kind_matches_the_backend_leaderboard_kinds() {
+        let ts = include_str!("../../../../src/components/relay/directory/directoryState.ts");
+        for line in [
+            r#"if (appId === "claude" || appId === "claude-desktop") return "claude";"#,
+            r#"if (appId === "codex" || appId === "codex-image") return "openai";"#,
+            r#"if (appId === "gemini") return "gemini";"#,
+            r#"return "overall";"#,
+        ] {
+            assert!(
+                ts.contains(line),
+                "directoryState.ts 的默认分组映射变了，与后端 LeaderboardKind 的线上名 \
+                 （overall/claude/openai/gemini）对不上一行：{line}"
+            );
+        }
+    }
 }

--- a/src-tauri/src/commands/relay/provision.rs
+++ b/src-tauri/src/commands/relay/provision.rs
@@ -980,13 +980,13 @@ pub(crate) fn apps_using_this_accounts_tiers(
 /// 留着当「当前项」只会让 CLI 拿一把失效密钥去发请求，报一个看不懂的 401。
 /// 用户重新选一个可用的就好。
 ///
-/// 所以当前项那条**直连 `state.db.delete_provider`** 绕过那层保护。
+/// 所以这里走 [`ProviderService::delete_stale`] —— 与手工删除**同一条管线**
+/// （含 additive-mode app 的 live config 清理），只是不做「当前项不许删」的保护。
+/// （历史上这里曾直连 `state.db.delete_provider` 绕过整个服务层，那条捷径会漏掉
+/// additive 的 live 清理 —— 2026-09-07 收口成策略变体，不再有第二条通道。）
 /// 悬空的 `is_current` 指针不用手工清：`settings::get_effective_current_provider`
 /// 会验证 id 在库里是否存在，不存在就自动清掉本地 settings 并回落
 /// （它的文档明说了这一条，正是为云同步导入后失效的场景写的）。
-///
-/// 非当前项走 `ProviderService::delete` —— 它顺带处理 additive-mode app 的
-/// live config 清理，那套逻辑不该在这里重写一遍。
 ///
 /// `AppType::all()` 是穷尽的（上游维护），加新 CLI 时这里自动覆盖。
 ///
@@ -1023,13 +1023,10 @@ pub(crate) fn prune_stale_tiers(
                 continue;
             }
 
-            let is_current = provider.id == current;
-            let outcome = if is_current {
-                // 绕过 ProviderService::delete 的「不许删当前项」保护（见上方说明）。
-                state.db.delete_provider(app_type.as_str(), &provider.id)
-            } else {
-                ProviderService::delete(state, app_type.clone(), &provider.id)
-            };
+            let was_current = provider.id == current;
+            // 单一删除通道：与用户手工删除走**同一条**服务层管线（含 additive-mode
+            // app 的 live config 清理），唯一差异是策略——见 [`ProviderService::delete_stale`]。
+            let outcome = ProviderService::delete_stale(state, app_type.clone(), &provider.id);
 
             match outcome {
                 Ok(()) => {
@@ -1038,7 +1035,7 @@ pub(crate) fn prune_stale_tiers(
                         provider.name,
                         app_type.as_str(),
                         provider.id,
-                        if is_current {
+                        if was_current {
                             " —— 它曾是当前项，请重新选一个档位"
                         } else {
                             ""
@@ -1903,6 +1900,37 @@ mod tests {
     /// **这一次** provision（= 一个账号）生成的 id ⇒ A 刷新一次就把 B 的全部档位
     /// 当成「不再存在」删光。同一个缺陷在 `remove_site_impl`（删一个账号）下更彻底：
     /// 它传空 `keep`，等于清掉该站所有账号的档位。
+    /// prune 对「当前项」档位也必须删得掉，且两条删除通道的行为差必须保持：
+    /// 手工删除通道的保护**仍然生效**（拒绝删当前项），prune 通道
+    /// （[`ProviderService::delete_stale`]）放行。曾经这里是直连
+    /// `db.delete_provider` 的第二通道，会漏 additive-mode app 的 live 清理
+    /// （2026-09-07 收口；这条测试钉住单一通道与保护语义）。
+    #[test]
+    fn pruning_removes_a_stale_tier_even_when_it_is_the_current_one() {
+        let site = "https://prune.example";
+        let db = std::sync::Arc::new(crate::database::Database::memory().expect("init db"));
+        let stale = provision::provider_id_for(site, Some(7), 1);
+        db.save_provider("codex", &seeded_owned(&stale, "Prune·废", Some(site), 7))
+            .expect("seed");
+        db.set_current_provider("codex", &stale)
+            .expect("set current");
+        let state = AppState::new(db.clone());
+
+        // 手工删除通道：当前项必须仍被保护。
+        assert!(
+            ProviderService::delete(&state, AppType::Codex, &stale).is_err(),
+            "用户手工删除当前项的保护不能被 prune 的需求破坏"
+        );
+
+        let keep: std::collections::HashSet<(String, String)> = Default::default();
+        let removed = prune_stale_tiers(&state, site, Some(7), &keep).expect("prune");
+        assert_eq!(removed, 1, "当前项档位该被 prune 删掉");
+        assert!(
+            !db.get_provider_ids("codex").expect("list").contains(&stale),
+            "库里不该再有那条"
+        );
+    }
+
     #[test]
     fn pruning_one_account_leaves_another_accounts_tiers_on_the_same_site() {
         let site = "https://bestapi.store";

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -5318,6 +5318,24 @@ impl ProviderService {
     /// 同时检查本地 settings 和数据库的当前供应商，防止删除任一端正在使用的供应商。
     /// 对于累加模式应用（OpenCode, OpenClaw），可以随时删除任意供应商，同时从 live 配置中移除。
     pub fn delete(state: &AppState, app_type: AppType, id: &str) -> Result<(), AppError> {
+        Self::delete_with_policy(state, app_type, id, false)
+    }
+
+    /// [`delete`] 的「允许删当前项」策略变体，给**档位清理**用（prune_stale_tiers）：
+    /// 走到那一步说明这条档位在服务端已经不存在了，sk 是死的 —— 留着当「当前项」
+    /// 只会让 CLI 拿失效密钥发请求。与 [`delete`] 共享同一条管线（含 additive-mode
+    /// app 的 live config 清理），**唯一**差异是不做「当前项不许删」的保护 ——
+    /// 别处想要这个语义先想清楚：那个保护是防用户误删正在用的配置的。
+    pub fn delete_stale(state: &AppState, app_type: AppType, id: &str) -> Result<(), AppError> {
+        Self::delete_with_policy(state, app_type, id, true)
+    }
+
+    fn delete_with_policy(
+        state: &AppState,
+        app_type: AppType,
+        id: &str,
+        allow_current: bool,
+    ) -> Result<(), AppError> {
         if app_type == AppType::Pi {
             return pi::delete(state, id);
         }
@@ -5374,7 +5392,9 @@ impl ProviderService {
         let local_current = crate::settings::get_current_provider(&app_type);
         let db_current = state.db.get_current_provider(app_type.as_str())?;
 
-        if local_current.as_deref() == Some(id) || db_current.as_deref() == Some(id) {
+        if !allow_current
+            && (local_current.as_deref() == Some(id) || db_current.as_deref() == Some(id))
+        {
             return Err(AppError::Message(
                 "无法删除当前正在使用的供应商".to_string(),
             ));


### PR DESCRIPTION
## 背景

09-06 审查低优先级存档项的两条，一次清掉。

## prune 双删除通道不对称（修根）

`prune_stale_tiers` 对当前项档位曾直连 `db.delete_provider` 绕过服务层——与非当前项的 `ProviderService::delete` 是两条通道，后者会做 additive-mode app 的 live config 清理，前者漏掉（靠「托管档位不落 additive app」的隐式前提成立）。

修法：需要的只是「允许删当前项」这个**策略**差异，不是绕过服务层。服务层抽 `delete_with_policy(allow_current)`，新增 `ProviderService::delete_stale`（同管线、只豁免当前项保护）；prune 全部走它，`is_current` 只剩日志用途。

回归测试钉住行为差：手工删除当前项**必须仍被拒绝**（保护不被 prune 的需求破坏），prune 通道放行。

## directoryState.ts 镜像闸

`defaultDirectoryKind` 的 app→榜单分组映射是后端 `LeaderboardKind` serde 线上名的 TS 镜像，分叉症状是 tab 查一个不存在的榜单（空列表、不报错）。补 include_str 闸钉住映射与 overall 缺省回落。

## 验证

后端三件套全绿（纯 Rust 改动，按仓规免跑前端闸）；新增两测试通过。
