### PR TITLE
docs+refactor: 术语表唯源 glossary.md + 四组按表改名（四词一义收口）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,13 +150,19 @@
 ## 三、LoongPort 自己的代码在哪
 
 ```
-src-tauri/src/relay/     ← 中转站链路（api / creds / login / provision / chatgpt_app）
-src-tauri/src/commands/relay.rs
-src/components/relay/    ← 前端面板
-src/lib/api/relay.ts     ← 前端类型与 invoke 封装
+src-tauri/src/relay/          ← 中转站链路（sub2api / creds / login / provision / chatgpt_app）
+src-tauri/src/commands/relay/ ← 中转站命令层（按领域拆分，总览见该目录 mod.rs）
+src/components/relay/         ← 前端面板
+src/lib/api/relay.ts          ← 前端类型与 invoke 封装
 ```
 
 碰这几处之外的文件时，先问一句「这是在改上游吗、改动面能不能更小」。
+
+### 术语唯源在 docs/glossary.md
+
+中转站域的概念用词（站点 / 账号行 / 分组 / 档位 / 套餐 / provider 记录 / 平台 / app…）
+**定义与命名规矩唯一源在 [`docs/glossary.md`](docs/glossary.md)**，新代码命名前先查它；
+wire/DB 契约名在它的冻结名单里（读宽写窄，别改）。这里只指路，不复制内容。
 
 ### 这是 fork，不是「把 cc-switch 当依赖引入」
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,65 @@
+# LoongPort 术语表（唯源）
+
+本仓的中转站域概念多、来源杂（服务端协议、上游 cc-switch、本地投影），同一事物曾用
+tier / group / plan / provider 四个词交替指称。本表是这些术语的**唯一定义处**。
+
+使用规则三条：
+
+1. **新代码命名前先查本表**——概念用词跟着表走，别再造同义词。
+2. **冻结名单是 wire/DB 契约名**（读宽写窄，认全历史值、只写当前值），别改。
+3. **新概念先入表**（一行定义 + 代码落点）再写代码。
+
+## 概念层级（一句话版）
+
+```
+中转站（relay site）── 一个域名
+  └─ 账号行（relay account row）── 站点 × 一个登录账号
+       └─ 分组（group，服务端事实）＝ 档位（tier，本地投影）
+                                          └─ 存储为一条 provider 记录
+```
+
+## 核心术语
+
+| 术语                     | 定义                                                                            | 代码落点                                                                                          | UI 用词     | 备注                                                       |
+| ------------------------ | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ----------- | ---------------------------------------------------------- |
+| 中转站 relay site        | 一个域名背后聚合多家 CLI 模型转发的服务                                         | `site_origin`（归一化 origin；apex/取数地址的区分见 `relay/identity.rs`）；表 `loongport_relay`   | 中转站      | 「relay」取站点义时只用 site_origin 表述，别再造站名       |
+| 账号行 relay account row | 中转站 × 一个登录账号（含登录态与凭据）；多账号同站并列展示的单位               | `creds::RelayAccount`（2026-09-07 前叫 `Relay`，一词三义之一，已改名）；参数名约定 `site_account` | 行          |                                                            |
+| 分组 group               | **服务端事实**：站点把一个 sk 按一档价卖给账号                                  | wire `group_name` / `group_id`；`sub2api::Group` / `newapi::Group`                                | 分组        | 服务端字典；倍率、定价挂在它身上                           |
+| 档位 tier                | 分组的**本地投影**：一条托管 provider 记录，可切换、可编辑                      | `TierInfo`（wire）、远端覆盖键 `tier_configs`、`relay_reset_tier_config`                          | 档位        | relay 域一律用 tier；一个分组可投影出多平台档位            |
+| 套餐 plan                | **vendor 域**与档位对应的概念：同一官网账号的不同接入变体（Zen / Go）           | `VendorPlanInfo`、`plan_by_segment`、`vendor_reset_plan_config`                                   | 套餐        | ⚠️ vendor 域代码**禁用 tier**（曾混用，2026-09-07 修正）   |
+| provider 记录            | 存储层统一载体（cc-switch 上游遗留）：两域的档位/套餐都存成它                   | `Provider`、`providers` 表、`providerId`                                                          | —（不外露） | 底层词；业务语义按所属域读（relay 的档位 / vendor 的套餐） |
+| 官方 API vendor          | 官网直连账号域，与中转站平级并列                                                | `vendor/`、`Vendor` 枚举                                                                          | 官方 API    |                                                            |
+| 平台 platform            | **sub2api 服务端**对 CLI 家族的称呼（openai / anthropic / gemini / grok）       | `platform_map::Platform`                                                                          | —           | 平台（服务端词）→ app（本地词）映射唯一源在 platform_map   |
+| App                      | 本 app 管理的 CLI 应用（codex / claude / gemini / grokbuild / codex-image / …） | `AppType`（Rust）、`AppId`（TS）                                                                  | 页签名      | 「平台」是服务端视角、「app」是本地视角，别混用            |
+| 广场 / 榜单 directory    | 中转站发现页与榜单                                                              | `relay_list_directory`、`LeaderboardKind`                                                         | 中转站广场  | VeriDrop 是**数据源**名（外部），不是功能名                |
+| 实测 / 众测 crowd        | 用户共享的匿名实测指标                                                          | `crowd/`、metrics Worker                                                                          | 实测        |                                                            |
+| 验真 verification        | 模型真伪探查（手动主动探针 + 被动异常上报）                                     | `relay/model_verification/`                                                                       | 验真        | 与熔断区分：验真管「真不真」，熔断管「还能不能用」         |
+| 熔断 breaker             | 账号 / 站点级故障隔离与恢复                                                     | `CircuitBreaker`                                                                                  | —           |                                                            |
+| 省心模式 easy mode       | 自动选路模式（与自主模式相对）                                                  | `auto_mode`                                                                                       | 省心        |                                                            |
+| 生图栏 codex-image       | 纯生图档位所在的独立页签                                                        | `AppType::CodexImage`                                                                             | 生图        | 生图模型家族唯一源 `IMAGE_MODEL_FAMILIES`                  |
+| 登录态 session           | 浏览器拿到的会话凭据及其寿命                                                    | refresh 链、`token_expires_at`                                                                    | 登录态      | 与凭据（credentials / sk）区分：登录态换 token，凭据是 key |
+
+## 冻结名单（wire / DB 契约，读宽写窄，别改）
+
+- `providerId`、`group_name` / `group_id`：wire + DB 双契约。
+- `user_edited`：DB 列，DTO 字段同名跟进。
+- 事件名（`events.rs` 主表 + 跨语言闸）与既有命令名（注册闸守着）。
+- DB 表名 `loongport_relay`（行类型已改名 `RelayAccount`，表名与历史数据不动）。
+
+改这些 = 迁移 / 跨端同步，不是重构；确有必要时按「读宽写窄」走（认全历史值、
+写入只产当前值，参考 `codex_history_migration.rs` 的 legacy 数组先例）。
+
+## 命名规矩（新代码硬规则）
+
+1. 禁 `op` 这类未定义黑话参数名——账号行参数叫 `site_account`。
+2. 禁 `do_` 前缀——命令实现直接用动词短语（如 `login_via_browser`）。
+3. relay 域档位用 tier、vendor 域用 plan、存储层用 provider；跨域引用时带域定语
+   （「vendor 的套餐」不说「vendor 的档位」）。
+4. UI 文案用「UI 用词」列的中文；代码标识符用英文术语列，不自造缩写。
+
+## 演进记录
+
+- 2026-09-07：建表（09-06 全仓架构审查「四词一义」的收口）。随本表落地的改名：
+  `creds::Relay` → `RelayAccount`、`op` 参数 → `site_account`、`do_login` →
+  `login_via_browser`（relay 与 vendor 两处）、`vendor_reset_tier_config` →
+  `vendor_reset_plan_config`。均为编译器可验证的纯内部名，wire/DB 契约未动。

--- a/src-tauri/src/commands/reconcile.rs
+++ b/src-tauri/src/commands/reconcile.rs
@@ -21,7 +21,7 @@ use crate::AppState;
 /// CLI 下，漏扫一个 app 就少算一块成本，对账比值会失真。归属判据用
 /// [`belongs_to_relay`]（严格版）：成本是要记到这一行头上的事实，未登录的行
 /// 不认别人账号的档位，否则 B 的消费会被算进 A 的对账。
-fn relay_provider_keys(state: &AppState, relay: &creds::Relay) -> Vec<(String, String)> {
+fn relay_provider_keys(state: &AppState, relay: &creds::RelayAccount) -> Vec<(String, String)> {
     let mut keys = Vec::new();
     for app_type in AppType::all() {
         let Ok(providers) = ProviderService::list(state, app_type.clone()) else {
@@ -71,8 +71,8 @@ fn reconcile(state: &AppState, relay_id: i64) -> Result<ReconciliationReport, Ap
 mod tests {
     use super::*;
 
-    fn relay_row(site: &str, account_id: Option<i64>) -> creds::Relay {
-        creds::Relay {
+    fn relay_row(site: &str, account_id: Option<i64>) -> creds::RelayAccount {
+        creds::RelayAccount {
             id: 1,
             site_origin: site.to_string(),
             site_name: "test".to_string(),

--- a/src-tauri/src/commands/relay/balance.rs
+++ b/src-tauri/src/commands/relay/balance.rs
@@ -15,7 +15,7 @@ use crate::relay::provision;
 /// 拿到结果的，同一行的每把 sk 问出的钱包余额是同一个账户的同一个数。
 pub(crate) fn relay_balance_inputs(
     state: &AppState,
-    relay: &creds::Relay,
+    relay: &creds::RelayAccount,
 ) -> (String, Vec<String>) {
     let mut base_url = None;
     let mut keys: Vec<String> = Vec::new();

--- a/src-tauri/src/commands/relay/login.rs
+++ b/src-tauri/src/commands/relay/login.rs
@@ -1108,7 +1108,7 @@ pub async fn relay_login(
     app: String,
 ) -> Result<Option<RefreshResult>, String> {
     let app_type = AppType::from_str(&app).map_err(|error| error.to_string())?;
-    let login = do_login(&app_handle, relay_id)
+    let login = login_via_browser(&app_handle, relay_id)
         .await
         .map_err(|error| error.to_string())?;
     if !login.logged_in {
@@ -1119,13 +1119,20 @@ pub async fn relay_login(
     ))
 }
 
-async fn do_login(app_handle: &tauri::AppHandle, target_id: i64) -> Result<LoginResult, AppError> {
+async fn login_via_browser(
+    app_handle: &tauri::AppHandle,
+    target_id: i64,
+) -> Result<LoginResult, AppError> {
     // 记下行 id —— 凭据要写回这一行，而 `save_credentials` 可能因为发现重复账号
     // 而把它合并到别的行去。
     // 顺带取出登录标识：重登时预填进登录框，用户只需补密码与人机验证。
-    let op = load_validated_relay(app_handle, target_id).await?;
-    let (relay_id, site_origin, login_identifier, backend_kind) =
-        (op.id, op.site_origin, op.login_identifier, op.backend_kind);
+    let site_account = load_validated_relay(app_handle, target_id).await?;
+    let (relay_id, site_origin, login_identifier, backend_kind) = (
+        site_account.id,
+        site_account.site_origin,
+        site_account.login_identifier,
+        site_account.backend_kind,
+    );
 
     // 已经有一个登录窗时：**销毁它再开新的**，而不是聚焦了就早退。
     //
@@ -1134,7 +1141,7 @@ async fn do_login(app_handle: &tauri::AppHandle, target_id: i64) -> Result<Login
     // 都没发生，且因为 label 被占，再点多少次都一样，只能重启 app。
     //
     // 直接销毁重开则总能给用户一个可见的窗口。代价是「他正在填的表单没了」，但能走到这里
-    // 说明上一轮的 `do_login` 已经返回（否则那边还持有窗口），也就是那个窗口已经没人在等它
+    // 说明上一轮的 `login_via_browser` 已经返回（否则那边还持有窗口），也就是那个窗口已经没人在等它
     // 的凭据了 —— 留着它反而是个陷阱。
     destroy_stale_login_window(app_handle).await;
 
@@ -1655,14 +1662,14 @@ fn persist_new_relay_newapi_session(
 pub(crate) async fn usable_relay<R: tauri::Runtime>(
     app_handle: &tauri::AppHandle<R>,
     relay_id: i64,
-) -> Result<creds::Relay, AppError> {
-    let op = load_validated_relay(app_handle, relay_id).await?;
+) -> Result<creds::RelayAccount, AppError> {
+    let site_account = load_validated_relay(app_handle, relay_id).await?;
 
-    if op.token_looks_valid(chrono::Utc::now().timestamp()) {
+    if site_account.token_looks_valid(chrono::Utc::now().timestamp()) {
         // ⭐ **token 够用，但账号身份可能缺** —— 补一次再返回。
         //
         // 「有 `auth_token` 却没 `account_id`」是个实测到的死局：
-        // [`creds::Relay::token_looks_valid`] 对 `token_expires_at = NULL` 返回
+        // [`creds::RelayAccount::token_looks_valid`] 对 `token_expires_at = NULL` 返回
         // `true`（有意的乐观降级）⇒ 这里直接早退 ⇒ 永远走不到下面那条**续期后打
         // profile** 的路径，而那原本是唯一拿得到 `account.id` 的地方。
         // 于是用户点任何刷新（provision / 余额 / 充值都经过本函数）都补不上。
@@ -1672,13 +1679,13 @@ pub(crate) async fn usable_relay<R: tauri::Runtime>(
         //
         // 放在这里而不是各调用点：本函数是 provision / balance / purchase /
         // check_session 的**必经点**，补一处就全覆盖。
-        if op.account_id.is_none() {
-            return Ok(backfill_account_identity(app_handle, op).await);
+        if site_account.account_id.is_none() {
+            return Ok(backfill_account_identity(app_handle, site_account).await);
         }
-        return Ok(op);
+        return Ok(site_account);
     }
 
-    let (renewed, refreshed) = refresh_relay_session(app_handle, &op).await?;
+    let (renewed, refreshed) = refresh_relay_session(app_handle, &site_account).await?;
 
     // 顺手刷一次账号身份：用户可能在中转站那边改了昵称或邮箱，而续期响应里没有账号信息
     // （`/auth/refresh` 只回 token），所以只有在这里额外打一次 profile 才发现得了。
@@ -1700,22 +1707,24 @@ pub(crate) async fn usable_relay<R: tauri::Runtime>(
 /// 有没有账号信息（NewAPI 回、sub2api 不回）来决定要不要补打一次 profile。
 async fn refresh_relay_session<R: tauri::Runtime>(
     app_handle: &tauri::AppHandle<R>,
-    op: &creds::Relay,
-) -> Result<(creds::Relay, backend::RefreshedSession), AppError> {
+    site_account: &creds::RelayAccount,
+) -> Result<(creds::RelayAccount, backend::RefreshedSession), AppError> {
     let state = app_handle.state::<AppState>();
     // ⭐ 充值窗口持有这个 NewAPI 账号的 refresh 轮换独占权时，后台续期不得抢跑：
     // NewAPI 的 refresh cookie 一次性轮换，这里并发续期会把充值窗口里那颗 cookie
     // 立刻作废（用户充值到一半被踢回登录页）。闸放在 `token_looks_valid` 早退**之后**：
     // token 仍然有效时根本不走续期，不受影响；sub2api 的续期也不受影响。
-    if op.backend_kind == creds::BackendKind::NewApi && state.purchase_sessions.is_active(op.id) {
+    if site_account.backend_kind == creds::BackendKind::NewApi
+        && state.purchase_sessions.is_active(site_account.id)
+    {
         return Err(AppError::Config(
             "充值窗口正在使用这个账号的登录态，请关闭充值窗口后重试".into(),
         ));
     }
-    let refreshed = backend::RuntimeBackend::for_relay(op)
-        .refresh_session(op.refresh_token.as_deref())
+    let refreshed = backend::RuntimeBackend::for_relay(site_account)
+        .refresh_session(site_account.refresh_token.as_deref())
         .await?;
-    let renewed = persist_refreshed_session(&state, op, &refreshed)?;
+    let renewed = persist_refreshed_session(&state, site_account, &refreshed)?;
     Ok((renewed, refreshed))
 }
 
@@ -1725,7 +1734,7 @@ async fn refresh_relay_session<R: tauri::Runtime>(
 /// ## 为什么必须有它（2026-08-17 bestapi.store 线上事故）
 ///
 /// `token_expires_at = NULL` 的行（登录快照没带回过期时间的站点）走的是
-/// [`creds::Relay::token_looks_valid`] 的乐观降级：永远「看起来有效」，于是
+/// [`creds::RelayAccount::token_looks_valid`] 的乐观降级：永远「看起来有效」，于是
 /// [`usable_relay`] 的主动续期**永不触发**。access token 在服务端到 24h 过期后，
 /// 启动探活撞上 401「登录已过期」直接清会话 —— refresh token 一次没用过就被连坐，
 /// 用户被迫重登，体感就是「登录态撑不过一两天」。
@@ -1753,21 +1762,21 @@ pub(crate) async fn relay_read_with_refresh_retry<R, F, Fut, T>(
 where
     R: tauri::Runtime,
     // Fn 而不是 FnOnce：原请求与续期后的重试各调一次。
-    F: Fn(creds::Relay) -> Fut,
+    F: Fn(creds::RelayAccount) -> Fut,
     Fut: std::future::Future<Output = Result<T, AppError>>,
 {
-    let op = usable_relay(app_handle, relay_id).await?;
-    match run(op.clone()).await {
+    let site_account = usable_relay(app_handle, relay_id).await?;
+    match run(site_account.clone()).await {
         Ok(value) => Ok(value),
         Err(original) => {
-            let has_refresh_credential = op
+            let has_refresh_credential = site_account
                 .refresh_token
                 .as_deref()
                 .is_some_and(|token| !token.trim().is_empty());
             if !has_refresh_credential || !backend::is_token_expiry_failure(&original) {
                 return Err(original);
             }
-            match refresh_relay_session(app_handle, &op).await {
+            match refresh_relay_session(app_handle, &site_account).await {
                 Ok((renewed, _)) => run(renewed).await,
                 Err(refresh_error) => {
                     log::warn!(
@@ -1783,15 +1792,15 @@ where
 async fn load_validated_relay<R: tauri::Runtime>(
     app_handle: &tauri::AppHandle<R>,
     relay_id: i64,
-) -> Result<creds::Relay, AppError> {
-    let op = {
+) -> Result<creds::RelayAccount, AppError> {
+    let site_account = {
         let state = app_handle.state::<AppState>();
         with_conn(&state, |conn| creds::get(conn, relay_id))?
             .ok_or_else(|| AppError::Config(format!("找不到 id 为 {relay_id} 的中转站")))?
     };
 
-    match discovery::probe_site(&op.site_origin).await {
-        Ok(detected) if detected.backend_kind == op.backend_kind => Ok(op),
+    match discovery::probe_site(&site_account.site_origin).await {
+        Ok(detected) if detected.backend_kind == site_account.backend_kind => Ok(site_account),
         Ok(_) => {
             let state = app_handle.state::<AppState>();
             with_conn(&state, |conn| creds::clear_credentials(conn, relay_id))?;
@@ -1807,11 +1816,11 @@ async fn load_validated_relay<R: tauri::Runtime>(
             discovery::DiscoveryErrorKind::UnsupportedSite => {
                 log::warn!(
                     "站点探针暂时无法识别 {}，沿用已保存的 {} 协议和凭据：{}",
-                    op.site_origin,
-                    op.backend_kind.as_str(),
+                    site_account.site_origin,
+                    site_account.backend_kind.as_str(),
                     error.message
                 );
-                Ok(op)
+                Ok(site_account)
             }
             discovery::DiscoveryErrorKind::ProtocolConflict => Err(AppError::Config(format!(
                 "站点协议识别结果冲突，未改动已有凭据：{}",
@@ -1821,7 +1830,7 @@ async fn load_validated_relay<R: tauri::Runtime>(
     }
 }
 
-/// 打一次 profile，把账号身份写回库并更新手上这份 `op`。
+/// 打一次 profile，把账号身份写回库并更新手上这份 `site_account`。
 ///
 /// 两个调用点、两种动机，但做的事完全一样，所以共用一个函数（各写一遍迟早分叉）：
 ///
@@ -1836,28 +1845,31 @@ async fn load_validated_relay<R: tauri::Runtime>(
 /// 判失败会让用户在「明明能用」的时候被挡住。
 pub(crate) async fn backfill_account_identity<R: tauri::Runtime>(
     app_handle: &tauri::AppHandle<R>,
-    mut op: creds::Relay,
-) -> creds::Relay {
-    let account = match backend::RuntimeBackend::for_relay(&op).account().await {
+    mut site_account: creds::RelayAccount,
+) -> creds::RelayAccount {
+    let account = match backend::RuntimeBackend::for_relay(&site_account)
+        .account()
+        .await
+    {
         Ok(a) => a,
         Err(e) => {
             log::warn!("读取账号信息失败（不影响使用）: {e}");
-            return op;
+            return site_account;
         }
     };
 
     let state = app_handle.state::<AppState>();
     if let Err(e) = with_conn(&state, |conn| {
-        creds::refresh_account_identity(conn, op.id, runtime_account_identity(&account))
+        creds::refresh_account_identity(conn, site_account.id, runtime_account_identity(&account))
     }) {
         log::warn!("刷新账号信息失败（不影响使用）: {e}");
-        return op;
+        return site_account;
     }
 
     // 写库成功才更新手上这份 —— 否则返回的结构与库里不一致，
     // 调用方据此判断 `account_id` 已补上，而下次读库又是空的。
-    apply_runtime_account_identity(&mut op, account);
-    op
+    apply_runtime_account_identity(&mut site_account, account);
+    site_account
 }
 
 fn runtime_account_identity(account: &backend::RuntimeAccount) -> creds::AccountIdentity<'_> {
@@ -1868,10 +1880,13 @@ fn runtime_account_identity(account: &backend::RuntimeAccount) -> creds::Account
     }
 }
 
-fn apply_runtime_account_identity(op: &mut creds::Relay, account: backend::RuntimeAccount) {
-    op.account_id = Some(account.id);
-    op.account_label = account.label;
-    op.login_identifier = account.login_identifier;
+fn apply_runtime_account_identity(
+    site_account: &mut creds::RelayAccount,
+    account: backend::RuntimeAccount,
+) {
+    site_account.account_id = Some(account.id);
+    site_account.account_label = account.label;
+    site_account.login_identifier = account.login_identifier;
 }
 
 pub(crate) fn should_clear_credentials_after_probe_error(error: &AppError) -> bool {
@@ -1880,9 +1895,9 @@ pub(crate) fn should_clear_credentials_after_probe_error(error: &AppError) -> bo
 
 pub(crate) fn persist_refreshed_session(
     state: &AppState,
-    current: &creds::Relay,
+    current: &creds::RelayAccount,
     refreshed: &backend::RefreshedSession,
-) -> Result<creds::Relay, AppError> {
+) -> Result<creds::RelayAccount, AppError> {
     persist_refreshed_session_with_identity_writer(
         state,
         current,
@@ -1897,10 +1912,10 @@ pub(crate) fn persist_refreshed_session(
 
 pub(crate) fn persist_refreshed_session_with_identity_writer(
     state: &AppState,
-    current: &creds::Relay,
+    current: &creds::RelayAccount,
     refreshed: &backend::RefreshedSession,
     write_identity: impl FnOnce(&AppState, i64, &backend::RuntimeAccount) -> Result<(), AppError>,
-) -> Result<creds::Relay, AppError> {
+) -> Result<creds::RelayAccount, AppError> {
     let refresh_token = refreshed
         .refresh_credential
         .clone()
@@ -1917,7 +1932,7 @@ pub(crate) fn persist_refreshed_session_with_identity_writer(
         )
     })?;
 
-    let mut renewed = creds::Relay {
+    let mut renewed = creds::RelayAccount {
         auth_token: refreshed.auth_token.clone(),
         refresh_token,
         token_expires_at: refreshed.token_expires_at,
@@ -2711,11 +2726,14 @@ mod tests {
         let (origin, server) = spawn_balance_server(router).await;
         let (app, relay_id) = saved_relay_app(&origin, discovery::BackendKind::Sub2Api);
 
-        let balance = relay_read_with_refresh_retry(app.handle(), relay_id, |op| async move {
-            backend::RuntimeBackend::for_relay(&op).balance().await
-        })
-        .await
-        .expect("服务端 401 过期必须被静默续期救回");
+        let balance =
+            relay_read_with_refresh_retry(app.handle(), relay_id, |site_account| async move {
+                backend::RuntimeBackend::for_relay(&site_account)
+                    .balance()
+                    .await
+            })
+            .await
+            .expect("服务端 401 过期必须被静默续期救回");
 
         assert_eq!(balance.balance, 12.5);
         let creds = relay_credentials(&app, relay_id);

--- a/src-tauri/src/commands/relay/provision.rs
+++ b/src-tauri/src/commands/relay/provision.rs
@@ -158,7 +158,7 @@ fn newapi_reconcile_stage(stage: newapi_provision::ReconcileStage) -> &'static s
 }
 
 pub(crate) async fn provision_backend(
-    op: &creds::Relay,
+    site_account: &creds::RelayAccount,
     browser_fallback: Option<sub2api::BrowserApiFallback>,
 ) -> Result<ManagedProvisionBatch, AppError> {
     // 一次 provision 解析一次选型表（内置 + 远端覆盖），两个 backend 共用 ——
@@ -166,22 +166,23 @@ pub(crate) async fn provision_backend(
     let tables = provision::ModelSelectionTables::resolve();
     // 站点声明探测与 backend 无关（约定路径是 LoongPort 的约定，newapi 站长同样能放）：
     // 404/失败/格式不认都是 None，绝不打断登录主流程。
-    let site_declaration = crate::relay::site_config::fetch_site_declaration(&op.site_origin).await;
+    let site_declaration =
+        crate::relay::site_config::fetch_site_declaration(&site_account.site_origin).await;
     if site_declaration.is_some() {
         log::info!(
             "{}",
             crate::diagnostics::DiagnosticEvent::new("relay.site_config", "declaration_found")
-                .field_display("site", crate::url_for_log(&op.site_origin))
+                .field_display("site", crate::url_for_log(&site_account.site_origin))
         );
     }
-    match op.backend_kind {
+    match site_account.backend_kind {
         discovery::BackendKind::Sub2Api => {
             let mut client = sub2api::Client::new(
-                &op.site_origin,
-                &op.auth_token,
-                op.account_id,
-                op.user_agent.as_deref(),
-                op.cf_clearance.as_deref(),
+                &site_account.site_origin,
+                &site_account.auth_token,
+                site_account.account_id,
+                site_account.user_agent.as_deref(),
+                site_account.cf_clearance.as_deref(),
             )?;
             // 登录后自动备 key 时登录窗还开着：站点被指纹级防护拦下（403 HTML）时，
             // 由登录窗代拉（见 `browser_api_fallback`）。测试等无 UI 上下文传 `None`。
@@ -202,8 +203,8 @@ pub(crate) async fn provision_backend(
                     let tier = targeted.tier;
                     ManagedProvisionCandidate {
                         provider_id: provision::provider_id_for(
-                            &op.site_origin,
-                            op.account_id,
+                            &site_account.site_origin,
+                            site_account.account_id,
                             tier.group_id,
                         ),
                         app_type: targeted.app_type,
@@ -215,12 +216,12 @@ pub(crate) async fn provision_backend(
                         models: tier.models,
                         roles: tier.roles,
                         allow_image_generation: Some(tier.allow_image_generation),
-                        api_base_url: op.api_base_url.clone(),
+                        api_base_url: site_account.api_base_url.clone(),
                     }
                 })
                 .collect();
             Ok(ManagedProvisionBatch {
-                account_id: op.account_id,
+                account_id: site_account.account_id,
                 site_declaration,
                 candidates,
                 observed_keep: std::collections::HashSet::new(),
@@ -234,12 +235,12 @@ pub(crate) async fn provision_backend(
         }
         discovery::BackendKind::NewApi => {
             let client = newapi::NewApiClient::with_optional_account_id(
-                &op.site_origin,
-                &op.auth_token,
-                op.account_id,
+                &site_account.site_origin,
+                &site_account.auth_token,
+                site_account.account_id,
             )?;
             let account = client.account().await?;
-            if op.account_id.is_some() && op.account_id != Some(account.id) {
+            if site_account.account_id.is_some() && site_account.account_id != Some(account.id) {
                 return Err(AppError::Config(
                     "NewAPI 登录态所属账号与本地中转站账号不一致，请重新登录".into(),
                 ));
@@ -282,7 +283,7 @@ pub(crate) async fn provision_backend(
                 if !reconciled.contains(identity) {
                     newapi_keep_insert(
                         &mut batch.observed_keep,
-                        &op.site_origin,
+                        &site_account.site_origin,
                         result.account_id,
                         identity,
                         None,
@@ -291,49 +292,50 @@ pub(crate) async fn provision_backend(
             }
 
             for group in result.groups {
-                let models = match sub2api::list_models(&op.site_origin, &group.api_key).await {
-                    Ok(models) => match normalize_newapi_model_catalog(models) {
-                        Some(models) => models,
-                        None => {
+                let models =
+                    match sub2api::list_models(&site_account.site_origin, &group.api_key).await {
+                        Ok(models) => match normalize_newapi_model_catalog(models) {
+                            Some(models) => models,
+                            None => {
+                                batch.failures.push(FailureInfo {
+                                    group_name: group.name,
+                                    reason: "model_catalog: /v1/models 未返回可用模型目录".into(),
+                                });
+                                // 目录拉不到 = 分类未知：保全四个槽位，别把旧档误删。
+                                newapi_keep_insert(
+                                    &mut batch.observed_keep,
+                                    &site_account.site_origin,
+                                    result.account_id,
+                                    &group.identity,
+                                    None,
+                                );
+                                continue;
+                            }
+                        },
+                        Err(error) => {
                             batch.failures.push(FailureInfo {
                                 group_name: group.name,
-                                reason: "model_catalog: /v1/models 未返回可用模型目录".into(),
+                                reason: format!("model_catalog: {error}"),
                             });
-                            // 目录拉不到 = 分类未知：保全四个槽位，别把旧档误删。
                             newapi_keep_insert(
                                 &mut batch.observed_keep,
-                                &op.site_origin,
+                                &site_account.site_origin,
                                 result.account_id,
                                 &group.identity,
                                 None,
                             );
                             continue;
                         }
-                    },
-                    Err(error) => {
-                        batch.failures.push(FailureInfo {
-                            group_name: group.name,
-                            reason: format!("model_catalog: {error}"),
-                        });
-                        newapi_keep_insert(
-                            &mut batch.observed_keep,
-                            &op.site_origin,
-                            result.account_id,
-                            &group.identity,
-                            None,
-                        );
-                        continue;
-                    }
-                };
+                    };
                 newapi_keep_insert(
                     &mut batch.observed_keep,
-                    &op.site_origin,
+                    &site_account.site_origin,
                     result.account_id,
                     &group.identity,
                     Some(&models),
                 );
                 batch.candidates.extend(newapi_candidates_for_group(
-                    &op.site_origin,
+                    &site_account.site_origin,
                     result.account_id,
                     &group,
                     &models,
@@ -387,19 +389,24 @@ pub(crate) async fn refresh_relay_provision(
     app_handle: &tauri::AppHandle,
     relay_id: i64,
 ) -> Result<ProvisionSummary, AppError> {
-    let op = usable_relay(app_handle, relay_id).await?;
-    let op = backfill_account_identity(app_handle, op).await;
-    provision_relay(app_handle, &op).await
+    let site_account = usable_relay(app_handle, relay_id).await?;
+    let site_account = backfill_account_identity(app_handle, site_account).await;
+    provision_relay(app_handle, &site_account).await
 }
 
 async fn provision_relay(
     app_handle: &tauri::AppHandle,
-    op: &creds::Relay,
+    site_account: &creds::RelayAccount,
 ) -> Result<ProvisionSummary, AppError> {
-    let batch = provision_backend(op, Some(browser_api_fallback(app_handle))).await?;
+    let batch = provision_backend(site_account, Some(browser_api_fallback(app_handle))).await?;
     let state = app_handle.state::<AppState>();
-    let result = persist_provision_batch(state.inner(), op, batch);
-    mark_pricing_after_success(state.inner(), op.id, chrono::Utc::now().timestamp(), result)
+    let result = persist_provision_batch(state.inner(), site_account, batch);
+    mark_pricing_after_success(
+        state.inner(),
+        site_account.id,
+        chrono::Utc::now().timestamp(),
+        result,
+    )
 }
 
 pub(crate) fn mark_pricing_after_success<T>(
@@ -417,7 +424,7 @@ pub(crate) fn mark_pricing_after_success<T>(
 
 pub(crate) fn persist_provision_batch(
     state: &AppState,
-    op: &creds::Relay,
+    site_account: &creds::RelayAccount,
     mut batch: ManagedProvisionBatch,
 ) -> Result<ProvisionSummary, AppError> {
     let mut tiers = Vec::new();
@@ -432,10 +439,12 @@ pub(crate) fn persist_provision_batch(
         // 先取出来：`candidate.group_name` 下面会被 move 进 failures，
         // 而倍率在那之后还要用。
         let rate_multiplier = candidate.rate_multiplier;
-        let display_name = provision::provider_display_name(&op.site_name, &candidate.group_name);
+        let display_name =
+            provision::provider_display_name(&site_account.site_name, &candidate.group_name);
         keep.insert((app_type.as_str().to_string(), provider_id.clone()));
 
-        let base_url = sub2api::base_url_for(app_type, &op.site_origin, &candidate.api_base_url);
+        let base_url =
+            sub2api::base_url_for(app_type, &site_account.site_origin, &candidate.api_base_url);
         // 下面这串分支是「带目录平台」的**生成器形状分派**（claude/gemini 走
         // roles+models、codex/grokbuild 走 models）——「哪些平台带目录」这个名单
         // 的事实唯源是 [`provision::model_catalog_apps`]，加平台时两边一起动
@@ -549,7 +558,11 @@ pub(crate) fn persist_provision_batch(
         let mut site_declared_origin: Option<String> = None;
         if is_first_import {
             if let Some(declared) = &batch.site_declaration {
-                if site_config::validate_same_origin(&declared.site_origin, &op.site_origin).is_ok()
+                if site_config::validate_same_origin(
+                    &declared.site_origin,
+                    &site_account.site_origin,
+                )
+                .is_ok()
                 {
                     if let Some(platform) = platform_map::platform_for_app(app_type) {
                         if let Some(segment) = declared.segment_for(platform) {
@@ -580,7 +593,7 @@ pub(crate) fn persist_provision_batch(
             id: provider_id.clone(),
             name: display_name.clone(),
             settings_config,
-            website_url: Some(op.site_origin.clone()),
+            website_url: Some(site_account.site_origin.clone()),
             // aggregator 而不是 official：official 那条分类会触发一批只对官方订阅成立的
             // 逻辑（stale auth 清理、统一会话桶注入）。
             category: Some("aggregator".to_string()),
@@ -699,9 +712,12 @@ pub(crate) fn persist_provision_batch(
 
     refresh_live_for_current_tiers(state, &refresh_live);
 
-    let removed = prune_stale_tiers(state, &op.site_origin, batch.account_id, &keep)?;
+    let removed = prune_stale_tiers(state, &site_account.site_origin, batch.account_id, &keep)?;
     if removed > 0 {
-        log::info!("清理了 {removed} 个不再存在的档位（{}）", op.site_origin);
+        log::info!(
+            "清理了 {removed} 个不再存在的档位（{}）",
+            site_account.site_origin
+        );
     }
 
     // 生图工具跟着「生图栏里有没有档位」对齐一次。见 `sync_imagegen_mcp` 的文档。
@@ -1449,12 +1465,12 @@ mod tests {
         let server = tokio::spawn(async move {
             axum::serve(listener, app).await.expect("serve test app");
         });
-        let op = creds::Relay {
+        let site_account = creds::RelayAccount {
             site_origin: origin,
             ..test_newapi_relay(7)
         };
 
-        let error = match provision_backend(&op, None).await {
+        let error = match provision_backend(&site_account, None).await {
             Ok(_) => panic!("persisted account mismatch must stop provisioning"),
             Err(error) => error,
         };
@@ -1507,10 +1523,10 @@ mod tests {
     }
 
     fn newapi_batch(
-        op: &creds::Relay,
+        site_account: &creds::RelayAccount,
         groups: &[crate::relay::newapi_provision::ReconciledGroup],
     ) -> ManagedProvisionBatch {
-        let account_id = op.account_id.expect("test relay has account id");
+        let account_id = site_account.account_id.expect("test relay has account id");
         // 与 provision_backend 同一条纪律：keep 槽位跟着分类走（混合目录 = 三个聊天栏）。
         let mut observed_keep = std::collections::HashSet::new();
         let candidates = groups
@@ -1519,13 +1535,13 @@ mod tests {
                 let models = newapi_models();
                 newapi_keep_insert(
                     &mut observed_keep,
-                    &op.site_origin,
+                    &site_account.site_origin,
                     account_id,
                     &group.identity,
                     Some(&models),
                 );
                 newapi_candidates_for_group(
-                    &op.site_origin,
+                    &site_account.site_origin,
                     account_id,
                     group,
                     &models,
@@ -1552,14 +1568,14 @@ mod tests {
     /// 404 —— 生图栏则永远零档位（「此账号在当前平台没有可用分组」）。
     #[test]
     fn newapi_pure_image_group_lands_only_in_the_image_column_and_migrates_legacy_tiers() {
-        let op = test_newapi_relay(7);
+        let site_account = test_newapi_relay(7);
         let group = test_newapi_group("图", "sk-image");
         let image_models =
             provision::normalize_model_names(vec!["nano-banana-2".into(), "gpt-image-2".into()]);
         let account_id = 7;
 
         let candidates = newapi_candidates_for_group(
-            &op.site_origin,
+            &site_account.site_origin,
             account_id,
             &group,
             &image_models,
@@ -1574,10 +1590,17 @@ mod tests {
         // provision 一次：三个聊天栏的旧投影必须被清掉、生图栏出现新档位。
         let db = Arc::new(crate::database::Database::memory().expect("memory db"));
         let state = AppState::new(db.clone());
-        persist_provision_batch(&state, &op, newapi_batch(&op, std::slice::from_ref(&group)))
-            .expect("seed legacy three-column projections");
-        let provider_id =
-            provision::newapi_provider_id_for(&op.site_origin, account_id, &group.identity.0);
+        persist_provision_batch(
+            &state,
+            &site_account,
+            newapi_batch(&site_account, std::slice::from_ref(&group)),
+        )
+        .expect("seed legacy three-column projections");
+        let provider_id = provision::newapi_provider_id_for(
+            &site_account.site_origin,
+            account_id,
+            &group.identity.0,
+        );
         for app_type in newapi_app_types() {
             assert!(db
                 .get_provider_by_id(&provider_id, app_type.as_str())
@@ -1588,7 +1611,7 @@ mod tests {
         let mut keep = std::collections::HashSet::new();
         newapi_keep_insert(
             &mut keep,
-            &op.site_origin,
+            &site_account.site_origin,
             account_id,
             &group.identity,
             Some(&image_models),
@@ -1601,8 +1624,8 @@ mod tests {
             failures: Vec::new(),
             keys_created: 0,
         };
-        let summary =
-            persist_provision_batch(&state, &op, migrated).expect("migrate to image column");
+        let summary = persist_provision_batch(&state, &site_account, migrated)
+            .expect("migrate to image column");
         assert_eq!(summary.tiers.len(), 1);
         assert_eq!(summary.tiers[0].app_id, AppType::CodexImage.as_str());
         for app_type in newapi_app_types() {
@@ -1632,9 +1655,9 @@ mod tests {
 
     #[test]
     fn newapi_group_expands_to_three_app_configs_with_one_provider_id() {
-        let op = test_newapi_relay(7);
+        let site_account = test_newapi_relay(7);
         let group = test_newapi_group(" vip/\u{4e2d}\u{6587} \u{1f680} ", "sk-shared");
-        let batch = newapi_batch(&op, std::slice::from_ref(&group));
+        let batch = newapi_batch(&site_account, std::slice::from_ref(&group));
 
         assert_eq!(batch.candidates.len(), 3);
         assert_eq!(batch.observed_keep.len(), 3);
@@ -1655,7 +1678,8 @@ mod tests {
 
         let db = Arc::new(crate::database::Database::memory().expect("memory db"));
         let state = AppState::new(db.clone());
-        let summary = persist_provision_batch(&state, &op, batch).expect("persist projections");
+        let summary =
+            persist_provision_batch(&state, &site_account, batch).expect("persist projections");
 
         assert_eq!(summary.tiers.len(), 3);
         for app_type in [AppType::Claude, AppType::Codex, AppType::Gemini] {
@@ -1669,7 +1693,7 @@ mod tests {
             );
             assert_eq!(
                 provider.website_url.as_deref(),
-                Some(op.site_origin.as_str())
+                Some(site_account.site_origin.as_str())
             );
             assert_eq!(
                 provider
@@ -1683,12 +1707,16 @@ mod tests {
 
     #[test]
     fn newapi_refresh_preserves_edited_config_but_recomputes_unedited_defaults() {
-        let op = test_newapi_relay(7);
+        let site_account = test_newapi_relay(7);
         let first_group = test_newapi_group("vip", "sk-first");
         let db = Arc::new(crate::database::Database::memory().expect("memory db"));
         let state = AppState::new(db.clone());
-        let first = persist_provision_batch(&state, &op, newapi_batch(&op, &[first_group]))
-            .expect("initial provision");
+        let first = persist_provision_batch(
+            &state,
+            &site_account,
+            newapi_batch(&site_account, &[first_group]),
+        )
+        .expect("initial provision");
         let provider_id = first.tiers[0].provider_id.clone();
 
         let mut edited = db
@@ -1724,8 +1752,8 @@ mod tests {
             .expect("save stale unedited provider");
 
         let second_group = test_newapi_group("vip", "sk-second");
-        let second_batch = newapi_batch(&op, &[second_group]);
-        persist_provision_batch(&state, &op, second_batch).expect("refresh provision");
+        let second_batch = newapi_batch(&site_account, &[second_group]);
+        persist_provision_batch(&state, &site_account, second_batch).expect("refresh provision");
 
         let edited_after = db
             .get_provider_by_id(&provider_id, AppType::Codex.as_str())
@@ -1833,7 +1861,7 @@ mod tests {
 
     #[test]
     fn newapi_provider_write_failure_keeps_successful_apps_and_reports_the_failure() {
-        let op = test_newapi_relay(7);
+        let site_account = test_newapi_relay(7);
         let db = Arc::new(crate::database::Database::memory().expect("memory db"));
         {
             let conn = db.conn.lock().expect("lock memory db");
@@ -1851,8 +1879,8 @@ mod tests {
 
         let summary = persist_provision_batch(
             &state,
-            &op,
-            newapi_batch(&op, &[test_newapi_group("partial", "sk-partial")]),
+            &site_account,
+            newapi_batch(&site_account, &[test_newapi_group("partial", "sk-partial")]),
         )
         .expect("two successful app projections keep the batch successful");
 
@@ -2310,7 +2338,7 @@ mod tests {
             )
         })
         .expect("credentials");
-        let op = with_conn(&state, |conn| creds::get(conn, row_id))
+        let site_account = with_conn(&state, |conn| creds::get(conn, row_id))
             .expect("load")
             .expect("exists");
 
@@ -2335,7 +2363,7 @@ mod tests {
             failures: Vec::new(),
             keys_created: 0,
         };
-        persist_provision_batch(&state, &op, batch).expect("persist");
+        persist_provision_batch(&state, &site_account, batch).expect("persist");
 
         let rows = list_relays_impl(&state, AppType::Codex).expect("list relays");
         let tier = rows

--- a/src-tauri/src/commands/relay/rows.rs
+++ b/src-tauri/src/commands/relay/rows.rs
@@ -172,7 +172,7 @@ pub fn relay_list_relays(state: State<'_, AppState>, app: String) -> Result<Vec<
 /// 「这一行能开带登录态的站点窗吗」——充值与查看用量共用同一判据
 /// （配置了入口 + 登录态有效 + NewAPI 还要有可轮换的 refresh cookie）。
 pub(crate) fn can_open_site_window(
-    relay: &creds::Relay,
+    relay: &creds::RelayAccount,
     logged_in: bool,
     configured_url: bool,
 ) -> bool {
@@ -203,76 +203,93 @@ pub(crate) fn list_relays_impl(
 
     relays
         .into_iter()
-        .map(|op| -> Result<RelayRow, AppError> {
-            let mine = tiers_of_site(state, &tiers, &op.site_origin, op.account_id, &app_type)?;
-            let logged_in = op.token_looks_valid(now);
-            let session_expired = op.session_expired(now);
-            let has_balance_key = !relay_balance_inputs(state, &op).1.is_empty();
+        .map(|site_account| -> Result<RelayRow, AppError> {
+            let mine = tiers_of_site(
+                state,
+                &tiers,
+                &site_account.site_origin,
+                site_account.account_id,
+                &app_type,
+            )?;
+            let logged_in = site_account.token_looks_valid(now);
+            let session_expired = site_account.session_expired(now);
+            let has_balance_key = !relay_balance_inputs(state, &site_account).1.is_empty();
             let status = if session_expired {
                 if has_balance_key {
                     RelayRowStatus::SessionExpiredUsable
                 } else {
                     RelayRowStatus::SessionExpired
                 }
-            } else if !logged_in && !op.can_refresh(now) {
+            } else if !logged_in && !site_account.can_refresh(now) {
                 RelayRowStatus::NotLoggedIn
             } else if mine.is_empty() {
                 RelayRowStatus::NoTiers
             } else {
                 RelayRowStatus::Ready
             };
-            let configured_url =
-                match remote_config::configured_purchase_url(&signed_config, &op.site_origin) {
-                    Ok(Some(_)) => true,
-                    Ok(None) => false,
-                    Err(_) => {
-                        let host = url::Url::parse(&op.site_origin)
-                            .ok()
-                            .and_then(|url| url.host_str().map(str::to_owned))
-                            .unwrap_or_else(|| "<unknown>".into());
-                        log::warn!("中转站 {host} 的购买入口配置无效，已禁用购买");
-                        false
-                    }
-                };
-            let usage_url_configured =
-                match remote_config::configured_usage_url(&signed_config, &op.site_origin) {
-                    Ok(Some(_)) => true,
-                    Ok(None) => false,
-                    Err(_) => {
-                        let host = url::Url::parse(&op.site_origin)
-                            .ok()
-                            .and_then(|url| url.host_str().map(str::to_owned))
-                            .unwrap_or_else(|| "<unknown>".into());
-                        log::warn!("中转站 {host} 的用量入口配置无效，已禁用查看用量");
-                        false
-                    }
-                };
-            let usage_blockers =
-                apps_using_this_accounts_tiers(state, &op.site_origin, op.account_id)
-                    .into_iter()
-                    .map(|(app_type, tier_name)| UsageBlocker {
-                        app: app_type.as_str().to_string(),
-                        tier_name,
-                    })
-                    .collect::<Vec<_>>();
+            let configured_url = match remote_config::configured_purchase_url(
+                &signed_config,
+                &site_account.site_origin,
+            ) {
+                Ok(Some(_)) => true,
+                Ok(None) => false,
+                Err(_) => {
+                    let host = url::Url::parse(&site_account.site_origin)
+                        .ok()
+                        .and_then(|url| url.host_str().map(str::to_owned))
+                        .unwrap_or_else(|| "<unknown>".into());
+                    log::warn!("中转站 {host} 的购买入口配置无效，已禁用购买");
+                    false
+                }
+            };
+            let usage_url_configured = match remote_config::configured_usage_url(
+                &signed_config,
+                &site_account.site_origin,
+            ) {
+                Ok(Some(_)) => true,
+                Ok(None) => false,
+                Err(_) => {
+                    let host = url::Url::parse(&site_account.site_origin)
+                        .ok()
+                        .and_then(|url| url.host_str().map(str::to_owned))
+                        .unwrap_or_else(|| "<unknown>".into());
+                    log::warn!("中转站 {host} 的用量入口配置无效，已禁用查看用量");
+                    false
+                }
+            };
+            let usage_blockers = apps_using_this_accounts_tiers(
+                state,
+                &site_account.site_origin,
+                site_account.account_id,
+            )
+            .into_iter()
+            .map(|(app_type, tier_name)| UsageBlocker {
+                app: app_type.as_str().to_string(),
+                tier_name,
+            })
+            .collect::<Vec<_>>();
             Ok(RelayRow {
-                id: op.id,
-                site_origin: op.site_origin.clone(),
-                site_name: op.site_name.clone(),
+                id: site_account.id,
+                site_origin: site_account.site_origin.clone(),
+                site_name: site_account.site_name.clone(),
                 // 有 account_id 才算真的认得这个账号 —— email 可能被中转站留空。
-                account_label: if op.account_id.is_some() {
-                    op.account_label.clone()
+                account_label: if site_account.account_id.is_some() {
+                    site_account.account_label.clone()
                 } else {
                     String::new()
                 },
                 status,
                 is_current: mine.iter().any(|tier| tier.is_current),
                 can_query_balance: logged_in || has_balance_key,
-                can_purchase: can_open_site_window(&op, logged_in, configured_url),
-                can_view_usage: can_open_site_window(&op, logged_in, usage_url_configured),
-                can_refresh: op.can_refresh(now),
+                can_purchase: can_open_site_window(&site_account, logged_in, configured_url),
+                can_view_usage: can_open_site_window(
+                    &site_account,
+                    logged_in,
+                    usage_url_configured,
+                ),
+                can_refresh: site_account.can_refresh(now),
                 usage_blockers,
-                remove_confirmation: if op.account_id.is_some() {
+                remove_confirmation: if site_account.account_id.is_some() {
                     RemoveConfirmation::Configured
                 } else {
                     RemoveConfirmation::NeverLoggedIn
@@ -382,7 +399,7 @@ pub(crate) fn reset_tier_config_in_state(
             same_site_identity(Some(&candidate.site_origin), Some(site_origin.as_str()))
         })
         .collect();
-    let op = match account_id {
+    let site_account = match account_id {
         Some(want) => candidates
             .into_iter()
             .find(|candidate| candidate.account_id == Some(want))
@@ -447,7 +464,11 @@ pub(crate) fn reset_tier_config_in_state(
     } else {
         provision::pick_tier_models(&app_type, Some(&catalog_models)).main
     };
-    let base_url = sub2api::base_url_for(&app_type, &op.site_origin, &op.api_base_url);
+    let base_url = sub2api::base_url_for(
+        &app_type,
+        &site_account.site_origin,
+        &site_account.api_base_url,
+    );
 
     let settings_config = if !catalog_models.is_empty() {
         provision::settings_config_with_models(
@@ -470,9 +491,9 @@ pub(crate) fn reset_tier_config_in_state(
 
     // 除 settings_config 外其余字段保持原样（sort_index / created_at 等都不该被重置）。
     //
-    // `managed_meta` 传 `op.account_id` 而不是上面那个 `account_id` ——
+    // `managed_meta` 传 `site_account.account_id` 而不是上面那个 `account_id` ——
     // 后者可能是 `None`（旧数据），而这次重建正好是**补上归属标记**的时机：
-    // 我们刚刚确认了它属于 `op` 这一行。
+    // 我们刚刚确认了它属于 `site_account` 这一行。
     //
     // 分组身份同样趁重建补上——但这条路拿不到分组数据（手上只有本地
     // `settings_config`），只能保留旧值；旧值也是 `None` 时维持 `None`
@@ -483,7 +504,11 @@ pub(crate) fn reset_tier_config_in_state(
         .and_then(|meta| meta.loongport_group.clone());
     let restored = Provider {
         settings_config,
-        meta: Some(managed_meta(&app_type, op.account_id, preserved_group)),
+        meta: Some(managed_meta(
+            &app_type,
+            site_account.account_id,
+            preserved_group,
+        )),
         ..existing
     };
 
@@ -876,10 +901,10 @@ pub(crate) fn remove_site_impl(
     // ⚠️ **`account_id` 与 `site_origin` 一样必须取**：删的是**一个账号**（一行），
     // 不是「这个站的全部」。同站另一个账号的档位不该被连带清掉 ——
     // 那正是 `prune_stale_tiers` 加账号维度要挡的事（见它的文档）。
-    let op = with_conn(state, |conn| creds::get(conn, id))?
+    let site_account = with_conn(state, |conn| creds::get(conn, id))?
         .ok_or_else(|| AppError::Config("这个站点已经不存在了".into()))?;
-    let site_origin = op.site_origin;
-    let account_id = op.account_id;
+    let site_origin = site_account.site_origin;
+    let account_id = site_account.account_id;
 
     // ⚠️ 闸：这个账号名下有档位正被某个 app 用着 ⇒ 默认**一条都不删，直接报错**；
     // `force == true` 才放行（只该来自点名了在用 app 的前端确认弹窗，见命令文档）。
@@ -1022,18 +1047,18 @@ mod tests {
     use super::*;
     use crate::commands::relay::test_support::*;
 
-    fn sub2api_with_session() -> creds::Relay {
+    fn sub2api_with_session() -> creds::RelayAccount {
         purchase_capability_relay(creds::BackendKind::Sub2Api)
     }
 
-    fn newapi_with_refresh_cookie() -> creds::Relay {
-        creds::Relay {
+    fn newapi_with_refresh_cookie() -> creds::RelayAccount {
+        creds::RelayAccount {
             refresh_token: Some("refresh-cookie".into()),
             ..purchase_capability_relay(creds::BackendKind::NewApi)
         }
     }
 
-    fn newapi_without_refresh_cookie() -> creds::Relay {
+    fn newapi_without_refresh_cookie() -> creds::RelayAccount {
         purchase_capability_relay(creds::BackendKind::NewApi)
     }
 
@@ -1053,7 +1078,7 @@ mod tests {
         assert!(!can_open_site_window(&sub2api_with_session(), false, true));
         assert!(!can_open_site_window(&sub2api_with_session(), true, false));
 
-        let newapi_with_blank_refresh_cookie = creds::Relay {
+        let newapi_with_blank_refresh_cookie = creds::RelayAccount {
             refresh_token: Some("   ".into()),
             ..newapi_with_refresh_cookie()
         };

--- a/src-tauri/src/commands/relay/session.rs
+++ b/src-tauri/src/commands/relay/session.rs
@@ -290,13 +290,13 @@ pub(crate) struct RelayPricingRefreshSummary {
 }
 
 pub(crate) async fn refresh_due_relay_pricing_rows<F, Fut>(
-    relays: Vec<creds::Relay>,
+    relays: Vec<creds::RelayAccount>,
     now: i64,
     interval: std::time::Duration,
     refresh: F,
 ) -> RelayPricingRefreshSummary
 where
-    F: Fn(creds::Relay) -> Fut + Sync,
+    F: Fn(creds::RelayAccount) -> Fut + Sync,
     Fut: Future<Output = Result<(), AppError>> + Send,
 {
     use futures::StreamExt;
@@ -345,16 +345,20 @@ pub(crate) async fn refresh_due_relay_pricing(
             async move {
                 // 倍率拉取是只读请求，走 401→续期→重试：`token_expires_at = NULL`
                 // 的行靠它从「永不续期、到点暴毙」的降级态自愈。
-                relay_read_with_refresh_retry(&app_handle, relay.id, |op| {
+                relay_read_with_refresh_retry(&app_handle, relay.id, |site_account| {
                     // 闭包要能调两次（原请求 + 重试），future 各自持有克隆出来的 Arc。
                     let db = Arc::clone(&db);
                     async move {
-                        let updates = pricing::fetch_rate_updates(&op).await?;
+                        let updates = pricing::fetch_rate_updates(&site_account).await?;
                         pricing::apply_rate_updates(&db, &updates)?;
                         let conn = db.conn.lock().map_err(|error| {
                             AppError::Database(format!("获取数据库连接失败: {error}"))
                         })?;
-                        creds::mark_pricing_synced(&conn, op.id, chrono::Utc::now().timestamp())
+                        creds::mark_pricing_synced(
+                            &conn,
+                            site_account.id,
+                            chrono::Utc::now().timestamp(),
+                        )
                     }
                 })
                 .await
@@ -558,8 +562,8 @@ async fn check_session(app_handle: &tauri::AppHandle) -> Result<Vec<i64>, AppErr
         let state = app_handle.state::<AppState>();
         with_conn(&state, creds::list)?
             .into_iter()
-            .filter(|op| !op.auth_token.is_empty())
-            .map(|op| op.id)
+            .filter(|site_account| !site_account.auth_token.is_empty())
+            .map(|site_account| site_account.id)
             .collect()
     };
 
@@ -572,8 +576,10 @@ async fn check_session(app_handle: &tauri::AppHandle) -> Result<Vec<i64>, AppErr
         // 拿 /user/profile 当探活请求（最便宜的鉴权端点）。撞上「登录已过期」类 401
         // 时先静默续期再重试一次 —— 那是 `token_expires_at = NULL` 的降级态行唯一
         // 的自救机会（详见 relay_read_with_refresh_retry 的文档）。
-        let probe = relay_read_with_refresh_retry(app_handle, id, |op| async move {
-            backend::RuntimeBackend::for_relay(&op).balance().await
+        let probe = relay_read_with_refresh_retry(app_handle, id, |site_account| async move {
+            backend::RuntimeBackend::for_relay(&site_account)
+                .balance()
+                .await
         })
         .await;
 
@@ -742,11 +748,14 @@ mod tests {
         let (origin, server) = spawn_balance_server(router).await;
         let (app, relay_id) = saved_relay_app(&origin, discovery::BackendKind::Sub2Api);
 
-        let error = relay_read_with_refresh_retry(app.handle(), relay_id, |op| async move {
-            backend::RuntimeBackend::for_relay(&op).balance().await
-        })
-        .await
-        .expect_err("续期失败时原请求的错误必须往外抛");
+        let error =
+            relay_read_with_refresh_retry(app.handle(), relay_id, |site_account| async move {
+                backend::RuntimeBackend::for_relay(&site_account)
+                    .balance()
+                    .await
+            })
+            .await
+            .expect_err("续期失败时原请求的错误必须往外抛");
 
         assert!(error.to_string().contains("登录已过期"), "{error}");
         assert!(!error.to_string().contains("续期失败"), "{error}");

--- a/src-tauri/src/commands/relay/site_config.rs
+++ b/src-tauri/src/commands/relay/site_config.rs
@@ -36,7 +36,7 @@ pub async fn relay_apply_site_config(
     relay_id: i64,
     input: String,
 ) -> Result<SiteConfigApplySummary, AppError> {
-    let op = usable_relay(&app_handle, relay_id).await?;
+    let site_account = usable_relay(&app_handle, relay_id).await?;
     let trimmed = input.trim();
     if trimmed.is_empty() {
         return Err(AppError::InvalidInput(
@@ -44,12 +44,12 @@ pub async fn relay_apply_site_config(
         ));
     }
     let declared = if trimmed.starts_with("https://") {
-        site_config::validate_same_origin(trimmed, &op.site_origin)?;
+        site_config::validate_same_origin(trimmed, &site_account.site_origin)?;
         site_config::fetch_declaration_from_url(trimmed).await?
     } else {
         site_config::parse_site_config(trimmed)?
     };
-    site_config::validate_same_origin(&declared.site_origin, &op.site_origin)?;
+    site_config::validate_same_origin(&declared.site_origin, &site_account.site_origin)?;
 
     let state = app_handle.state::<crate::store::AppState>();
     let mut applied = Vec::new();
@@ -72,7 +72,7 @@ pub async fn relay_apply_site_config(
             if !is_managed(&provider) {
                 continue;
             }
-            if provider.website_url.as_deref() != Some(op.site_origin.as_str()) {
+            if provider.website_url.as_deref() != Some(site_account.site_origin.as_str()) {
                 continue;
             }
             if !site_config::apply_segment_to_app(
@@ -101,7 +101,7 @@ pub async fn relay_apply_site_config(
         ));
     }
     Ok(SiteConfigApplySummary {
-        site_origin: op.site_origin,
+        site_origin: site_account.site_origin,
         declared_origin: declared.site_origin,
         applied,
     })
@@ -175,7 +175,7 @@ pub async fn relay_reset_site_config(
     app_handle: tauri::AppHandle,
     relay_id: i64,
 ) -> Result<SiteConfigApplySummary, AppError> {
-    let op = usable_relay(&app_handle, relay_id).await?;
+    let site_account = usable_relay(&app_handle, relay_id).await?;
     let state = app_handle.state::<crate::store::AppState>();
 
     let mut applied = Vec::new();
@@ -188,7 +188,7 @@ pub async fn relay_reset_site_config(
             if !is_managed(&provider) {
                 continue;
             }
-            if provider.website_url.as_deref() != Some(op.site_origin.as_str()) {
+            if provider.website_url.as_deref() != Some(site_account.site_origin.as_str()) {
                 continue;
             }
             let Some((api_key, base_url, model)) =
@@ -228,7 +228,7 @@ pub async fn relay_reset_site_config(
         return Err(AppError::Config("该站点下没有可恢复默认的托管档位".into()));
     }
     Ok(SiteConfigApplySummary {
-        site_origin: op.site_origin,
+        site_origin: site_account.site_origin,
         declared_origin: String::new(),
         applied,
     })
@@ -352,7 +352,7 @@ mod tests {
             )
         })
         .expect("credentials");
-        let op = with_conn(&state, |conn| creds::get(conn, row_id))
+        let site_account = with_conn(&state, |conn| creds::get(conn, row_id))
             .expect("load")
             .expect("exists");
 
@@ -393,7 +393,7 @@ mod tests {
             failures: Vec::new(),
             keys_created: 0,
         };
-        persist_provision_batch(&state, &op, batch).expect("persist");
+        persist_provision_batch(&state, &site_account, batch).expect("persist");
 
         let provider = state
             .db

--- a/src-tauri/src/commands/relay/test_support.rs
+++ b/src-tauri/src/commands/relay/test_support.rs
@@ -4,8 +4,8 @@
 //! 各域测试 mod 的头部统一 `use crate::commands::relay::test_support::*;`。
 use super::*;
 
-pub(crate) fn purchase_capability_relay(backend_kind: creds::BackendKind) -> creds::Relay {
-    creds::Relay {
+pub(crate) fn purchase_capability_relay(backend_kind: creds::BackendKind) -> creds::RelayAccount {
+    creds::RelayAccount {
         id: 1,
         site_origin: "https://relay.example".into(),
         site_name: "Relay".into(),
@@ -58,8 +58,8 @@ pub(crate) fn tier(id: &str) -> TierInfo {
     }
 }
 
-pub(crate) fn test_newapi_relay(account_id: i64) -> creds::Relay {
-    creds::Relay {
+pub(crate) fn test_newapi_relay(account_id: i64) -> creds::RelayAccount {
+    creds::RelayAccount {
         id: account_id,
         site_origin: "https://newapi.example".into(),
         site_name: "NewAPI".into(),
@@ -147,7 +147,7 @@ pub(crate) fn saved_relay_app(
 pub(crate) fn relay_credentials(
     app: &tauri::App<tauri::test::MockRuntime>,
     relay_id: i64,
-) -> creds::Relay {
+) -> creds::RelayAccount {
     let state = app.state::<AppState>();
     with_conn(&state, |conn| creds::get(conn, relay_id))
         .expect("read saved relay")

--- a/src-tauri/src/commands/relay/windows.rs
+++ b/src-tauri/src/commands/relay/windows.rs
@@ -36,35 +36,35 @@ async fn open_purchase_window<R: tauri::Runtime>(
     app_handle: &tauri::AppHandle<R>,
     relay_id: i64,
 ) -> Result<(), AppError> {
-    let op = usable_relay(app_handle, relay_id).await?;
+    let site_account = usable_relay(app_handle, relay_id).await?;
 
     // 充值页直接承载付款动作，它指向哪由**签名配置**说了算 —— 客户端不再读站点
     // 公开设置的支付开关去推测 `/purchase` 还是 `/redeem`（那是在替站长决定入口）。
     // 配置没加载 / 这个站没配入口都明确报错，绝不回落到猜测的路由。
     let config = remote_config::load_cached()
         .ok_or_else(|| AppError::Config("中转站配置尚未加载，暂时无法打开充值入口".into()))?;
-    let purchase_url = remote_config::configured_purchase_url(&config, &op.site_origin)?
+    let purchase_url = remote_config::configured_purchase_url(&config, &site_account.site_origin)?
         .ok_or_else(|| AppError::Config("该中转站尚未配置充值入口".into()))?;
 
-    let window = purchase::purchase_window(relay_id, &op.site_origin);
-    dispatch_site_window(app_handle, op, window, purchase_url).await
+    let window = purchase::purchase_window(relay_id, &site_account.site_origin);
+    dispatch_site_window(app_handle, site_account, window, purchase_url).await
 }
 
 async fn open_usage_window<R: tauri::Runtime>(
     app_handle: &tauri::AppHandle<R>,
     relay_id: i64,
 ) -> Result<(), AppError> {
-    let op = usable_relay(app_handle, relay_id).await?;
+    let site_account = usable_relay(app_handle, relay_id).await?;
 
     // 用量页入口同样由签名配置拥有（sub2api 是 /usage，New API 是各自 console
     // 路由）——路由事实在站方，客户端不猜。
     let config = remote_config::load_cached()
         .ok_or_else(|| AppError::Config("中转站配置尚未加载，暂时无法打开用量入口".into()))?;
-    let usage_url = remote_config::configured_usage_url(&config, &op.site_origin)?
+    let usage_url = remote_config::configured_usage_url(&config, &site_account.site_origin)?
         .ok_or_else(|| AppError::Config("该中转站尚未配置用量入口".into()))?;
 
-    let window = purchase::usage_window(relay_id, &op.site_origin);
-    dispatch_site_window(app_handle, op, window, usage_url).await
+    let window = purchase::usage_window(relay_id, &site_account.site_origin);
+    dispatch_site_window(app_handle, site_account, window, usage_url).await
 }
 
 /// 按协议分派**站点页面窗**开窗；窗口身份（label/标题）与目标 URL 都必须由
@@ -75,7 +75,7 @@ async fn open_usage_window<R: tauri::Runtime>(
 /// 所以协议分派的回归测试直接驱动本函数、自己构造内存里的 `RemoteConfig`。
 pub(crate) async fn dispatch_site_window<R: tauri::Runtime>(
     app_handle: &tauri::AppHandle<R>,
-    op: creds::Relay,
+    site_account: creds::RelayAccount,
     window: purchase::SiteWindow,
     target_url: url::Url,
 ) -> Result<(), AppError> {
@@ -103,9 +103,9 @@ pub(crate) async fn dispatch_site_window<R: tauri::Runtime>(
         return Ok(());
     }
 
-    match op.backend_kind {
+    match site_account.backend_kind {
         creds::BackendKind::Sub2Api => {
-            open_sub2api_site_window(app_handle, op, window, target_url).await
+            open_sub2api_site_window(app_handle, site_account, window, target_url).await
         }
         // NewAPI 的站点窗是「cookie 形态登录态 + 轮换跟踪」的另一套实现
         // （`relay::newapi_purchase`，接线顺序的理由见它的模块文档）。
@@ -113,8 +113,8 @@ pub(crate) async fn dispatch_site_window<R: tauri::Runtime>(
         // （含「重新登录」文案）—— lease 在那之后才被消费。
         creds::BackendKind::NewApi => {
             let state = app_handle.state::<AppState>();
-            let lease = state.purchase_sessions.try_acquire(op.id)?;
-            newapi_purchase::open(app_handle, op, window, target_url, lease).await
+            let lease = state.purchase_sessions.try_acquire(site_account.id)?;
+            newapi_purchase::open(app_handle, site_account, window, target_url, lease).await
         }
     }
 }
@@ -127,7 +127,7 @@ pub(crate) async fn dispatch_site_window<R: tauri::Runtime>(
 /// 所以回归测试直接驱动本函数、自己构造内存里的 `RemoteConfig`。
 pub(crate) async fn open_sub2api_site_window<R: tauri::Runtime>(
     app_handle: &tauri::AppHandle<R>,
-    op: creds::Relay,
+    site_account: creds::RelayAccount,
     window: purchase::SiteWindow,
     target_url: url::Url,
 ) -> Result<(), AppError> {
@@ -142,17 +142,17 @@ pub(crate) async fn open_sub2api_site_window<R: tauri::Runtime>(
     // 所以在开窗前主动要一次续期：不看「现在还能不能用」，看「够不够撑完一次付款」。
     // 拿不到更长的 token 也照样开窗 —— 那时用户至少还能完成一笔快的（扫码即付），
     // 硬拦住他反而是把「可能不够」当成「一定不行」。
-    let op = ensure_token_outlasts_a_payment(app_handle, op).await;
+    let site_account = ensure_token_outlasts_a_payment(app_handle, site_account).await;
 
     // 先取账号档案。**必须在开窗之前** —— 站点的 router 守卫在页面启动那一刻就读
     // localStorage，注入脚本必须在那之前就带着完整的值。拿不到就别开窗：
     // 开一个注定落到登录页的窗口，用户只会以为「点了充值却要我重新登录」。
     let client = sub2api::Client::new(
-        &op.site_origin,
-        &op.auth_token,
-        op.account_id,
-        op.user_agent.as_deref(),
-        op.cf_clearance.as_deref(),
+        &site_account.site_origin,
+        &site_account.auth_token,
+        site_account.account_id,
+        site_account.user_agent.as_deref(),
+        site_account.cf_clearance.as_deref(),
     )?;
     let auth_user = purchase::auth_user_from_profile(client.profile_raw().await?)?;
 
@@ -161,7 +161,7 @@ pub(crate) async fn open_sub2api_site_window<R: tauri::Runtime>(
 
     // 关窗事件要带上是哪一行 —— 前端据此只刷那一行的余额。
     let handle_for_close = app_handle.clone();
-    let closed_relay_id = op.id;
+    let closed_relay_id = site_account.id;
 
     let built = tauri::WebviewWindowBuilder::new(
         app_handle,
@@ -191,8 +191,8 @@ pub(crate) async fn open_sub2api_site_window<R: tauri::Runtime>(
     // 吞掉（「点了支付没反应」），理由与 `browser_import` 那段逐条相同。
     .on_new_window(|_url, _features| tauri::webview::NewWindowResponse::Allow)
     .initialization_script(purchase::inject_script(
-        &op.site_origin,
-        &op.auth_token,
+        &site_account.site_origin,
+        &site_account.auth_token,
         &auth_user,
     ))
     .build()
@@ -204,8 +204,8 @@ pub(crate) async fn open_sub2api_site_window<R: tauri::Runtime>(
     // 只 emit 事件、不在这里查余额：查余额要发 HTTP，而这个回调不能 await ——
     // 站点级缓存（看板用）的失效+补刷走 spawn，不受此限。
     let close_handle = app_handle.clone();
-    let close_site = op.site_origin.clone();
-    let close_api_base = op.api_base_url.clone();
+    let close_site = site_account.site_origin.clone();
+    let close_api_base = site_account.api_base_url.clone();
     built.on_window_event(move |event| {
         if matches!(event, tauri::WindowEvent::Destroyed) {
             let _ = handle_for_close.emit(PURCHASE_CLOSED, closed_relay_id);
@@ -245,20 +245,20 @@ pub(crate) async fn open_sub2api_site_window<R: tauri::Runtime>(
 /// 让用户至少能完成一笔快的；把「可能不够」当成「一定不行」去拦住他更糟。
 async fn ensure_token_outlasts_a_payment<R: tauri::Runtime>(
     app_handle: &tauri::AppHandle<R>,
-    op: creds::Relay,
-) -> creds::Relay {
-    let Some(refresh) = op.refresh_token.clone() else {
+    site_account: creds::RelayAccount,
+) -> creds::RelayAccount {
+    let Some(refresh) = site_account.refresh_token.clone() else {
         log::info!("充值前想续期但没有 refresh token，用现有凭据开窗");
-        return op;
+        return site_account;
     };
 
-    match sub2api::refresh_token(&op.site_origin, &refresh).await {
+    match sub2api::refresh_token(&site_account.site_origin, &refresh).await {
         Ok(fresh) => {
             let state = app_handle.state::<AppState>();
             if let Err(e) = with_conn(&state, |conn| {
                 creds::update_tokens(
                     conn,
-                    op.id,
+                    site_account.id,
                     &fresh.auth_token,
                     // 服务端没轮换时沿用旧的 —— 覆写成 None 会让下次过期时无法续期。
                     fresh.refresh_token.as_deref().or(Some(refresh.as_str())),
@@ -269,18 +269,18 @@ async fn ensure_token_outlasts_a_payment<R: tauri::Runtime>(
                 // 只是下次还会再续一遍。
                 log::warn!("充值前续期成功但写库失败（不影响本次开窗）: {e}");
             }
-            creds::Relay {
+            creds::RelayAccount {
                 auth_token: fresh.auth_token,
                 refresh_token: fresh.refresh_token.or(Some(refresh)),
                 token_expires_at: fresh.token_expires_at,
-                ..op
+                ..site_account
             }
         }
         Err(e) => {
             // 续期失败不拦：现有 token 还没过期（`usable_relay` 已经保证了），
             // 只是可能撑不完一次慢付款。
             log::warn!("充值前续期失败，用现有凭据开窗: {e}");
-            op
+            site_account
         }
     }
 }
@@ -369,7 +369,7 @@ mod tests {
         // 所以两者恰好同源、`configured_purchase_url` 解析成功。
         let (app, relay_id) =
             saved_relay_app(&format!("http://{addr}"), discovery::BackendKind::Sub2Api);
-        let op = relay_credentials(&app, relay_id);
+        let site_account = relay_credentials(&app, relay_id);
 
         let configured = format!("https://{addr}/topup-center?flow=card");
         let config = remote_config::RemoteConfig {
@@ -388,12 +388,13 @@ mod tests {
             },
             ..remote_config::RemoteConfig::default()
         };
-        let purchase_url = remote_config::configured_purchase_url(&config, &op.site_origin)
-            .expect("签名目录解析不该报错")
-            .expect("这个站在目录里配了购买入口");
+        let purchase_url =
+            remote_config::configured_purchase_url(&config, &site_account.site_origin)
+                .expect("签名目录解析不该报错")
+                .expect("这个站在目录里配了购买入口");
 
-        let window = purchase::purchase_window(relay_id, &op.site_origin);
-        open_sub2api_site_window(app.handle(), op, window, purchase_url)
+        let window = purchase::purchase_window(relay_id, &site_account.site_origin);
+        open_sub2api_site_window(app.handle(), site_account, window, purchase_url)
             .await
             .expect("开充值窗");
 
@@ -496,9 +497,9 @@ mod tests {
             &origin.replacen("http://", "https://", 1),
             discovery::BackendKind::NewApi,
         );
-        let op = relay_credentials(&app, relay_id);
+        let site_account = relay_credentials(&app, relay_id);
         assert_eq!(
-            op.refresh_token.as_deref(),
+            site_account.refresh_token.as_deref(),
             Some("saved-refresh-token"),
             "前提：这行有非空 refresh credential"
         );
@@ -524,13 +525,14 @@ mod tests {
             },
             ..remote_config::RemoteConfig::default()
         };
-        let purchase_url = remote_config::configured_purchase_url(&config, &op.site_origin)
-            .expect("签名目录解析不该报错")
-            .expect("这个站在目录里配了购买入口");
+        let purchase_url =
+            remote_config::configured_purchase_url(&config, &site_account.site_origin)
+                .expect("签名目录解析不该报错")
+                .expect("这个站在目录里配了购买入口");
 
         // MockRuntime 的 cookies_for_url 恒返回空 ⇒ 走 300ms 启动超时路径（生产 20s）。
-        let window = purchase::purchase_window(relay_id, &op.site_origin);
-        let error = dispatch_site_window(app.handle(), op, window, purchase_url)
+        let window = purchase::purchase_window(relay_id, &site_account.site_origin);
+        let error = dispatch_site_window(app.handle(), site_account, window, purchase_url)
             .await
             .expect_err("mock 下观察不到轮换，必须按超时收场");
 
@@ -574,12 +576,12 @@ mod tests {
         let (app, relay_id) =
             saved_relay_app("https://newapi.example", discovery::BackendKind::NewApi);
         blank_saved_refresh_credential(&app, relay_id);
-        let op = relay_credentials(&app, relay_id);
+        let site_account = relay_credentials(&app, relay_id);
 
-        let window = purchase::purchase_window(relay_id, &op.site_origin);
+        let window = purchase::purchase_window(relay_id, &site_account.site_origin);
         let error = dispatch_site_window(
             app.handle(),
-            op,
+            site_account,
             window,
             url::Url::parse("https://newapi.example/console/topup").unwrap(),
         )
@@ -620,11 +622,11 @@ mod tests {
         .build()
         .expect("预建同 label 窗口");
 
-        let op = relay_credentials(&app, relay_id);
-        let window = purchase::purchase_window(relay_id, &op.site_origin);
+        let site_account = relay_credentials(&app, relay_id);
+        let window = purchase::purchase_window(relay_id, &site_account.site_origin);
         dispatch_site_window(
             app.handle(),
-            op,
+            site_account,
             window,
             url::Url::parse(&format!("{origin}/console/topup")).unwrap(),
         )
@@ -693,11 +695,11 @@ mod tests {
             id
         };
 
-        let op = relay_credentials(&app, relay2);
-        let window = purchase::purchase_window(relay2, &op.site_origin);
+        let site_account = relay_credentials(&app, relay2);
+        let window = purchase::purchase_window(relay2, &site_account.site_origin);
         let error = dispatch_site_window(
             app.handle(),
-            op,
+            site_account,
             window,
             url::Url::parse("https://newapi2.example/console/topup").unwrap(),
         )
@@ -727,15 +729,15 @@ mod tests {
     async fn newapi_purchase_reports_when_its_own_lease_is_already_held() {
         let (app, relay_id) =
             saved_relay_app("https://newapi.example", discovery::BackendKind::NewApi);
-        let op = relay_credentials(&app, relay_id);
+        let site_account = relay_credentials(&app, relay_id);
 
         let coordinator = Arc::clone(&app.state::<AppState>().purchase_sessions);
         let held = coordinator.try_acquire(relay_id).expect("预占自己的 lease");
 
-        let window = purchase::purchase_window(relay_id, &op.site_origin);
+        let window = purchase::purchase_window(relay_id, &site_account.site_origin);
         let error = dispatch_site_window(
             app.handle(),
-            op,
+            site_account,
             window,
             url::Url::parse("https://newapi.example/console/topup").unwrap(),
         )

--- a/src-tauri/src/commands/vendor.rs
+++ b/src-tauri/src/commands/vendor.rs
@@ -583,7 +583,7 @@ pub async fn vendor_open_login(
         .map(|r| r.login_identifier)
         .unwrap_or_default();
 
-    let Some(row_id) = do_login(&app_handle, vendor, &login_hint)
+    let Some(row_id) = login_via_browser(&app_handle, vendor, &login_hint)
         .await
         .map_err(|e| e.to_string())?
     else {
@@ -648,7 +648,7 @@ pub async fn vendor_refresh(
     ))
 }
 
-async fn do_login(
+async fn login_via_browser(
     app_handle: &tauri::AppHandle,
     vendor: Vendor,
     login_hint: &str,
@@ -660,7 +660,7 @@ async fn do_login(
 
     // 已经有一个登录窗时：**销毁它再开新的**，而不是聚焦了就早退。
     // 残留窗口可能是隐藏状态，而 `set_focus` 对不可见窗口是 no-op ⇒ 用户点了登录
-    // 什么都没发生，且 label 被占，再点多少次都一样（照 `relay::do_login` 那段）。
+    // 什么都没发生，且 label 被占，再点多少次都一样（照 `relay::login_via_browser` 那段）。
     if let Some(stale) = app_handle.get_webview_window(window_label) {
         log::info!("发现残留的官网登录窗口，销毁后重开");
         let _ = stale.destroy();
@@ -680,7 +680,7 @@ async fn do_login(
     .title(format!("登录 {}", vendor.display_name()))
     .inner_size(480.0, 720.0)
     .resizable(true)
-    // ⚠️ **每次登录都必须是全新的登录态**。理由与 `relay::do_login` 那处逐条相同
+    // ⚠️ **每次登录都必须是全新的登录态**。理由与 `relay::login_via_browser` 那处逐条相同
     // （详见那段长注释）：不加的话 WebView 用的是全 app 共享的**持久** profile，
     // 于是「删掉账号 → 重新添加」会被官网的 SPA 认成已登录直接跳走 ⇒
     // **同一个厂商永远只能挂第一个登录过的账号**，而多账号正是本表唯一索引
@@ -1061,15 +1061,15 @@ async fn provision_impl(
 /// 算的）。一次恢复六条会把他在别的 tab 里的编辑一起冲掉，而界面上没有任何地方
 /// 告诉过他这一点。
 #[tauri::command]
-pub async fn vendor_reset_tier_config(
+pub async fn vendor_reset_plan_config(
     state: State<'_, AppState>,
     provider_id: String,
     app_id: String,
 ) -> Result<(), String> {
-    vendor_reset_tier_config_impl(state.inner(), &provider_id, &app_id).map_err(|e| e.to_string())
+    vendor_reset_plan_config_impl(state.inner(), &provider_id, &app_id).map_err(|e| e.to_string())
 }
 
-fn vendor_reset_tier_config_impl(
+fn vendor_reset_plan_config_impl(
     state: &AppState,
     provider_id: &str,
     app_id: &str,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1706,7 +1706,7 @@ pub fn run() {
             commands::vendor_balance,
             commands::vendor_remove,
             commands::vendor_reorder,
-            commands::vendor_reset_tier_config,
+            commands::vendor_reset_plan_config,
             commands::import_default_config,
             commands::get_claude_desktop_status,
             commands::get_claude_desktop_default_routes,

--- a/src-tauri/src/relay/backend.rs
+++ b/src-tauri/src/relay/backend.rs
@@ -171,12 +171,12 @@ pub fn is_token_expiry_failure(error: &AppError) -> bool {
 }
 
 pub enum RuntimeBackend<'a> {
-    Sub2Api { relay: &'a creds::Relay },
-    NewApi { relay: &'a creds::Relay },
+    Sub2Api { relay: &'a creds::RelayAccount },
+    NewApi { relay: &'a creds::RelayAccount },
 }
 
 impl<'a> RuntimeBackend<'a> {
-    pub fn for_relay(relay: &'a creds::Relay) -> Self {
+    pub fn for_relay(relay: &'a creds::RelayAccount) -> Self {
         match relay.backend_kind {
             BackendKind::Sub2Api => Self::Sub2Api { relay },
             BackendKind::NewApi => Self::NewApi { relay },
@@ -489,10 +489,10 @@ mod tests {
     }
 
     use super::*;
-    use crate::relay::creds::Relay;
+    use crate::relay::creds::RelayAccount;
 
-    fn relay(origin: &str, backend_kind: BackendKind) -> Relay {
-        Relay {
+    fn relay(origin: &str, backend_kind: BackendKind) -> RelayAccount {
+        RelayAccount {
             id: 7,
             site_origin: origin.to_string(),
             site_name: "Test relay".into(),
@@ -639,7 +639,7 @@ mod tests {
                         "success": true,
                         "data": {
                             "version": "1.0.0",
-                            "system_name": "Relay",
+                            "system_name": "RelayAccount",
                             "theme": "default",
                             "register_enabled": true,
                             "password_login_enabled": true,

--- a/src-tauri/src/relay/balance.rs
+++ b/src-tauri/src/relay/balance.rs
@@ -92,7 +92,7 @@ pub struct BalanceQuery<'a> {
 /// 这一个 enum 上** —— 顺序本身仍然只在本模块定义一次，调用方无从改动它。
 pub enum SessionFallback<'a> {
     /// sub2api / NewAPI 中转站的 JWT 路。**NewAPI 站只有这一条**，不能删。
-    Relay(&'a creds::Relay),
+    Relay(&'a creds::RelayAccount),
     /// 官网厂商的网页登录态路。每家的会话接口不同（`vendor::balance` 分发）。
     Vendor {
         vendor: crate::vendor::Vendor,

--- a/src-tauri/src/relay/creds.rs
+++ b/src-tauri/src/relay/creds.rs
@@ -96,7 +96,7 @@ impl FromSql for BackendKind {
 
 /// 一个站点 × 账号（含凭据）。
 #[derive(Debug, Clone)]
-pub struct Relay {
+pub struct RelayAccount {
     pub id: i64,
     pub site_origin: String,
     pub site_name: String,
@@ -173,7 +173,7 @@ pub struct Relay {
     pub sort_index: i64,
 }
 
-impl Relay {
+impl RelayAccount {
     /// 凭据是否还能用于发请求。
     ///
     /// **过期判定留 60 秒余量**：正好卡在边界上发请求会拿到 401，白跑一趟。
@@ -277,8 +277,8 @@ const SELECT_COLS: &str =
      auth_token, refresh_token, token_expires_at, sort_index, backend_kind, user_agent, \
      cf_clearance, pricing_synced_at";
 
-fn row_to_relay(row: &rusqlite::Row<'_>) -> rusqlite::Result<Relay> {
-    Ok(Relay {
+fn row_to_relay(row: &rusqlite::Row<'_>) -> rusqlite::Result<RelayAccount> {
+    Ok(RelayAccount {
         id: row.get(0)?,
         site_origin: row.get(1)?,
         site_name: row.get(2)?,
@@ -298,7 +298,7 @@ fn row_to_relay(row: &rusqlite::Row<'_>) -> rusqlite::Result<Relay> {
 }
 
 /// 列出全部站点，当前选中的排在最前。
-pub fn list(conn: &Connection) -> Result<Vec<Relay>, AppError> {
+pub fn list(conn: &Connection) -> Result<Vec<RelayAccount>, AppError> {
     let mut stmt = conn
         .prepare(&format!(
             // ⚠️ 排序键必须是**用户拖出来的那个**，不能是任何会被别的操作改动的状态：
@@ -341,7 +341,7 @@ pub fn reorder(conn: &Connection, ids: &[i64]) -> Result<(), AppError> {
 }
 
 /// 按 id 读一行。
-pub fn get(conn: &Connection, id: i64) -> Result<Option<Relay>, AppError> {
+pub fn get(conn: &Connection, id: i64) -> Result<Option<RelayAccount>, AppError> {
     conn.query_row(
         &format!("SELECT {SELECT_COLS} FROM loongport_relay WHERE id = ?1"),
         params![id],
@@ -1533,14 +1533,14 @@ mod tests {
         assert!(!base.token_looks_valid(1000));
 
         // 服务端降级态（没给 expiry）不能判成「未就位」去轮询等 —— 那会永远等不到。
-        let no_expiry = Relay {
+        let no_expiry = RelayAccount {
             token_expires_at: None,
             ..base.clone()
         };
         assert!(no_expiry.token_looks_valid(i64::MAX - 100));
 
         // 没有 token 就是没登录，与过期是两件事。
-        let empty = Relay {
+        let empty = RelayAccount {
             auth_token: String::new(),
             ..base
         };
@@ -1577,7 +1577,7 @@ mod tests {
         assert!(!stale.session_expired(0));
 
         // 有 refresh_token 时**不报过期**：下次请求会自动续期，报了用户白跑一次重登。
-        let renewable = Relay {
+        let renewable = RelayAccount {
             refresh_token: Some("rt".into()),
             ..stale
         };

--- a/src-tauri/src/relay/model_verification/target.rs
+++ b/src-tauri/src/relay/model_verification/target.rs
@@ -195,7 +195,7 @@ fn resolve_relay(
     db: &Database,
     site_origin: &str,
     account_id: Option<i64>,
-) -> Result<creds::Relay, AppError> {
+) -> Result<creds::RelayAccount, AppError> {
     let candidates: Vec<_> = {
         let conn = db
             .conn

--- a/src-tauri/src/relay/newapi_purchase.rs
+++ b/src-tauri/src/relay/newapi_purchase.rs
@@ -207,7 +207,7 @@ fn startup_timeout_error() -> AppError {
 }
 
 /// 从 relay 行取出非空的 refresh credential；空缺即「要求重新登录」的错误。
-fn required_refresh_credential(relay: &creds::Relay) -> Result<&str, AppError> {
+fn required_refresh_credential(relay: &creds::RelayAccount) -> Result<&str, AppError> {
     relay
         .refresh_token
         .as_deref()
@@ -235,7 +235,7 @@ fn required_refresh_credential(relay: &creds::Relay) -> Result<&str, AppError> {
 /// `shutdown` 是窗口销毁的停机信号端，接进 `Destroyed` 事件后交给 monitor。
 pub(crate) fn build_window<R: tauri::Runtime>(
     app_handle: &tauri::AppHandle<R>,
-    relay: &creds::Relay,
+    relay: &creds::RelayAccount,
     window: super::purchase::SiteWindow,
     target_url: &url::Url,
     refresh_credential: &str,
@@ -335,7 +335,7 @@ fn persist_refresh_credential<R: tauri::Runtime>(
 /// 本函数不持久化它们、不回传给前端。
 pub async fn open<R: tauri::Runtime>(
     app_handle: &tauri::AppHandle<R>,
-    relay: creds::Relay,
+    relay: creds::RelayAccount,
     window: super::purchase::SiteWindow,
     target_url: url::Url,
     lease: PurchaseSessionLease,
@@ -754,8 +754,8 @@ mod tests {
     // cookies_for_url 恒空，命令级 happy-path 走超时路径，URL 只能在建窗后观察）
     // ======================================================================
 
-    fn newapi_relay(id: i64, site_origin: &str) -> creds::Relay {
-        creds::Relay {
+    fn newapi_relay(id: i64, site_origin: &str) -> creds::RelayAccount {
+        creds::RelayAccount {
             id,
             site_origin: site_origin.into(),
             site_name: "NewAPI".into(),

--- a/src-tauri/src/relay/pricing.rs
+++ b/src-tauri/src/relay/pricing.rs
@@ -5,7 +5,7 @@ use rusqlite::params;
 use crate::{
     database::{lock_conn, Database},
     error::AppError,
-    relay::{backend::BackendKind, creds::Relay, newapi, provision, sub2api},
+    relay::{backend::BackendKind, creds::RelayAccount, newapi, provision, sub2api},
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -15,7 +15,7 @@ pub struct RateUpdate {
 }
 
 fn sub2api_rate_updates(
-    relay: &Relay,
+    relay: &RelayAccount,
     groups: Vec<sub2api::Group>,
     user_rates: HashMap<i64, f64>,
 ) -> Vec<RateUpdate> {
@@ -44,7 +44,7 @@ fn sub2api_rate_updates(
         .collect()
 }
 
-fn newapi_rate_updates(relay: &Relay, groups: Vec<newapi::Group>) -> Vec<RateUpdate> {
+fn newapi_rate_updates(relay: &RelayAccount, groups: Vec<newapi::Group>) -> Vec<RateUpdate> {
     let account_id = relay
         .account_id
         .expect("authenticated relay required for NewAPI pricing");
@@ -61,7 +61,7 @@ fn newapi_rate_updates(relay: &Relay, groups: Vec<newapi::Group>) -> Vec<RateUpd
         .collect()
 }
 
-pub async fn fetch_rate_updates(relay: &Relay) -> Result<Vec<RateUpdate>, AppError> {
+pub async fn fetch_rate_updates(relay: &RelayAccount) -> Result<Vec<RateUpdate>, AppError> {
     let account_id = relay
         .account_id
         .ok_or_else(|| AppError::InvalidInput("未登录中转站不能刷新倍率".into()))?;
@@ -119,7 +119,7 @@ mod tests {
     use super::*;
     use crate::relay::{
         backend::BackendKind,
-        creds::Relay,
+        creds::RelayAccount,
         newapi::{Group as NewApiGroup, GroupIdentity},
         provision, sub2api,
     };
@@ -131,8 +131,8 @@ mod tests {
         Json, Router,
     };
 
-    fn relay(backend_kind: BackendKind) -> Relay {
-        Relay {
+    fn relay(backend_kind: BackendKind) -> RelayAccount {
+        RelayAccount {
             id: 1,
             site_origin: "https://relay.example".into(),
             site_name: "Relay".into(),

--- a/src-tauri/src/relay/provision.rs
+++ b/src-tauri/src/relay/provision.rs
@@ -447,7 +447,7 @@ pub fn sort_tiers(tiers: &mut [TargetedTier]) {
 /// 那正好废掉「同站多账号」这个核心能力：库层面按 `(site_origin, account_id)`
 /// 分得很干净，档位层面却退化成只按站点。
 ///
-/// `None` = 那一行还没登录（`creds::Relay::account_id` 为 `NULL`）。
+/// `None` = 那一行还没登录（`creds::RelayAccount::account_id` 为 `NULL`）。
 /// 未登录的行本来就 provision 不出档位（没有 token 拉不到分组），
 /// 但签名要能表达这个状态 —— 用 `"anon"` 参与哈希而不是跳过，
 /// 免得「未登录」与「account_id 恰好是某个值」撞到同一个 id 上。

--- a/src/lib/api/vendor.ts
+++ b/src/lib/api/vendor.ts
@@ -151,7 +151,7 @@ export const vendorApi = {
    * 冲掉，而界面上没有任何地方告诉过他这一点。
    */
   resetTierConfig: (providerId: string, appId: AppId): Promise<void> =>
-    invoke("vendor_reset_tier_config", { providerId, appId }),
+    invoke("vendor_reset_plan_config", { providerId, appId }),
 
   /**
    * 开登录窗，等凭据回来，存成一行账号。


### PR DESCRIPTION
## 背景

09-06 审查里唯一被搁置的结构项：「四词一义」（同一概念用 tier / group / plan / provider 交替指称）+ `relay` 一词三义 + `op` 黑话参数 + `do_` 前缀。当时判定「大迁移收益不抵风险」——本 PR 按**小心边界**重做：只动编译器可验证的纯内部名，wire / DB 契约名进冻结名单（读宽写窄），并把整套术语收进唯源文档。

## 术语表唯源：`docs/glossary.md`

- 16 个核心术语（中转站/账号行/分组/档位/套餐/provider 记录/平台/app/广场/实测/验真/熔断/省心模式/生图栏/登录态/官方 API），每个给：一句话定义、代码落点、UI 用词、备注。
- **冻结名单**：`providerId`、`group_name/group_id`、`user_edited`、事件与既有命令名、表名 `loongport_relay`——wire/DB 契约，改它们=迁移不是重构。
- **命名硬规矩**：禁 `op` 黑话、禁 `do_` 前缀、relay 域用 tier / vendor 域用 plan / 存储层用 provider、UI 用词与代码标识符分列。
- CLAUDE.md §三 只加指路（唯源不复制），顺带修正已过期的代码布局块（`commands/relay/` 目录、`sub2api`）。

## 按表落地的四组改名（纯内部，零 wire/DB 变化）

| 旧 | 新 | 理由 |
|---|---|---|
| `creds::Relay` | `creds::RelayAccount` | 「relay 一词三义」之一：它是账号行，不是站点也不是功能域 |
| `op` 参数 | `site_account` | 全 commands/relay 域 214 处；正则前后环视排除 `no-op` 文案误伤 |
| `do_login` | `login_via_browser` | relay 与 vendor 两处，去 `do_` 无信息前缀 |
| `vendor_reset_tier_config` | `vendor_reset_plan_config` | vendor 域借用 relay 域术语的交叉污染（审查实证）；前后端同 PR 改，注册闸核验 |

## 明确不做（记录在册）

- `TierInfo` 布尔前缀混排（`user_edited` 等）：DTO 字段 ↔ DB 列同名，属冻结名单。
- `leaderboard`/`directory` 模块更名：与既有 `commands/relay/directory.rs` 撞名，收益低。

## 验证

六道闸全绿（cargo test 0 失败 / clippy -D warnings / fmt / tsc / prettier / vitest 190 文件 1300 通过）。
