### PR TITLE
fix(crowd-metrics): 趋势每档补站点级窗口统计

### DIFF
--- a/crowd-metrics/src/aggregate.test.ts
+++ b/crowd-metrics/src/aggregate.test.ts
@@ -294,6 +294,23 @@ describe("趋势（buildTrends）", () => {
     const sum = bins.reduce((s, c) => s + c, 0);
     expect(sum).toBe(30); // 3 来源 × 10 样本全落 bin[2]
   });
+
+  it("站点级每档带窗口统计（指标格随时间档联动的数据源；含 30d）", () => {
+    const trend = buildTrends(sources(3), NOW);
+    for (const key of ["24h", "7d", "30d"] as const) {
+      const site = trend.ranges[key].sites["example.com"];
+      expect(site.window).toBeDefined();
+      expect(site.window!.samples).toBe(30);
+      expect(site.window!.ttftP50Ms).not.toBeNull();
+      expect(site.window!.sources).toBe(3);
+    }
+  });
+
+  it("范围级窗口同门禁：全未受信来源 → window 缺省（桶仍可空占位）", () => {
+    const rows = [makeRaw({ source: "only", ua_trusted: 0 })];
+    const trend = buildTrends(rows, NOW);
+    expect(trend.ranges["24h"].sites["example.com"]).toBeUndefined();
+  });
 });
 
 describe("趋势模型维度（P4）", () => {

--- a/crowd-metrics/src/aggregate.ts
+++ b/crowd-metrics/src/aggregate.ts
@@ -362,18 +362,7 @@ export function buildSnapshot(rows: RawRow[], nowSec: number): Snapshot {
 
   // 跨站来源集合：真源几乎必然出现在多家站（产品形态决定）—— 这是 cohort
   // 判定里「只此一家」那半个条件的唯一事实源。
-  const sitesBySource = new Map<string, Set<string>>();
-  for (const [site, list] of bySite) {
-    for (const r of list) {
-      const set = sitesBySource.get(r.source) ?? new Set<string>();
-      set.add(site);
-      sitesBySource.set(r.source, set);
-    }
-  }
-  const exclusiveSources = new Set<string>();
-  for (const [source, sites] of sitesBySource) {
-    if (sites.size === 1) exclusiveSources.add(source);
-  }
+  const exclusiveSources = exclusiveSourcesOf(bySite);
 
   const sites: Record<string, SiteStats> = {};
   // 站点按字典序产出，快照字节稳定（同数据 → 同输出，便于对账与缓存）。
@@ -383,6 +372,24 @@ export function buildSnapshot(rows: RawRow[], nowSec: number): Snapshot {
   }
 
   return { version: 1, generatedAt: nowSec, sites };
+}
+
+/** 「只出现在一家站」的来源集合：cohort 判定里「只此一家」半个条件的唯一
+ *  事实源。快照与趋势两处共用（各算一份会漂移）。 */
+function exclusiveSourcesOf(bySite: Map<string, ParsedRow[]>): Set<string> {
+  const sitesBySource = new Map<string, Set<string>>();
+  for (const [site, list] of bySite) {
+    for (const r of list) {
+      const set = sitesBySource.get(r.source) ?? new Set<string>();
+      set.add(site);
+      sitesBySource.set(r.source, set);
+    }
+  }
+  const exclusive = new Set<string>();
+  for (const [source, sites] of sitesBySource) {
+    if (sites.size === 1) exclusive.add(source);
+  }
+  return exclusive;
 }
 
 /** 趋势档位：跨度 + 输出桶粒度。粒度选点让每档点位数落在 24~60 之间
@@ -440,6 +447,8 @@ export function buildTrends(rows: RawRow[], nowSec: number, modelRows: RawModelR
   }
 
   const ranges: TrendPayload["ranges"] = {} as TrendPayload["ranges"];
+  // cohort 剔除的「只此一家」来源集合：与快照同源同算（唯源，两处共用）。
+  const exclusiveSources = exclusiveSourcesOf(bySite);
   for (const { key, spanSecs, bucketSecs } of TREND_RANGES) {
     // 网格锚在「整点对齐的窗口末尾」，最后一格是当前（可能未满的）小时。
     const endHour = Math.floor(nowSec / 3600) * 3600;
@@ -468,6 +477,10 @@ export function buildTrends(rows: RawRow[], nowSec: number, modelRows: RawModelR
         }
       }
       if (!anyPublished) continue;
+
+      // 站点在此档的窗口统计（与快照 w24/w7 同款聚合与门禁）——展示侧的
+      // 指标格随时间档切换读它，30d 档由此首次有了窗口口径。
+      const window = windowOrNull(inRange, exclusiveSources);
 
       // P4：该站在此档的模型趋势（逐 (site, model, bucket) 过 k-匿，
       // 与站点桶同款规则；tpsP50Ms 从 tps 直方图求）。
@@ -502,7 +515,12 @@ export function buildTrends(rows: RawRow[], nowSec: number, modelRows: RawModelR
         }
       }
 
-      sites[site] = { buckets, ttftBins: rangeBins, ...(Object.keys(models).length > 0 ? { models } : {}) };
+      sites[site] = {
+        buckets,
+        ttftBins: rangeBins,
+        ...(window ? { window } : {}),
+        ...(Object.keys(models).length > 0 ? { models } : {}),
+      };
     }
 
     ranges[key] = { bucketSeconds: bucketSecs, sites };

--- a/crowd-metrics/src/index.ts
+++ b/crowd-metrics/src/index.ts
@@ -20,8 +20,9 @@ const RATE_LIMIT_RETENTION_SECS = 2 * 86400;
 /** KV 快照键。 */
 const SNAPSHOT_KEY = "snapshot:v1";
 /** KV 趋势键（三档一包，recompute 与快照同拍写、同 freshness 策略）。
- *  v2：P5 模型桶/窗口出参追加 anomalies —— 键升版强制旧缓存失效重算。 */
-const TREND_KEY = "trend:v2";
+ *  v2：P5 模型桶/窗口出参追加 anomalies。
+ *  v3：站点级每档补 window（指标格随时间档联动）—— 键升版强制旧缓存失效重算。 */
+const TREND_KEY = "trend:v3";
 
 const CORS_HEADERS: Record<string, string> = {
   "access-control-allow-origin": "*",

--- a/crowd-metrics/src/types.ts
+++ b/crowd-metrics/src/types.ts
@@ -106,6 +106,9 @@ export interface SiteTrend {
   buckets: TrendBucket[];
   /** 该范围内合并的 TTFT 直方图（分布图随时间范围联动用）。 */
   ttftBins: number[];
+  /** 站点在此范围内的窗口统计（与快照 w24/w7 同款聚合与门禁）——展示侧
+   *  指标格随时间档切换读它；范围级门禁未过则缺省。 */
+  window?: WindowStats;
   /** P4：模型维度的趋势（有 v2 数据才有；键=模型名）。 */
   models?: Record<string, SiteTrendLite>;
 }


### PR DESCRIPTION
## 概要

修 /status 时间档与站点卡指标脱钩：指标格此前只能读快照 w24/w7，切 7d/30d 时数值与标签不动，30d 档根本无窗口口径。

- `buildTrends` 每档每站过 `windowOrNull`（与快照 w24/w7 **同款聚合与门禁**：k-匿/ASN/cohort 剔除/极值裁剪），出参 `sites[].window`
- `exclusiveSourcesOf` 提为公共函数——快照与趋势共用一份「只此一家」来源集合（唯源，两处各算会漂移）
- trend KV 键 v2→v3 强制旧缓存失效
- **已部署生产**：24h samples=110/err=0 vs 7d samples=142/err=0.7%，三档窗口已分化

## 验证

- [x] 76 测试全绿（新增：三档窗口齐备含 30d、范围级门禁缺省）
- [x] 线上 /v1/trend 实测三档窗口出参分化