### PR TITLE
fix(cli): 验证命令补 --skip-git-repo-check + 文档补 Node 安装前提

### DIFF
--- a/docs/loongport-cli.md
+++ b/docs/loongport-cli.md
@@ -54,7 +54,7 @@ $ loongport-cli --add-site https://example.com --key sk-xxxx --app codex
 探测站点 https://example.com …
 ✅ 已为 codex 配置「某中转站」（模型 gpt-5.4）
    密钥已写进 CLI 自己的配置文件，无需再设环境变量。
-   验证: codex exec "回复一个字：好"
+   验证: codex exec --skip-git-repo-check "回复一个字：好"
 ```
 
 ### `--model` 省略时会发生什么
@@ -80,13 +80,21 @@ $ loongport-cli --add-site https://example.com --key sk-xxxx --app codex
 配完直接用目标 CLI 验证：
 
 ```bash
-codex exec "回复一个字：好"    # 或
+codex exec --skip-git-repo-check "回复一个字：好"    # 或
 claude -p "回复一个字：好"
 ```
 
+> `--skip-git-repo-check` 是 codex 的要求：不在 git 仓库里执行时要显式带上
+> （服务器上通常就在 `$HOME`，实测必踩）。
+
 ## 前提与边界
 
-- **前提**：目标 CLI 本身（codex / claude 等）需要自己先装好，本工具只负责写配置
+- **前提**：目标 CLI 本身（codex / claude 等）需要自己先装好，本工具只负责写配置。两者都通过 npm 安装，**需要 Node 18+**——注意 Ubuntu 20.04 用 `apt` 装的 Node 是 12（太老），用 NodeSource 装：
+
+  ```bash
+  curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash - && sudo apt-get install -y nodejs
+  sudo npm install -g @openai/codex @anthropic-ai/claude-code
+  ```
 - **重复运行**：固定 provider id `loongport-relay`，再跑一次 = 覆盖上一次。换站、换 key、换模型都是重跑同一条命令，不会堆积残留
 - **不做的事**：浏览器 OAuth 登录、多账号、档位管理、本地路由与故障转移——那些是桌面版的能力；服务器上的多站多档位需求等真实用户反馈再议
 - 退出码：`0` 成功，`1` 运行错误（网络 / 密钥 / 写盘），`2` 参数错误

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -283,7 +283,9 @@ async fn pick_model(base_url: &str, key: &str) -> Result<String, String> {
 
 fn verify_hint(app: &AppType) -> &'static str {
     match app {
-        AppType::Codex => "codex exec \"回复一个字：好\"",
+        // --skip-git-repo-check：服务器场景通常在 $HOME 这类非 git 目录里跑，
+        // 不带这个参数 codex 直接拒绝执行（20.04 真机实测）。
+        AppType::Codex => "codex exec --skip-git-repo-check \"回复一个字：好\"",
         AppType::Claude => "claude -p \"回复一个字：好\"",
         _ => "直接运行该 CLI 发一条消息",
     }


### PR DESCRIPTION
20.04 真机全链路实测（loongport-cli 配置 → codex exec / claude -p 真实对话）发现的两个用户必踩坑：\n\n1. **cli.rs 印的验证命令在目标场景必失败**（bug）：服务器用户在 $HOME 跑 `codex exec "回复一个字：好"` 会被 codex 以「Not inside a trusted directory」拒绝，必须带 `--skip-git-repo-check`。verify_hint 与 docs 同步修正\n2. **文档前提缺 Node 安装指引**：codex/claude CLI 都要 Node 18+，Ubuntu 20.04 的 apt Node 是 12——补 NodeSource 20.x 一条龙\n\n证伪不写：claude -p 纯净首跑无 onboarding 卡点（实测），不文档化。\n\n官网不动：web 端只展示 --add-site 命令不涉及这两坑，细节归 GitHub 文档（web 精简指路、文档装细节的既有分工）。