### PR TITLE
feat(imagegen): grok 准入 + 档位筛选 Combobox + 独立图标 + 自定义张数并发（1-50）

### DIFF
--- a/src-tauri/src/commands/relay/imagegen.rs
+++ b/src-tauri/src/commands/relay/imagegen.rs
@@ -21,15 +21,17 @@ pub struct ImagegenImageRef {
     pub mime: String,
 }
 
-/// `relay_imagegen_generate` 的返回：这次用了哪个档位/模型、图片落在哪。
+/// `relay_imagegen_generate` 的返回：这次用了哪个档位/模型、图片落在哪、几张没成。
 ///
-/// 模型名给前端展示用（「已生成（gpt-image-2）」），不是让前端替用户做任何决定。
+/// 模型名给前端展示用（「已生成（gpt-image-2）」），不是让前端替用户做任何决定；
+/// `failed` 是部分失败的张数（批量并发下成功的那部分已落盘，用户拿得到）。
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ImagegenGenerateResult {
     pub tier_name: String,
     pub model: String,
     pub images: Vec<ImagegenImageRef>,
+    pub failed: usize,
 }
 
 /// App 内直接生图（生图页「生成」视图）：不经过任何 CLI 会话。
@@ -37,8 +39,9 @@ pub struct ImagegenGenerateResult {
 /// 与 MCP 工具（`--mcp-image-gen`）共用 [`imagegen`] 这一个核心 —— 档位选择、
 /// 请求形状、落盘与修剪完全一致，差别只在结果不进宿主对话。
 ///
-/// `n` = 张数（批量）。范围判据的唯一源在核心层（`imagegen::validate_count`，
-/// 上限与计费后果的说明见那里），本层只做缺省补 1。
+/// `n` = 张数（批量，1-50 自由输入）。范围判据的唯一源在核心层
+/// （`imagegen::validate_count`），>4 张的并发拆单与部分失败语义见
+/// `imagegen::generate_batch`，本层只做缺省补 1。
 #[tauri::command]
 pub async fn relay_imagegen_generate(
     app_handle: tauri::AppHandle,
@@ -52,14 +55,7 @@ pub async fn relay_imagegen_generate(
     }
     let count = imagegen::validate_count(n.unwrap_or(1))?;
     let tier = imagegen::load_current_tier()?;
-    let images = imagegen::generate_image(
-        &tier,
-        prompt,
-        size.as_deref(),
-        count,
-        imagegen::request_timeout(count),
-    )
-    .await?;
+    let (images, failed) = imagegen::generate_batch(&tier, prompt, size.as_deref(), count).await?;
     imagegen::ensure_asset_scope(&app_handle);
     Ok(ImagegenGenerateResult {
         tier_name: tier.display_name,
@@ -71,6 +67,7 @@ pub async fn relay_imagegen_generate(
                 mime: img.mime.to_string(),
             })
             .collect(),
+        failed,
     })
 }
 

--- a/src-tauri/src/relay/imagegen.rs
+++ b/src-tauri/src/relay/imagegen.rs
@@ -355,10 +355,11 @@ pub(crate) fn request_timeout(n: u32) -> std::time::Duration {
     std::time::Duration::from_secs(SINGLE_IMAGE_TIMEOUT_SECS * n.max(1) as u64)
 }
 
-/// 一次请求最多几张。闸在核心层这一份（两条入口都调 [`validate_count`]）：
-/// 一次 `n` 张就是 `n` 张的钱，前端选择器与工具 schema 只放合法值，
-/// 但真正的闸必须在后端 —— 别的入口不该绕过它。
-pub(crate) const MAX_IMAGE_COUNT: u32 = 4;
+/// 一次生成最多几张。闸在核心层这一份（两条入口都调 [`validate_count`]）：
+/// 一次 `n` 张就是 `n` 张的钱，前端与工具 schema 只是入口，真正的闸必须在后端 ——
+/// 别的入口不该绕过它。50 是「用户明确要一批」的合理上限，也是防手滑的天花板
+/// （比如把循环变量当张数传进来）。
+pub(crate) const MAX_IMAGE_COUNT: u32 = 50;
 
 /// 张数的唯一判据（合法原样返回，越界报错）。App 内命令与 MCP 工具共用，
 /// 各自再写一遍范围就会分叉。
@@ -367,6 +368,75 @@ pub(crate) fn validate_count(n: u32) -> Result<u32, String> {
         Ok(n)
     } else {
         Err(format!("张数只支持 1 到 {MAX_IMAGE_COUNT}"))
+    }
+}
+
+/// >4 张的批量并发跑单张请求时，同时在途的请求数。
+///
+/// 50 个请求同时打一家中转站容易撞限流（429），排队比触发对方风控便宜；
+/// 4 与单请求的张数上限对齐，一个小批量就是一波。
+const BATCH_CONCURRENCY: usize = 4;
+
+/// 批量生图的分单：
+///
+/// - `≤4` 张：**一条请求带 `n`**（现状路径）—— 账单一行、原子成功或失败。
+/// - `>4` 张：**拆成单张请求并发跑**。上游的 `n` 参数不是无限收的（官方 images
+///   API 单请求有上限，中转站各自截断），单张并发是唯一到处都通的形状；并发也让
+///   总耗时 ≈ 张数/并发数 × 单张时间，而不是串行叠加 —— 这正是放开到 50 张后
+///   超时仍然可控的原因。
+fn split_batch(total: u32) -> Vec<u32> {
+    if total <= 4 {
+        vec![total]
+    } else {
+        vec![1; total as usize]
+    }
+}
+
+/// 批量生图入口：分单 → 有界并发执行 → 汇总。
+///
+/// **部分失败不整体报错**：成功的图都已落盘、用户拿得到，返回值带失败张数，
+/// 由调用方提示（App 内的 warning toast / MCP 的 text block）。全部失败才 `Err`
+/// —— 那时把第一条错误原文带出去（生图失败的原因几乎全在服务端）。
+pub(crate) async fn generate_batch(
+    tier: &Tier,
+    prompt: &str,
+    size: Option<&str>,
+    total: u32,
+) -> Result<(Vec<GeneratedImage>, usize), String> {
+    let batches = split_batch(total);
+    let results: Vec<Result<Vec<GeneratedImage>, String>> = {
+        use futures::stream::StreamExt as _;
+        // 先 `.copied()` 再闭包：闭包参数是所有权 u32 而不是引用 —— 闭包借迭代项
+        // 引用会撞上「closure 的 FnOnce 不够 general」的 HRTB 限制（编译器把签名
+        // 统一成对任意生命周期成立的那种，async 块办不到）。
+        futures::stream::iter(
+            batches
+                .iter()
+                .copied()
+                .map(|n| generate_image(tier, prompt, size, n, request_timeout(n))),
+        )
+        .buffered(BATCH_CONCURRENCY)
+        .collect()
+        .await
+    };
+
+    let mut images = Vec::new();
+    let mut failed = 0usize;
+    let mut first_error = None;
+    for (batch_size, result) in batches.iter().zip(results) {
+        match result {
+            Ok(mut saved) => images.append(&mut saved),
+            Err(e) => {
+                log::warn!("批量生图中一张（n={batch_size}）失败: {e}");
+                failed += *batch_size as usize;
+                first_error.get_or_insert(e);
+            }
+        }
+    }
+    if images.is_empty() {
+        Err(first_error.unwrap_or_else(|| "生图接口没有返回任何图片".into()))
+    } else {
+        Ok((images, failed))
     }
 }
 
@@ -788,9 +858,20 @@ base_url = "https://api.example.com/v1"
     fn validate_count_is_the_single_range_gate() {
         assert_eq!(validate_count(1).unwrap(), 1);
         assert_eq!(validate_count(4).unwrap(), 4);
-        for bad in [0, 5, 50] {
+        assert_eq!(validate_count(50).unwrap(), 50);
+        for bad in [0, 51, 500] {
             assert!(validate_count(bad).is_err(), "n={bad} 必须被拒");
         }
+    }
+
+    /// 拆单规则：≤4 一条请求（账单一行、原子成败）；>4 拆并发单张
+    /// （上游 `n` 参数不是无限收的，单张并发是唯一到处都通的形状）。
+    #[test]
+    fn split_batch_routes_small_totals_into_one_request() {
+        assert_eq!(split_batch(1), vec![1]);
+        assert_eq!(split_batch(4), vec![4]);
+        assert_eq!(split_batch(5), vec![1; 5]);
+        assert_eq!(split_batch(50), vec![1; 50]);
     }
 
     /// 同一份内容得到同一个名字（可复现），不同内容不撞名。

--- a/src-tauri/src/relay/imagegen_mcp.rs
+++ b/src-tauri/src/relay/imagegen_mcp.rs
@@ -124,7 +124,7 @@ fn registration_server(exe: &str) -> McpServer {
             ..Default::default()
         },
         description: Some(
-            "用 LoongPort「生图」标签页里当前那个接入配置生图（gpt-image 系列）。\
+            "用 LoongPort「生图」标签页里当前那个接入配置生图（gpt-image、grok-imagine 等生图模型）。\
              由 LoongPort 自动维护，密钥不写进 CLI 配置 —— 换档位也不必重启 CLI。"
                 .to_string(),
         ),
@@ -176,7 +176,7 @@ const PROTOCOL_VERSION: &str = "2024-11-05";
 fn tools_list() -> Value {
     json!([{
         "name": "generate_image",
-        "description": "用 LoongPort 绑定的中转站接入配置生成图片（gpt-image 系列模型）。直接返回图片本身，同时给出保存到本地的路径。",
+        "description": "用 LoongPort 绑定的中转站接入配置生成图片（gpt-image、grok-imagine 等生图模型）。直接返回图片本身，同时给出保存到本地的路径。",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -190,7 +190,7 @@ fn tools_list() -> Value {
                 },
                 "n": {
                     "type": "integer",
-                    "description": "一次生成几张（1-4，默认 1）。按张数计费且耗时成倍增加；宿主的工具超时（codex 默认 300 秒）可能在多张时先到 —— 要更多张时，并发多次调用本工具（每次各自计时）通常更稳。"
+                    "description": "一次生成几张（1-50，默认 1）。按张数计费；超过 4 张会自动拆成并发单张请求。大批量耗时更长，宿主的工具超时（codex 默认 300 秒）可能在完成前先到 —— 超大批量时并发多次调用本工具（每次各自计时）通常更稳。"
                 }
             },
             "required": ["prompt"]
@@ -254,8 +254,7 @@ async fn handle_tool_call(req: &Value) -> Result<Value, String> {
     // ⚠️ **每次调用都重查当前档位**，不用启动时那份 —— 用户在 LoongPort 里换了生图
     // 档位，下一次生图就该用新的，**不必重启 codex**。见 `imagegen::current_image_tier_id`。
     let tier = imagegen::load_current_tier()?;
-    let images =
-        imagegen::generate_image(&tier, prompt, size, n, imagegen::request_timeout(n)).await?;
+    let (images, failed) = imagegen::generate_batch(&tier, prompt, size, n).await?;
     let list = images
         .iter()
         .map(|i| i.path.display().to_string())
@@ -276,10 +275,15 @@ async fn handle_tool_call(req: &Value) -> Result<Value, String> {
     //    不发等于白放着能力不用。
     //
     // bytes 在写文件前就在手上，所以这不额外发请求。
+    let failure_note = if failed > 0 {
+        format!("（另有 {failed} 张失败）")
+    } else {
+        String::new()
+    };
     let mut content = vec![json!({
         "type": "text",
         "text": format!(
-            "已生成 {} 张图片（接入配置：{}，模型：{}），已存到：\n{list}",
+            "已生成 {} 张图片{failure_note}（接入配置：{}，模型：{}），已存到：\n{list}",
             images.len(),
             tier.display_name,
             tier.model

--- a/src-tauri/src/relay/provision.rs
+++ b/src-tauri/src/relay/provision.rs
@@ -1033,6 +1033,8 @@ pub const DEFAULT_MODEL: &str = "gpt-5.6-sol";
 
 /// 生图模型的名字前缀家族。**一个表唯源**：[`is_image_model`]（认不认）与
 /// [`image_model_rank`]（谁更新）都从这里取 —— 两者必须对同一个集合给出一致答案。
+/// grok 家族形态特殊（有精确匹配条目），单独放 [`is_grok_image_model`]，两处同样
+/// 引用它 —— 前缀表 + grok 特判合起来才是完整的「生图模型集合」。
 ///
 /// ## 家族与准入依据
 ///
@@ -1042,20 +1044,21 @@ pub const DEFAULT_MODEL: &str = "gpt-5.6-sol";
 ///   `nano-banana-2` 与 `gpt-image-2` 同走 `/v1/images/generations`（OpenAI images
 ///   语义，b64_json 返回）。不认它的话，「`gpt-image-*` + `nano-banana-*`」的纯生图
 ///   分组会被当混合分组落进聊天栏。
+/// - grok 家族（[`is_grok_image_model`]，2026-09-07 准入）：照抄上游
+///   `isGrokImageGenerationModel` 的三条 —— `grok-imagine` / `grok-imagine-edit`
+///   精确匹配、`grok-imagine-image*` 前缀。中转站把 grok 生图挂在 **openai 平台
+///   分组**上卖（app_type 是 Codex，sk 走 `auth.OPENAI_API_KEY`），生图端点同一条
+///   `/v1/images/generations`，所以与 GPT 族同样准入。`grok-imagine-video` **不在**
+///   白名单：上游不认它（`isGrokImageGenerationModel` 的前缀是 `grok-imagine-image`），
+///   认了只会写出转发不了的配置。
 ///
 /// 仍然**不收** `dall-e` / `flux` / `imagen`：它们虽在 new-api 上游官方表
 /// `ImageGenerationModels`（`common/model.go`）里，但那张表是静态的、连 `gpt-image-2`
 /// 都没有，站点 fork 普遍自行扩展（实测有站点同时服务 `gpt-image-2` 与 `nano-banana-2`，
 /// 都不在官方表里）—— 即 new-api 侧**不存在一张可照抄的权威表**，本仓的准入口径是
-/// 「有站点实测背书才收」。目前也无 LoongPort 用户的真实分组踩到那三族；而且收了
-/// 会波及 sub2api 侧（其上游 `IsGPTImageGenerationModel` 只有 GPT 族，认了只会写出
-/// 转发不了的配置）。谁踩到新家族就在这里加一行 —— [`image_model_rank`] 的家族
-/// 优先级随之生效（**表里越靠前的家族跨家族并存时越优先**，`gpt-image-*` 是生图
-/// 管线的原生家族）。
-///
-/// ⚠️ 有意不含上游 `isOpenAIImageGenerationModel` 另外认的三个 grok 别名
-/// （`grok-imagine` / `-edit` / `-image*`）—— 生图工具只装在 codex 档位上
-/// （openai 平台），grok 档位落的是另一个 CLI。
+/// 「有上游判据或站点实测背书才收」。谁踩到新家族就在这里加一行 ——
+/// [`image_model_rank`] 的家族优先级随之生效（**表里越靠前的家族跨家族并存时越
+/// 优先**，`gpt-image-*` 是生图管线的原生家族，grok 家族垫底）。
 const IMAGE_MODEL_FAMILIES: &[&str] = &["gpt-image-", "nano-banana"];
 
 /// 一条档位该落到哪一栏：纯生图的进 [`AppType::CodexImage`]，其余原样返回。
@@ -1498,6 +1501,11 @@ fn maybe_one_m(tables: &ModelSelectionTables, model: &str) -> String {
 /// 优先级越高），同家族再按数字段比 —— `gpt-image-1.5` → `[1, 5]`、`gpt-image-2` →
 /// `[2]`、`gpt-image-10` → `[10]`，逐段比较，段数不同时短的算小（`1` < `1.5`）。
 /// 认不出数字的版本段排空（那种名字无从判断新旧，让它输给能判的）。
+///
+/// grok 家族（[`is_grok_image_model`]）不在前缀表里，表循环不命中后单独排：
+/// 优先级 0（垫底 —— 与 nano-banana 同级，但版本段从 `grok-imagine-image` 之后
+/// 抠，现无带版本号的形态 ⇒ 恒空段 ⇒ 跨家族并存时输给有版本的；`gpt-image-*`
+/// 与 grok 混编时 GPT 族靠表内优先级胜出）。
 fn image_model_rank(model: &str) -> (u32, Vec<u32>) {
     let normalized = model.trim().to_ascii_lowercase();
     for (index, prefix) in IMAGE_MODEL_FAMILIES.iter().enumerate() {
@@ -1518,6 +1526,20 @@ fn image_model_rank(model: &str) -> (u32, Vec<u32>) {
             .filter_map(|seg| seg.parse::<u32>().ok())
             .collect();
         return (precedence, segments);
+    }
+    if is_grok_image_model(&normalized) {
+        let rest = normalized.strip_prefix("grok-imagine-image").unwrap_or("");
+        let version: String = rest
+            .trim_start_matches('-')
+            .chars()
+            .take_while(|c| c.is_ascii_digit() || *c == '.')
+            .collect();
+        let segments = version
+            .split('.')
+            .filter(|seg| !seg.is_empty())
+            .filter_map(|seg| seg.parse::<u32>().ok())
+            .collect();
+        return (0, segments);
     }
     (0, Vec::new())
 }
@@ -1542,7 +1564,7 @@ fn grok_model_rank(model: &str) -> Vec<u32> {
         .unwrap_or_default()
 }
 
-/// 这个模型名是生图模型吗（[`IMAGE_MODEL_FAMILIES`] 前缀家族）。
+/// 这个模型名是生图模型吗（[`IMAGE_MODEL_FAMILIES`] 前缀家族 + grok 家族）。
 ///
 /// UI 据此显示「生图档位」标记。判据放在**模型名**而不是「拉一次 `/v1/models` 看看」，
 /// 是因为 `relay_list_relays` 那条路**只读本地不发网络**（首屏契约）——
@@ -1565,6 +1587,19 @@ pub fn is_image_model(model: &str) -> bool {
     IMAGE_MODEL_FAMILIES
         .iter()
         .any(|prefix| normalized.starts_with(prefix))
+        || is_grok_image_model(&normalized)
+}
+
+/// grok 生图家族，照抄上游 sub2api `isGrokImageGenerationModel` 的三条（接口事实）：
+/// `grok-imagine` / `grok-imagine-edit` 精确匹配，`grok-imagine-image*` 前缀。
+///
+/// 不并进 [`IMAGE_MODEL_FAMILIES`]（纯前缀表）—— `grok-imagine` 当前缀会连
+/// `grok-imagine-video` 一起收进来，而上游不认 video（写了转发不了）。
+/// 传入的串须已过 [`is_image_model`] 的归一化（trim + 小写）。
+fn is_grok_image_model(normalized: &str) -> bool {
+    normalized == "grok-imagine"
+        || normalized == "grok-imagine-edit"
+        || normalized.starts_with("grok-imagine-image")
 }
 
 /// 这个分组是不是「纯生图分组」：目录里一个非生图模型都没有。
@@ -2152,6 +2187,42 @@ mod tests {
         assert!(!is_image_model(DEFAULT_MODEL));
         assert!(!is_image_model("gpt-5.4-mini"));
         assert!(!is_image_model(""));
+    }
+
+    /// grok 家族照抄上游 `isGrokImageGenerationModel` 的三条（2026-09-07 准入，
+    /// 见 `is_grok_image_model` 的文档）—— 与上游分叉的方向都是坏的：
+    /// 我们认上游不认 ⇒ 写出转发不了的配置；上游认我们不认 ⇒ 纯生图分组被当
+    /// 混合分组落聊天栏、还写个文本模型进去。
+    #[test]
+    fn grok_image_family_matches_the_upstream_allowlist_exactly() {
+        // 三条白名单。
+        assert!(is_image_model("grok-imagine"));
+        assert!(is_image_model("grok-imagine-edit"));
+        assert!(is_image_model("grok-imagine-image"));
+        assert!(is_image_model("grok-imagine-image-quality"));
+        // 上游不认的近亲：video 是视频模型（写了转发不了），grok-4 是文本模型。
+        assert!(!is_image_model("grok-imagine-video"));
+        assert!(!is_image_model("grok-4"));
+        assert!(!is_image_model("grok-code-4.6"));
+        // 归一化与 GPT 族同一待遇。
+        assert!(is_image_model("  Grok-Imagine-Image  "));
+    }
+
+    /// 只挂 grok 生图模型的分组是纯生图分组，默认模型就是其中版本最新的那个
+    /// （而不是被当成混合分组写个文本模型进去）。
+    #[test]
+    fn a_grok_only_group_picks_its_own_model() {
+        let only = vec![
+            "grok-imagine-image".to_string(),
+            "grok-imagine-image-2".to_string(),
+        ];
+        assert!(is_pure_image_group(&only));
+        assert_eq!(pick_model(Some(&only)), "grok-imagine-image-2");
+
+        // 跨家族混编：gpt-image 靠表内家族优先级胜出。
+        let mixed = vec!["grok-imagine-image".to_string(), "gpt-image-2".to_string()];
+        assert!(is_pure_image_group(&mixed));
+        assert_eq!(pick_model(Some(&mixed)), "gpt-image-2");
     }
 
     /// 跨家族并存时表里靠前的家族（`gpt-image-*`）优先 —— 2026-09-05 实测的某 new-api

--- a/src/components/AppSwitcher.tsx
+++ b/src/components/AppSwitcher.tsx
@@ -22,10 +22,9 @@ const APP_BADGE_ICON: Partial<
 > = {
   claude: { icon: Terminal },
   "claude-desktop": { icon: Monitor, offsetY: 0.5 },
-  // 与 claude-desktop 同一个手法：同品牌图标 + 一个角标说明「这是那个 CLI 的另一面」。
-  // 角标是图片而不是文字，因为它要在 20px 的图标上认得出来。
   // （PR #116 上游合并时随上游版 AppSwitcher 丢过一次，别再丢。）
-  "codex-image": { icon: ImageIcon, offsetY: 0.5 },
+  // 生图页原也在此列（OpenAI 标 + 图片角标）—— tab 改名「生图」并支持多家生图
+  // 模型后已换成独立图标（见 AppGlyph 的生图分支），不再挂 codex 的品牌。
 };
 
 interface AppSwitcherProps {
@@ -38,11 +37,10 @@ interface AppSwitcherProps {
   onShowApp?: (app: AppId) => void;
 }
 
-const APP_ICON_NAME: Record<AppId, string> = {
+const APP_ICON_NAME: Record<Exclude<AppId, "codex-image">, string> = {
   claude: "claude",
   "claude-desktop": "claude",
   codex: "openai",
-  "codex-image": "openai",
   gemini: "gemini",
   grokbuild: "grok",
   opencode: "opencode",
@@ -53,6 +51,22 @@ const APP_ICON_NAME: Record<AppId, string> = {
 
 /** 应用图标 + 角标（Claude Code / Desktop 用角标区分终端与桌面） */
 function AppGlyph({ app, isActive }: { app: AppId; isActive: boolean }) {
+  // 生图页用独立的图片图标（跟页面的 violet 主题同色）：它不再从属于某一家 CLI
+  // （生图模型 gpt-image / nano-banana / grok-imagine 多家族），挂着 OpenAI 品牌
+  // 反而误导。其余 app 走品牌图标（+可选角标）。
+  if (app === "codex-image") {
+    return (
+      <ImageIcon
+        className={cn(
+          "h-5 w-5 shrink-0",
+          isActive
+            ? "text-violet-600 dark:text-violet-400"
+            : "text-muted-foreground",
+        )}
+        aria-hidden="true"
+      />
+    );
+  }
   const badgeConfig = APP_BADGE_ICON[app];
   const BadgeIcon = badgeConfig?.icon;
   return (

--- a/src/components/relay/ImagegenPlayground.tsx
+++ b/src/components/relay/ImagegenPlayground.tsx
@@ -19,10 +19,24 @@ import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import { fmtBytes } from "@/lib/format";
 import { convertFileSrc } from "@tauri-apps/api/core";
-import { FolderOpen, Loader2, Sparkles } from "lucide-react";
+import {
+  Check,
+  ChevronsUpDown,
+  FolderOpen,
+  Loader2,
+  Sparkles,
+} from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
 import {
   Dialog,
   DialogContent,
@@ -31,7 +45,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import {
   Select,
   SelectContent,
@@ -40,6 +60,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
 import { relayApi, type ImagegenGalleryEntry } from "@/lib/api";
 import {
   imagegenKeys,
@@ -51,9 +72,6 @@ import {
 /** 尺寸档位：gpt-image 的三档（与 MCP 工具的 size 语义一致，不给「自动」）。 */
 const SIZE_OPTIONS = ["1024x1024", "1536x1024", "1024x1536"] as const;
 
-/** 张数档位。上限 4 是后端闸（一次 n 张就是 n 张的钱），这里只是选择器。 */
-const COUNT_OPTIONS = ["1", "2", "4"] as const;
-
 export function ImagegenPlayground() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -63,6 +81,7 @@ export function ImagegenPlayground() {
   const [size, setSize] = useState<string>("1024x1024");
   const [count, setCount] = useState<string>("1");
   const [preview, setPreview] = useState<ImagegenGalleryEntry | null>(null);
+  const [tierPickerOpen, setTierPickerOpen] = useState(false);
 
   // 档位列表与「档位」视图同一条命令（listRelays 按栏查，结果天然同质）。
   const tiersQuery = useImageTiers();
@@ -88,16 +107,31 @@ export function ImagegenPlayground() {
   };
 
   const onGenerate = () => {
+    // 输入框里的值可能还在半截（空串/越界），提交时夹回合法域 —— 真正的闸在后端。
+    const parsed = Number.parseInt(count, 10);
+    const safe = Number.isNaN(parsed) ? 1 : Math.min(50, Math.max(1, parsed));
     generate.mutate(
-      { prompt: prompt.trim(), size, count: Number(count) },
+      { prompt: prompt.trim(), size, count: safe },
       {
-        onSuccess: (result) =>
-          toast.success(
-            t("loongport.imagegenPlayground.generatedToast", {
-              count: result.images.length,
-              model: result.model,
-            }),
-          ),
+        onSuccess: (result) => {
+          // 部分失败：成功的图已落盘画廊，warning 说明有几张没成，别当整体失败。
+          if (result.failed > 0) {
+            toast.warning(
+              t("loongport.imagegenPlayground.partialFailureToast", {
+                count: result.images.length,
+                failed: result.failed,
+                model: result.model,
+              }),
+            );
+          } else {
+            toast.success(
+              t("loongport.imagegenPlayground.generatedToast", {
+                count: result.images.length,
+                model: result.model,
+              }),
+            );
+          }
+        },
         onError: (e) => toast.error(String(e)),
       },
     );
@@ -108,40 +142,73 @@ export function ImagegenPlayground() {
 
   return (
     <div className="space-y-4">
-      {/* 档位快切：显示名是「站点 · 分组」，模型随档位走，不提供独立模型下拉。 */}
+      {/* 档位快切：可输入筛选的 Combobox（形状抄 ModelPicker 的 Command-in-Popover）。
+          行内带模型与倍率 —— 倍率是后端算好的事实，null（未知）不显示，绝不当 0。 */}
       <div className="flex flex-wrap items-center gap-2">
-        <Label
-          htmlFor="imagegen-tier-select"
-          className="text-xs text-muted-foreground"
-        >
+        <Label className="text-xs text-muted-foreground">
           {t("loongport.imagegenPlayground.tierLabel")}
         </Label>
-        <Select
-          value={currentTier?.providerId ?? ""}
-          onValueChange={(providerId) => {
-            const tier = tiers.find(
-              (candidate) => candidate.providerId === providerId,
-            );
-            if (tier) void switchTier(tier.providerId, tier.displayName);
-          }}
-          disabled={tiers.length === 0}
-        >
-          <SelectTrigger id="imagegen-tier-select" className="w-[280px]">
-            <SelectValue
-              placeholder={t("loongport.imagegenPlayground.noTier")}
-            />
-          </SelectTrigger>
-          <SelectContent>
-            {tiers.map((tier) => (
-              <SelectItem key={tier.providerId} value={tier.providerId}>
-                {tier.displayName}
-                <span className="ml-1.5 text-xs text-muted-foreground">
-                  {tier.model}
-                </span>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <Popover open={tierPickerOpen} onOpenChange={setTierPickerOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              role="combobox"
+              aria-expanded={tierPickerOpen}
+              disabled={tiers.length === 0}
+              className="w-[280px] justify-between font-normal"
+            >
+              <span className="truncate">
+                {currentTier?.displayName ??
+                  t("loongport.imagegenPlayground.noTier")}
+              </span>
+              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-[320px] p-0" align="start">
+            <Command label={t("loongport.imagegenPlayground.tierLabel")}>
+              <CommandInput
+                placeholder={t(
+                  "loongport.imagegenPlayground.tierFilterPlaceholder",
+                )}
+              />
+              <CommandList>
+                <CommandEmpty>
+                  {t("loongport.imagegenPlayground.tierFilterEmpty")}
+                </CommandEmpty>
+                <CommandGroup>
+                  {tiers.map((tier) => (
+                    <CommandItem
+                      key={tier.providerId}
+                      value={tier.providerId}
+                      keywords={[tier.displayName, tier.model]}
+                      onSelect={() => {
+                        setTierPickerOpen(false);
+                        void switchTier(tier.providerId, tier.displayName);
+                      }}
+                    >
+                      <Check
+                        className={cn(
+                          "mr-2 h-4 w-4 shrink-0",
+                          currentTier?.providerId === tier.providerId
+                            ? "opacity-100"
+                            : "opacity-0",
+                        )}
+                      />
+                      <span className="min-w-0 flex-1 truncate">
+                        {tier.displayName}
+                      </span>
+                      <span className="ml-2 shrink-0 text-xs text-muted-foreground">
+                        {tier.model}
+                        {tier.rateMultiplier !== null &&
+                          ` · ${t("loongport.tier.rate", { value: tier.rateMultiplier })}`}
+                      </span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
       </div>
 
       {tiers.length === 0 ? (
@@ -173,23 +240,26 @@ export function ImagegenPlayground() {
                 ))}
               </SelectContent>
             </Select>
-            {/* 批量张数：一次点下去就是 n 张的钱，hint 把后果写在点上（计费/耗时）。 */}
-            <Select value={count} onValueChange={setCount}>
-              <SelectTrigger
-                className="w-[110px]"
-                aria-label={t("loongport.imagegenPlayground.countLabel")}
-                title={t("loongport.imagegenPlayground.countHint")}
-              >
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {COUNT_OPTIONS.map((option) => (
-                  <SelectItem key={option} value={option}>
-                    ×{option}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            {/* 批量张数：自由输入（1-50，后端闸）。一次点下去就是 n 张的钱，
+                hint 把后果写在点上；>4 张后端自动拆并发单张，耗时 ≈ 张数/4 × 单张。 */}
+            <Input
+              type="number"
+              inputMode="numeric"
+              min={1}
+              max={50}
+              value={count}
+              onChange={(e) => setCount(e.target.value)}
+              onBlur={() => {
+                // 失焦时夹回合法域：空/非法回落 1，越界夹到边界 ——
+                // 真正的闸在后端，这里只是不把显然非法的值发出去。
+                const parsed = Number.parseInt(count, 10);
+                if (Number.isNaN(parsed)) setCount("1");
+                else setCount(String(Math.min(50, Math.max(1, parsed))));
+              }}
+              aria-label={t("loongport.imagegenPlayground.countLabel")}
+              title={t("loongport.imagegenPlayground.countHint")}
+              className="w-[80px]"
+            />
             <Button
               type="button"
               onClick={onGenerate}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3442,7 +3442,7 @@
       "companionNotice": "Generate images here, or from CLI chats",
       "companionDetail": "The Generate view creates images directly, without going through any CLI session; image and chat connection profiles are independent, and switches take effect on the next generation.",
       "emptyTitle": "No image-generation connection profiles",
-      "emptyBody": "When you create connection profiles, LoongPort identifies groups that support only gpt-image models. If your relay service does not offer such a group, this page remains empty.",
+      "emptyBody": "When creating connection profiles, LoongPort recognizes groups that only serve image models (gpt-image, grok-imagine, etc.). If the relay site offers no such group, this page stays empty.",
       "mcpSwitchLabel": "Offer the image tool in Codex / Claude chats",
       "mcpSwitchHint": "Turn off to stop registering the tool with CLIs (direct generation here is unaffected); after enabling, open a new terminal to load it"
     },
@@ -3453,11 +3453,13 @@
       },
       "tierLabel": "Current profile",
       "noTier": "Not selected",
-      "noTierHint": "No image connection profiles yet — they are created from groups that only serve gpt-image models.",
+      "noTierHint": "No image connection profiles yet — they are created from groups that only serve image models (gpt-image, grok-imagine, etc.).",
+      "tierFilterPlaceholder": "Filter by site or model…",
+      "tierFilterEmpty": "No matching connection profiles",
       "promptPlaceholder": "Describe the image to generate…",
       "sizeLabel": "Size",
       "countLabel": "Count",
-      "countHint": "Generates several at once: billed per image, and slower (roughly 30s to 2min each)",
+      "countHint": "Generate several at once (1-50): billed per image; more than 4 are submitted concurrently, taking about (count / 4) × single-image time",
       "generate": "Generate",
       "generating": "Generating…",
       "generateHint": "Generation is slow — usually 30 seconds to 2 minutes",
@@ -3465,7 +3467,8 @@
       "galleryTitle": "History",
       "galleryLoading": "Loading…",
       "galleryEmpty": "No images generated yet",
-      "reveal": "Reveal in folder"
+      "reveal": "Reveal in folder",
+      "partialFailureToast": "Generated {{count}} image(s) ({{model}}); {{failed}} failed"
     },
     "siteConfig": {
       "entry": "Import site config",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3442,7 +3442,7 @@
       "companionNotice": "このページで直接生成、または CLI 会話から生成",
       "companionDetail": "生成ビューでは CLI セッションを経由せず画像を生成します。画像生成とチャットの接続プロファイルは互いに独立で、切り替えは次回の生成から反映されます。",
       "emptyTitle": "画像生成用の接続プロファイルがありません",
-      "emptyBody": "接続プロファイルの作成時に、LoongPort は gpt-image モデルのみに対応するグループを識別します。中継サービスに該当するグループがない場合、このページは空のままです。",
+      "emptyBody": "接続プロファイル作成時、LoongPort は画像生成モデル（gpt-image、grok-imagine など）のみのグループを認識します。中継サイトにこうしたグループがない場合、このページは空のままです。",
       "mcpSwitchLabel": "Codex / Claude の会話に画像生成ツールを提供",
       "mcpSwitchHint": "オフにすると CLI への登録を停止します（このページでの直接生成には影響しません）。オンにした後は新しいターミナルで読み込まれます"
     },
@@ -3453,11 +3453,13 @@
       },
       "tierLabel": "現在の接続プロファイル",
       "noTier": "未選択",
-      "noTierHint": "画像生成の接続プロファイルはまだありません。gpt-image 系モデルのみのグループから自動的に作られます。",
+      "noTierHint": "画像生成の接続プロファイルはまだありません。画像生成モデル（gpt-image、grok-imagine など）のみのグループから自動的に作られます。",
+      "tierFilterPlaceholder": "サイト名やモデル名で絞り込み…",
+      "tierFilterEmpty": "一致する接続プロファイルはありません",
       "promptPlaceholder": "生成する画像を説明してください…",
       "sizeLabel": "サイズ",
       "countLabel": "枚数",
-      "countHint": "複数枚を一度に生成：枚数分の課金になり、時間もかかります（1 枚 30 秒〜2 分程度）",
+      "countHint": "一度に複数枚生成（1-50）：枚数分の課金になります。5 枚以上は自動で並列リクエストに分割され、所要時間は約「枚数÷4 × 1 枚の時間」です",
       "generate": "生成",
       "generating": "生成中…",
       "generateHint": "生成には時間がかかります（30 秒〜2 分程度）",
@@ -3465,7 +3467,8 @@
       "galleryTitle": "生成履歴",
       "galleryLoading": "読み込み中…",
       "galleryEmpty": "まだ生成した画像はありません",
-      "reveal": "フォルダで表示"
+      "reveal": "フォルダで表示",
+      "partialFailureToast": "{{count}} 枚を生成しました（{{model}}）、{{failed}} 枚が失敗"
     },
     "siteConfig": {
       "entry": "サイト設定を取り込む",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3443,7 +3443,7 @@
       "companionNotice": "本頁可直接生圖，也可在 CLI 對話中生圖",
       "companionDetail": "生成視圖直接出圖，不經過 CLI 會話；生圖與聊天各用各的連線設定檔，切換後下次生成即生效。",
       "emptyTitle": "尚無圖像生成連線設定檔",
-      "emptyBody": "建立連線設定檔時，LoongPort 會識別只支援 gpt-image 模型的群組。若中轉站未提供這類群組，此頁面將保持空白。",
+      "emptyBody": "建立連線設定檔時，LoongPort 會識別僅含生圖模型（gpt-image、grok-imagine 等）的分組。若中轉站未提供這類分組，本頁將保持為空。",
       "mcpSwitchLabel": "在 Codex / Claude 對話中提供生圖工具",
       "mcpSwitchHint": "關閉後不再註冊到 CLI（本頁直接生圖不受影響）；首次開啟後需新開終端載入"
     },
@@ -3454,11 +3454,13 @@
       },
       "tierLabel": "目前連線設定檔",
       "noTier": "未選擇",
-      "noTierHint": "還沒有生圖連線設定檔；僅支援 gpt-image 模型的分組會自動產生。",
+      "noTierHint": "還沒有生圖連線設定檔；僅含生圖模型（gpt-image、grok-imagine 等）的分組會自動產生。",
+      "tierFilterPlaceholder": "輸入站點或模型篩選…",
+      "tierFilterEmpty": "沒有符合的連線設定檔",
       "promptPlaceholder": "描述要生成的圖片…",
       "sizeLabel": "尺寸",
       "countLabel": "張數",
-      "countHint": "一次生成多張：按張數計費，也會更慢（每張約半分鐘到兩分鐘）",
+      "countHint": "一次生成多張（1-50）：按張數計費；超過 4 張自動並發提交，耗時約等於張數÷4 乘單張時間",
       "generate": "生成",
       "generating": "生成中…",
       "generateHint": "生圖較慢，通常需要半分鐘到兩分鐘",
@@ -3466,7 +3468,8 @@
       "galleryTitle": "生成記錄",
       "galleryLoading": "載入中…",
       "galleryEmpty": "還沒有生成過圖片",
-      "reveal": "在資料夾中顯示"
+      "reveal": "在資料夾中顯示",
+      "partialFailureToast": "已生成 {{count}} 張（{{model}}），{{failed}} 張失敗"
     },
     "siteConfig": {
       "entry": "匯入站點設定",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -3442,7 +3442,7 @@
       "companionNotice": "本页可直接生图，也可在 CLI 对话中生图",
       "companionDetail": "生成视图直接出图，不经过 CLI 会话；生图与聊天各用各的接入配置，切换后下次生成即生效。",
       "emptyTitle": "尚无图像生成接入配置",
-      "emptyBody": "创建接入配置时，LoongPort 会识别仅支持 gpt-image 模型的分组。若中转站未提供这类分组，本页将保持为空。",
+      "emptyBody": "创建接入配置时，LoongPort 会识别仅含生图模型（gpt-image、grok-imagine 等）的分组。若中转站未提供这类分组，本页将保持为空。",
       "mcpSwitchLabel": "在 Codex / Claude 对话中提供生图工具",
       "mcpSwitchHint": "关闭后不再注册到 CLI（本页直接生图不受影响）；首次开启后需新开终端加载"
     },
@@ -3453,11 +3453,13 @@
       },
       "tierLabel": "当前接入配置",
       "noTier": "未选择",
-      "noTierHint": "还没有生图接入配置；仅支持 gpt-image 模型的分组会自动产生。",
+      "noTierHint": "还没有生图接入配置；仅含生图模型（gpt-image、grok-imagine 等）的分组会自动产生。",
+      "tierFilterPlaceholder": "输入站点或模型筛选…",
+      "tierFilterEmpty": "没有匹配的接入配置",
       "promptPlaceholder": "描述要生成的图片…",
       "sizeLabel": "尺寸",
       "countLabel": "张数",
-      "countHint": "一次生成多张：按张数计费，也会更慢（每张约半分钟到两分钟）",
+      "countHint": "一次生成多张（1-50）：按张数计费；超过 4 张自动并发提交，耗时约等于张数÷4 乘单张时间",
       "generate": "生成",
       "generating": "生成中…",
       "generateHint": "生图较慢，通常需要半分钟到两分钟",
@@ -3465,7 +3467,8 @@
       "galleryTitle": "生成记录",
       "galleryLoading": "加载中…",
       "galleryEmpty": "还没有生成过图片",
-      "reveal": "在文件夹中显示"
+      "reveal": "在文件夹中显示",
+      "partialFailureToast": "已生成 {{count}} 张（{{model}}），{{failed}} 张失败"
     },
     "siteConfig": {
       "entry": "导入站点配置",

--- a/src/lib/api/relay.ts
+++ b/src/lib/api/relay.ts
@@ -676,11 +676,13 @@ export interface ImagegenImageRef {
   mime: string;
 }
 
-/** `relayImagegenGenerate` 的返回：这次用了哪个档位/模型、图片落在哪。 */
+/** `relayImagegenGenerate` 的返回：这次用了哪个档位/模型、图片落在哪、几张没成。 */
 export interface ImagegenGenerateResult {
   tierName: string;
   model: string;
   images: ImagegenImageRef[];
+  /** 部分失败的张数（批量并发下成功的那部分已落盘）。 */
+  failed: number;
 }
 
 /** 画廊里一张图的元数据（路径 / 格式 / 大小 / mtime，均由后端给出）。 */

--- a/tests/config/loongportLocales.test.ts
+++ b/tests/config/loongportLocales.test.ts
@@ -368,11 +368,16 @@ const requiredKeys = [
   "imagegenPlayground.tierLabel",
   "imagegenPlayground.noTier",
   "imagegenPlayground.noTierHint",
+  // 档位快切 Combobox 的筛选占位与空态（照中转站广场的筛选交互）。
+  "imagegenPlayground.tierFilterPlaceholder",
+  "imagegenPlayground.tierFilterEmpty",
   "imagegenPlayground.promptPlaceholder",
   "imagegenPlayground.sizeLabel",
-  // 批量张数的计费/耗时提示是知情前提 —— 缺了它「×4」就是个不知价格的按钮。
+  // 批量张数的计费/耗时提示是知情前提 —— 缺了它自由输入就是个不知价格的框；
+  // 部分失败 toast 是「成功的已到手、几张没成」的唯一交代。
   "imagegenPlayground.countLabel",
   "imagegenPlayground.countHint",
+  "imagegenPlayground.partialFailureToast",
   "imagegenPlayground.generate",
   "imagegenPlayground.generating",
   "imagegenPlayground.generateHint",


### PR DESCRIPTION
## Summary / 概述

生图页四项补强：

1. **grok 生图准入**：判据照抄上游 sub2api `isGrokImageGenerationModel`（`grok-imagine` / `grok-imagine-edit` 精确 + `grok-imagine-image*` 前缀；`-video` 不在白名单）。中转站的 grok 生图挂 openai 平台分组，与 GPT 族同一条 `/v1/images/generations` 链路；纯 grok 分组正确落生图栏并选自己的模型
2. **档位快切 Combobox**：可输入搜索（照中转站广场的筛选体验，形状抄 ModelPicker），行内显示模型与倍率
3. **tab 独立生图图标**：violet 图片图标替换「OpenAI 标 + 角标」—— 生图不再从属单一 CLI
4. **自定义张数（1-50）+ 并发**：≤4 一条请求；>4 拆成并发单张请求（有界并发 4，防限流），总耗时 ≈ 张数÷4 × 单张。部分失败不整体报错（成功已落盘，toast / MCP 文案带失败张数），全部失败才报错。MCP 工具 schema 同步放开到 1-50

## Related Issue / 关联 Issue

无

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
