### PR TITLE
feat(imagegen): 自定义存储位置 + 换路径一次性迁移（历史不断）

### DIFF
--- a/src-tauri/src/commands/relay/imagegen.rs
+++ b/src-tauri/src/commands/relay/imagegen.rs
@@ -88,6 +88,82 @@ pub fn relay_imagegen_list_images(
     Ok(imagegen::gallery_images())
 }
 
+/// 当前生图存储目录（展示用，`PathBuf::to_string_lossy` 已是平台原生分隔符）。
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ImagegenOutputDir {
+    pub path: String,
+}
+
+/// `relay_imagegen_set_output_dir` 的返回：切换到了哪、搬迁模式下搬过去几张。
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct ImagegenOutputDirSwitchResult {
+    pub path: String,
+    pub moved: usize,
+}
+
+/// 读当前生图存储目录。
+#[tauri::command]
+pub fn relay_imagegen_get_output_dir() -> Result<ImagegenOutputDir, String> {
+    Ok(ImagegenOutputDir {
+        path: imagegen::output_dir().to_string_lossy().to_string(),
+    })
+}
+
+/// 更改生图存储目录（绝对路径；`migrate` = 把旧目录里我们生成的图搬过去）。
+///
+/// 顺序是**先搬迁、验证都过了才写设置** —— 迁移失败时设置不变，目录还在原地，
+/// 用户重试幂等（同名跳过）。写入即生效：两条入口每次都现读 `imagegen::output_dir()`，
+/// codex 里的 MCP 不必重启。磁盘根目录与用户主目录拒绝（画廊会退化成无意义扫描）。
+#[tauri::command]
+pub fn relay_imagegen_set_output_dir(
+    app_handle: tauri::AppHandle,
+    path: String,
+    migrate: bool,
+) -> Result<ImagegenOutputDirSwitchResult, String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return Err("存储位置不能为空".into());
+    }
+    let target = std::path::PathBuf::from(trimmed);
+    if !target.is_absolute() {
+        return Err("存储位置必须是绝对路径".into());
+    }
+    // canonicalize：折叠 `..` 与软链成真实路径，顺带确认目录存在
+    // （目录选择对话框给的都存在，这里兜住别的入口）。
+    let canonical = target
+        .canonicalize()
+        .map_err(|e| format!("目录不存在：{e}"))?;
+    if canonical.parent().is_none() {
+        return Err("不能把磁盘根目录作为存储位置".into());
+    }
+    if canonical == crate::config::get_home_dir() {
+        return Err("不能把整个用户主目录作为存储位置".into());
+    }
+    let display = canonical.to_string_lossy().to_string();
+    let old = imagegen::output_dir();
+    if canonical == old {
+        return Ok(ImagegenOutputDirSwitchResult {
+            path: display,
+            moved: 0,
+        });
+    }
+    std::fs::create_dir_all(&canonical).map_err(|e| format!("创建目录失败: {e}"))?;
+    let moved = if migrate {
+        imagegen::migrate_images(&old, &canonical)?
+    } else {
+        0
+    };
+    crate::settings::set_imagegen_output_dir(display.clone())
+        .map_err(|e| format!("保存设置失败: {e}"))?;
+    imagegen::ensure_asset_scope(&app_handle);
+    Ok(ImagegenOutputDirSwitchResult {
+        path: display,
+        moved,
+    })
+}
+
 /// 在文件管理器里显示一张生成的图。
 ///
 /// 只接受出图目录内的路径 —— 这是个「打开本地文件」的命令，不该被拿去探测任意路径。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1680,6 +1680,8 @@ pub fn run() {
             commands::relay_imagegen_generate,
             commands::relay_imagegen_list_images,
             commands::relay_imagegen_reveal_image,
+            commands::relay_imagegen_get_output_dir,
+            commands::relay_imagegen_set_output_dir,
             commands::relay_set_imagegen_mcp_enabled,
             commands::relay_switch_tier,
             commands::relay_switch_tier_model,

--- a/src-tauri/src/relay/imagegen.rs
+++ b/src-tauri/src/relay/imagegen.rs
@@ -327,12 +327,36 @@ pub(crate) fn images_url(base_url: &str) -> String {
 
 /// 出的图存哪。
 ///
-/// 放 `<数据目录>/generated_images/`：与数据库同目录，用户找得到，也不会污染他当前
-/// 的工作目录（Agent 常在用户仓库里跑，往那里丢文件会进 git status）。
+/// 优先用户自定义（settings.json 设备级 `imagegenOutputDir`，生图页「更改存储位置」
+/// 写入）；缺省 `<数据目录>/generated_images/`：与数据库同目录，用户找得到，也不会
+/// 污染他当前的工作目录（Agent 常在用户仓库里跑，往那里丢文件会进 git status）。
 pub(crate) fn output_dir() -> PathBuf {
+    if let Some(custom) = custom_output_dir() {
+        return custom;
+    }
     // 同样走 `app_dir()` —— 用户把数据目录挪走了，图也该跟着落在那里，
     // 而不是散在默认目录（他会找不到）。
     app_dir().join("generated_images")
+}
+
+/// 设备级设置里的自定义出图目录（绝对路径字符串）。
+///
+/// 直读 settings.json **文件**而不是 `crate::settings` 的进程内缓存 —— 与
+/// [`device_level_image_tier`] 同一个理由：MCP 子进程没有主程序的启动流程，缓存恒为
+/// 空，读缓存会一直得到「没有自定义」⇒ MCP 把图写进默认目录而 App 看自定义目录，
+/// 两边静默分叉。读文件让两个进程天然一致，且换路径后 **codex 不必重启**
+/// （MCP 每次生图现读，与切档位同一好处）。
+fn custom_output_dir() -> Option<PathBuf> {
+    let path = crate::config::get_home_dir()
+        .join(crate::config::APP_DIR_NAME)
+        .join("settings.json");
+    let raw = std::fs::read_to_string(&path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    let dir = json.get("imagegenOutputDir")?.as_str()?.trim();
+    if dir.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(dir))
 }
 
 /// 一次请求的超时上限 = 每张图 [`SINGLE_IMAGE_TIMEOUT_SECS`] 的既证预算 × 张数。
@@ -636,6 +660,8 @@ pub struct GalleryImage {
 /// 扫描出图目录，按 mtime 从新到旧返回（画廊顺序）。
 ///
 /// 目录不存在视为空画廊，不是错误 —— 没生成过图是常态。
+/// 只认 [`is_image_file`]（我们自己的命名）—— 存储路径指到用户目录时，
+/// 他的文件不进画廊。
 pub(crate) fn gallery_images() -> Vec<GalleryImage> {
     let dir = output_dir();
     let Ok(entries) = std::fs::read_dir(&dir) else {
@@ -694,15 +720,72 @@ fn mime_from_extension(ext: &str) -> &'static str {
     }
 }
 
+/// 换存储位置时把旧目录里**我们生成的图**搬到新目录（一次性迁移）。
+///
+/// - 只搬 [`is_image_file`] 认的文件：旧目录若是用户自己的目录，他的东西不动。
+/// - 幂等：目标已有同名文件（内容寻址命名 ⇒ 同名即同内容）就跳过 ——
+///   中途失败重试不撞名、不重复占位；迁移发生在写设置**之前**，失败则设置不变。
+/// - 跨盘（如 C:→D:）`rename` 会失败，回落 copy + remove（对任何 rename 失败
+///   形态都安全）。
+/// - 返回实际搬过去的张数。
+pub(crate) fn migrate_images(from: &Path, to: &Path) -> Result<usize, String> {
+    std::fs::create_dir_all(to).map_err(|e| format!("创建新目录失败: {e}"))?;
+    let entries = std::fs::read_dir(from).map_err(|e| format!("读取旧目录失败: {e}"))?;
+    let mut moved = 0usize;
+    for entry in entries.filter_map(Result::ok) {
+        let path = entry.path();
+        if !is_image_file(&path) {
+            continue;
+        }
+        let Some(name) = path.file_name() else {
+            continue;
+        };
+        let dest = to.join(name);
+        if dest.exists() {
+            continue;
+        }
+        if std::fs::rename(&path, &dest).is_err() {
+            std::fs::copy(&path, &dest).map_err(|e| format!("复制图片失败: {e}"))?;
+            std::fs::remove_file(&path).map_err(|e| format!("删除旧图失败: {e}"))?;
+        }
+        moved += 1;
+    }
+    Ok(moved)
+}
+
+/// 这个文件是不是 **LoongPort 生成的图**：认 [`output_dir`] 里我们自己写的
+/// 内容寻址命名（`gpt-image-<12 位 hex>-<序号>.<图片扩展名>`，见 `generate_image`
+/// 的落盘处），不认「任何图片文件」。
+///
+/// ## 为什么必须按名字、不能按扩展名（自定义存储路径的安全前提）
+///
+/// 修剪（删最旧）和画廊都吃这个判据。用户一旦把存储路径指到**自己的目录**
+/// （比如放照片的文件夹），按扩展名过滤的修剪会把他自己的图当成「最旧的」
+/// **删掉**，画廊也会混进他的私人文件。按命名过滤则只认我们的产物：
+/// 用户目录里自己的文件永远不进画廊、永远不会被修剪碰到。
 fn is_image_file(path: &Path) -> bool {
-    path.extension()
-        .map(|ext| {
-            matches!(
-                ext.to_string_lossy().to_lowercase().as_str(),
-                "png" | "jpg" | "jpeg" | "webp" | "gif"
-            )
-        })
-        .unwrap_or(false)
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    let Some((stem, ext)) = name.rsplit_once('.') else {
+        return false;
+    };
+    if !matches!(
+        ext.to_ascii_lowercase().as_str(),
+        "png" | "jpg" | "jpeg" | "webp" | "gif"
+    ) {
+        return false;
+    }
+    let Some((prefix, index)) = stem.rsplit_once('-') else {
+        return false;
+    };
+    let Some(hash) = prefix.strip_prefix("gpt-image-") else {
+        return false;
+    };
+    hash.len() == 12
+        && hash.chars().all(|c| c.is_ascii_hexdigit())
+        && !index.is_empty()
+        && index.chars().all(|c| c.is_ascii_digit())
 }
 
 fn base64_decode(s: &str) -> Result<Vec<u8>, String> {
@@ -896,6 +979,61 @@ base_url = "https://api.example.com/v1"
         // 串行大批：不能合并（上游不收），逐张串行。
         assert_eq!(split_batch(5, false), (vec![1; 5], 1));
         assert_eq!(split_batch(50, false), (vec![1; 50], 1));
+    }
+
+    /// 只认自己写的内容寻址命名（`gpt-image-<12hex>-<序号>.<图片扩展名>`）——
+    /// 自定义存储路径的安全前提：用户的文件永远不进画廊、不被修剪碰到。
+    #[test]
+    fn is_image_file_only_recognizes_our_content_addressed_names() {
+        assert!(is_image_file(Path::new("/x/gpt-image-0123456789ab-0.png")));
+        assert!(is_image_file(Path::new("gpt-image-abcdef123456-12.webp")));
+        // 用户的图 / 命名形状不对的都不是我们的。
+        assert!(!is_image_file(Path::new("vacation.png")));
+        assert!(!is_image_file(Path::new("gpt-image-short-0.png")));
+        assert!(!is_image_file(Path::new("gpt-image-0123456789ab-x.png")));
+        assert!(!is_image_file(Path::new("gpt-image-0123456789ab.png")));
+        assert!(!is_image_file(Path::new("gpt-image-0123456789ab-0.txt")));
+    }
+
+    /// 迁移只搬我们的图、用户的文件留原地，且幂等（同名跳过，重试不撞）。
+    #[test]
+    fn migrate_moves_only_our_named_files_and_is_idempotent() {
+        let base = std::env::temp_dir().join(format!("lp-migrate-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let from = base.join("from");
+        let to = base.join("to");
+        std::fs::create_dir_all(&from).unwrap();
+        std::fs::write(from.join("gpt-image-0123456789ab-0.png"), b"a").unwrap();
+        std::fs::write(from.join("gpt-image-abcdef123456-1.webp"), b"b").unwrap();
+        std::fs::write(from.join("vacation.png"), b"mine").unwrap();
+        std::fs::write(from.join("notes.txt"), b"x").unwrap();
+
+        assert_eq!(migrate_images(&from, &to).unwrap(), 2);
+        assert!(to.join("gpt-image-0123456789ab-0.png").exists());
+        assert!(!from.join("gpt-image-0123456789ab-0.png").exists());
+        assert!(
+            from.join("vacation.png").exists() && from.join("notes.txt").exists(),
+            "用户的文件必须留在原地"
+        );
+
+        // 幂等：旧目录再出现同名文件（中途失败的残局）时目标已有同名 ⇒ 跳过。
+        std::fs::write(from.join("gpt-image-0123456789ab-0.png"), b"a").unwrap();
+        assert_eq!(migrate_images(&from, &to).unwrap(), 0);
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// ⭐ `imagegenOutputDir` 这个手抄的 JSON 键必须与 `AppSettings` 字段对得上
+    /// （serde camelCase 派生）。抄错 ⇒ 自定义路径永远读不到，图悄悄落回默认目录，
+    /// 而 App 与 MCP 两边一致地错 —— 没有任何东西会报错。
+    #[test]
+    fn the_output_dir_key_matches_the_settings_field() {
+        let settings_rs = include_str!("../settings.rs");
+        assert!(
+            settings_rs.contains("pub imagegen_output_dir: Option<String>"),
+            "`AppSettings::imagegen_output_dir` 改名了 —— `custom_output_dir` 里那个 \
+             camelCase 键名跟着改"
+        );
     }
 
     /// 同一份内容得到同一个名字（可复现），不同内容不撞名。

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -561,6 +561,13 @@ pub struct AppSettings {
     /// 生效点在 `relay::imagegen_mcp::sync_registration`（幂等，切开关即对齐）。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub imagegen_mcp_enabled: Option<bool>,
+    /// 生图文件的存储目录（**绝对路径**）。`None` = 默认 `<数据目录>/generated_images/`。
+    ///
+    /// 设备级（不进云同步 —— 另一台机器的磁盘布局不同）；由生图页「更改存储位置」
+    /// 写入。读取方是 `relay::imagegen::output_dir`（**直读 settings.json 文件**，
+    /// MCP 子进程没有主程序的设置缓存，读缓存会两边分叉）。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub imagegen_output_dir: Option<String>,
     /// 当前 Gemini 供应商 ID（本地存储，优先于数据库 is_current）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_provider_gemini: Option<String>,
@@ -677,6 +684,7 @@ impl Default for AppSettings {
             current_provider_codex: None,
             current_provider_codex_image: None,
             imagegen_mcp_enabled: None,
+            imagegen_output_dir: None,
             current_provider_gemini: None,
             current_provider_grokbuild: None,
             current_provider_opencode: None,
@@ -1160,6 +1168,15 @@ pub fn get_imagegen_mcp_enabled() -> bool {
 pub fn set_imagegen_mcp_enabled(enabled: bool) -> Result<(), AppError> {
     mutate_settings(|settings| {
         settings.imagegen_mcp_enabled = Some(enabled);
+    })
+}
+
+/// 设置生图存储目录并落盘（绝对路径，校验在命令层）。**写入即生效**：
+/// 两个入口（App 内与 MCP）每次生图/列表都现读 `imagegen::output_dir()`，
+/// 没有「要重启才认新路径」这回事。
+pub fn set_imagegen_output_dir(dir: String) -> Result<(), AppError> {
+    mutate_settings(|settings| {
+        settings.imagegen_output_dir = Some(dir);
     })
 }
 

--- a/src/components/relay/ImagegenPlayground.tsx
+++ b/src/components/relay/ImagegenPlayground.tsx
@@ -22,6 +22,7 @@ import { convertFileSrc } from "@tauri-apps/api/core";
 import {
   Check,
   ChevronsUpDown,
+  FolderInput,
   FolderOpen,
   Loader2,
   Sparkles,
@@ -62,12 +63,14 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { relayApi, type ImagegenGalleryEntry } from "@/lib/api";
+import { relayApi, settingsApi, type ImagegenGalleryEntry } from "@/lib/api";
 import {
   imagegenKeys,
   useImageTiers,
   useImagegenGallery,
   useImagegenGenerate,
+  useImagegenOutputDir,
+  useImagegenSetOutputDir,
 } from "@/lib/query/imagegen";
 
 /** 尺寸档位：gpt-image 的三档（与 MCP 工具的 size 语义一致，不给「自动」）。 */
@@ -78,6 +81,8 @@ export function ImagegenPlayground() {
   const queryClient = useQueryClient();
   const gallery = useImagegenGallery();
   const generate = useImagegenGenerate();
+  const outputDir = useImagegenOutputDir();
+  const setOutputDir = useImagegenSetOutputDir();
   const [prompt, setPrompt] = useState("");
   const [size, setSize] = useState<string>("1024x1024");
   const [count, setCount] = useState<string>("1");
@@ -85,6 +90,39 @@ export function ImagegenPlayground() {
   const [parallel, setParallel] = useState(true);
   const [preview, setPreview] = useState<ImagegenGalleryEntry | null>(null);
   const [tierPickerOpen, setTierPickerOpen] = useState(false);
+  // 存储位置迁移确认弹窗的待定目标（null = 不显示）。
+  const [dirConfirm, setDirConfirm] = useState<{
+    from: string;
+    to: string;
+  } | null>(null);
+
+  // 选目录 → 弹迁移确认（搬迁并切换 / 直接切换）。取消选择（null）什么都不做。
+  const handlePickOutputDir = async () => {
+    const picked = await settingsApi.pickDirectory(outputDir.data?.path);
+    if (!picked) return;
+    if (outputDir.data && picked === outputDir.data.path) return;
+    setDirConfirm({ from: outputDir.data?.path ?? "", to: picked });
+  };
+
+  const applyOutputDir = (migrate: boolean) => {
+    if (!dirConfirm) return;
+    const target = dirConfirm;
+    setDirConfirm(null);
+    setOutputDir.mutate(
+      { path: target.to, migrate },
+      {
+        onSuccess: (result) =>
+          toast.success(
+            migrate
+              ? t("loongport.imagegenPlayground.storageMovedToast", {
+                  count: result.moved,
+                })
+              : t("loongport.imagegenPlayground.storageSwitchedToast"),
+          ),
+        onError: (e) => toast.error(String(e)),
+      },
+    );
+  };
 
   // 档位列表与「档位」视图同一条命令（listRelays 按栏查，结果天然同质）。
   const tiersQuery = useImageTiers();
@@ -295,11 +333,31 @@ export function ImagegenPlayground() {
         </div>
       )}
 
-      {/* 画廊：MCP 生成的图也落在这里 —— 两个入口的产物汇成同一份记录。 */}
+      {/* 画廊：MCP 生成的图也落在这里 —— 两个入口的产物汇成同一份记录。
+          存储位置就近展示与更改（路径由后端给出，前端只展示）。 */}
       <section className="space-y-2">
-        <h3 className="text-sm font-medium">
-          {t("loongport.imagegenPlayground.galleryTitle")}
-        </h3>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h3 className="text-sm font-medium">
+            {t("loongport.imagegenPlayground.galleryTitle")}
+          </h3>
+          <div className="flex min-w-0 items-center gap-1.5 text-xs text-muted-foreground">
+            <span className="shrink-0">
+              {t("loongport.imagegenPlayground.storageLabel")}
+            </span>
+            <span className="truncate font-mono" title={outputDir.data?.path}>
+              {outputDir.data?.path ?? "…"}
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2 text-xs"
+              onClick={handlePickOutputDir}
+            >
+              {t("loongport.imagegenPlayground.storageChange")}
+            </Button>
+          </div>
+        </div>
         {gallery.isLoading ? (
           <p className="text-sm text-muted-foreground">
             {t("loongport.imagegenPlayground.galleryLoading")}
@@ -369,6 +427,57 @@ export function ImagegenPlayground() {
             >
               <FolderOpen className="h-4 w-4" />
               {t("loongport.imagegenPlayground.reveal")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* 存储位置迁移确认：形状与 SwitchTierConfirmDialog 同族（ghost→outline→主梯度）。
+          不做每图索引 —— 文件系统是唯一事实源，历史靠这一次性搬迁保住。 */}
+      <Dialog
+        open={dirConfirm != null}
+        onOpenChange={(open) => {
+          if (!open) setDirConfirm(null);
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {t("loongport.imagegenPlayground.storageDialog.title")}
+            </DialogTitle>
+            <DialogDescription>
+              {t("loongport.imagegenPlayground.storageDialog.body")}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-1 break-all text-xs">
+            <p className="font-mono text-muted-foreground">
+              {dirConfirm?.from}
+            </p>
+            <p className="font-mono">{dirConfirm?.to}</p>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setDirConfirm(null)}
+            >
+              {t("loongport.imagegenPlayground.storageDialog.cancel")}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={setOutputDir.isPending}
+              onClick={() => applyOutputDir(false)}
+            >
+              {t("loongport.imagegenPlayground.storageDialog.switchOnly")}
+            </Button>
+            <Button
+              type="button"
+              disabled={setOutputDir.isPending}
+              onClick={() => applyOutputDir(true)}
+            >
+              <FolderInput className="h-4 w-4" />
+              {t("loongport.imagegenPlayground.storageDialog.moveAndSwitch")}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3470,6 +3470,17 @@
       "galleryLoading": "Loading…",
       "galleryEmpty": "No images generated yet",
       "reveal": "Reveal in folder",
+      "storageLabel": "Stored in",
+      "storageChange": "Change",
+      "storageMovedToast": "Storage location changed; moved {{count}} image(s)",
+      "storageSwitchedToast": "Storage location changed",
+      "storageDialog": {
+        "title": "Change storage location",
+        "body": "New images will be stored in the new location. Move existing generated images there too?",
+        "cancel": "Cancel",
+        "switchOnly": "Switch only",
+        "moveAndSwitch": "Move & switch"
+      },
       "partialFailureToast": "Generated {{count}} image(s) ({{model}}); {{failed}} failed"
     },
     "siteConfig": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3470,6 +3470,17 @@
       "galleryLoading": "読み込み中…",
       "galleryEmpty": "まだ生成した画像はありません",
       "reveal": "フォルダで表示",
+      "storageLabel": "保存先",
+      "storageChange": "変更",
+      "storageMovedToast": "保存先を変更しました（{{count}} 枚を移動）",
+      "storageSwitchedToast": "保存先を変更しました",
+      "storageDialog": {
+        "title": "保存先の変更",
+        "body": "新しい場所が有効になると、以後の画像はそこに保存されます。既存の生成画像も移動しますか？",
+        "cancel": "キャンセル",
+        "switchOnly": "切り替えのみ",
+        "moveAndSwitch": "移動して切り替え"
+      },
       "partialFailureToast": "{{count}} 枚を生成しました（{{model}}）、{{failed}} 枚が失敗"
     },
     "siteConfig": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3471,6 +3471,17 @@
       "galleryLoading": "載入中…",
       "galleryEmpty": "還沒有生成過圖片",
       "reveal": "在資料夾中顯示",
+      "storageLabel": "儲存位置",
+      "storageChange": "變更",
+      "storageMovedToast": "已切換儲存位置，搬遷 {{count}} 張圖片",
+      "storageSwitchedToast": "已切換儲存位置",
+      "storageDialog": {
+        "title": "變更儲存位置",
+        "body": "新位置啟用後，之後產生的圖片都存在那裡。要把已產生的圖片也搬過去嗎？",
+        "cancel": "取消",
+        "switchOnly": "直接切換",
+        "moveAndSwitch": "搬遷並切換"
+      },
       "partialFailureToast": "已生成 {{count}} 張（{{model}}），{{failed}} 張失敗"
     },
     "siteConfig": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -3470,6 +3470,17 @@
       "galleryLoading": "加载中…",
       "galleryEmpty": "还没有生成过图片",
       "reveal": "在文件夹中显示",
+      "storageLabel": "存储位置",
+      "storageChange": "更改",
+      "storageMovedToast": "已切换存储位置，搬迁 {{count}} 张图片",
+      "storageSwitchedToast": "已切换存储位置",
+      "storageDialog": {
+        "title": "更改存储位置",
+        "body": "新位置启用后，之后生成的图片都存在那里。要把已生成的图片也搬过去吗？",
+        "cancel": "取消",
+        "switchOnly": "直接切换",
+        "moveAndSwitch": "搬迁并切换"
+      },
       "partialFailureToast": "已生成 {{count}} 张（{{model}}），{{failed}} 张失败"
     },
     "siteConfig": {

--- a/src/lib/api/relay.ts
+++ b/src/lib/api/relay.ts
@@ -668,10 +668,35 @@ export const relayApi = {
   imagegenRevealImage: (path: string): Promise<void> =>
     invoke("relay_imagegen_reveal_image", { path }),
 
+  /** 读当前生图存储目录（后端给出的原生分隔符路径，前端只展示）。 */
+  imagegenGetOutputDir: (): Promise<ImagegenOutputDir> =>
+    invoke("relay_imagegen_get_output_dir"),
+
+  /**
+   * 更改生图存储目录。`migrate` = 把旧目录里我们生成的图搬过去（幂等；
+   * 后端先搬迁再写设置，失败则设置不变）。写入即生效，MCP 侧不必重启 codex。
+   */
+  imagegenSetOutputDir: (
+    path: string,
+    migrate: boolean,
+  ): Promise<ImagegenOutputDirSwitchResult> =>
+    invoke("relay_imagegen_set_output_dir", { path, migrate }),
+
   /** 切换「在 CLI 对话中提供生图工具（MCP）」；后端落设置并立刻对齐注册。 */
   setImagegenMcpEnabled: (enabled: boolean): Promise<void> =>
     invoke("relay_set_imagegen_mcp_enabled", { enabled }),
 };
+
+/** 当前生图存储目录。 */
+export interface ImagegenOutputDir {
+  path: string;
+}
+
+/** 更改存储目录的结果：切换到了哪、搬迁模式下搬过去几张。 */
+export interface ImagegenOutputDirSwitchResult {
+  path: string;
+  moved: number;
+}
 
 /** 一张生成图片的落盘事实（直接生图结果与画廊条目共用形状）。 */
 export interface ImagegenImageRef {

--- a/src/lib/query/imagegen.ts
+++ b/src/lib/query/imagegen.ts
@@ -13,6 +13,8 @@ export const imagegenKeys = {
   gallery: ["imagegen", "gallery"] as const,
   /** 生图档位列表（与「档位」视图同一条 `listRelays` 命令，一个缓存两处用）。 */
   tiers: ["imagegen", "tiers"] as const,
+  /** 当前存储目录（展示行 + 更改入口）。 */
+  outputDir: ["imagegen", "outputDir"] as const,
 };
 
 /** 生图页共用一份的档位列表：生成视图的快切、页级的空态判定都读它。 */
@@ -59,6 +61,27 @@ export const useSetImagegenMcpEnabled = () => {
     mutationFn: (enabled: boolean) => relayApi.setImagegenMcpEnabled(enabled),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["settings"] });
+    },
+  });
+};
+
+/** 当前生图存储目录（展示用）。 */
+export const useImagegenOutputDir = () =>
+  useQuery({
+    queryKey: imagegenKeys.outputDir,
+    queryFn: () => relayApi.imagegenGetOutputDir(),
+    staleTime: Infinity,
+  });
+
+/** 更改存储目录（migrate = 把旧图搬过去）。成功后失效目录与画廊。 */
+export const useImagegenSetOutputDir = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ path, migrate }: { path: string; migrate: boolean }) =>
+      relayApi.imagegenSetOutputDir(path, migrate),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: imagegenKeys.outputDir });
+      void queryClient.invalidateQueries({ queryKey: imagegenKeys.gallery });
     },
   });
 };

--- a/tests/config/loongportLocales.test.ts
+++ b/tests/config/loongportLocales.test.ts
@@ -389,6 +389,16 @@ const requiredKeys = [
   "imagegenPlayground.galleryLoading",
   "imagegenPlayground.galleryEmpty",
   "imagegenPlayground.reveal",
+  // 存储位置：展示行、更改入口与迁移确认弹窗（搬迁/直接切换是知情取舍）。
+  "imagegenPlayground.storageLabel",
+  "imagegenPlayground.storageChange",
+  "imagegenPlayground.storageMovedToast",
+  "imagegenPlayground.storageSwitchedToast",
+  "imagegenPlayground.storageDialog.title",
+  "imagegenPlayground.storageDialog.body",
+  "imagegenPlayground.storageDialog.cancel",
+  "imagegenPlayground.storageDialog.switchOnly",
+  "imagegenPlayground.storageDialog.moveAndSwitch",
 ] as const;
 
 type Translations = Record<string, unknown>;


### PR DESCRIPTION
## Summary / 概述

生图文件支持**自定义存储位置**，换路径时以**一次性迁移**保住历史（不做每图索引，文件系统保持唯一事实源）：

1. **前置安全洞收紧**：画廊与修剪从「按图片扩展名」收紧为只认 LoongPort 自己的内容寻址命名（`gpt-image-<12位hash>-<序号>.<ext>`）。这是开自定义路径的前提 —— 用户把路径指到自己的照片目录后，他自己的文件永远不进画廊、永远不会被「保留 200 张」的修剪删掉
2. **存储位置设置**：settings.json 设备级 `imagegenOutputDir`（绝对路径，Windows / macOS 原生分隔符由 `PathBuf` 处理）；缺省仍为 `<数据目录>/generated_images/`。读取直读设置文件（MCP 子进程没有主程序缓存），**写入即生效，codex 不必重启**；asset 协议白名单与 reveal 包含校验自动跟随
3. **就近更改入口**：画廊标题旁「存储位置 <路径>［更改］」→ 目录选择 → 迁移确认弹窗：
   - **搬迁并切换**（主按钮）：把旧目录里我们生成的图搬过去 —— 只搬自己的命名、幂等（同名跳过，中断重试不撞）、跨盘回落 copy+remove；先搬迁再写设置，失败则设置不变
   - **直接切换**（outline）：旧图留在原处（Finder 里还在），新目录从空开始
4. 磁盘根目录与用户主目录拒绝（画廊会退化成无意义扫描）

## Related Issue / 关联 Issue

无

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
