### PR TITLE
fix(relay): 行级余额接进 site_balance_cache（SWR）——修开页转圈/查询失败

### DIFF
--- a/src-tauri/src/commands/relay/balance.rs
+++ b/src-tauri/src/commands/relay/balance.rs
@@ -69,12 +69,26 @@ pub(crate) fn relay_balance_inputs(
 ///
 /// **不返回 `Err`**（除了「这一行不存在」）：三条路都失败时回 `success:false`，
 /// 前端才有失败态可渲染、有刷新按钮可点。见 [`crate::relay::balance`] 模块文档。
+/// ## 读路径接进 `site_balance_cache`（2026-09-07 收口，修「没改透」）
+///
+/// 站点余额的唯一事实源是 [`crate::relay::balance`] 的缓存（看板 #283/#286 起
+/// 已走它）；本命令此前**每打一次都同步走全链路网络** —— 同一个事实两条读路径，
+/// 开页每行转圈、跨境抖动直接渲染成「查询失败」。现在同一张表：
+///
+/// - 缓存新鲜（TTL 内，含负缓存）→ **秒回缓存值**，零网络；
+/// - 缓存过期但有值 → 立即回旧值 + 踢后台单飞刷新（完成发
+///   `SITE_BALANCES_UPDATED`，前端失效重读）—— SWR；
+/// - 没进过缓存 / `force`（手动刷新按钮）→ 走下面的全链路解析，**结果写回缓存**
+///   （正/负都写），行路径从「旁路」变成「又一个写入方」。
+///
+/// 对账快照采样只在真查那条路上落（缓存命中没有新信息，不采样）。
 #[tauri::command]
 pub async fn relay_balance(
     app_handle: tauri::AppHandle,
     relay_id: i64,
+    force: Option<bool>,
 ) -> Result<balance::RowBalanceResult, String> {
-    relay_balance_impl(&app_handle, relay_id)
+    relay_balance_impl(&app_handle, relay_id, force.unwrap_or(false))
         .await
         .map_err(|error| error.to_string())
 }
@@ -82,6 +96,7 @@ pub async fn relay_balance(
 pub(crate) async fn relay_balance_impl<R: tauri::Runtime>(
     app_handle: &tauri::AppHandle<R>,
     relay_id: i64,
+    force: bool,
 ) -> Result<balance::RowBalanceResult, AppError> {
     let (relay, base_url, api_keys) = {
         let state = app_handle.state::<AppState>();
@@ -90,6 +105,25 @@ pub(crate) async fn relay_balance_impl<R: tauri::Runtime>(
         let (base_url, api_keys) = relay_balance_inputs(&state, &relay);
         (relay, base_url, api_keys)
     };
+
+    if !force {
+        let state = app_handle.state::<AppState>();
+        if let Some(entry) = balance::cached_site_balance(&state.db, &relay.site_origin) {
+            let fresh = chrono::Utc::now().timestamp() - entry.1 <= balance::SITE_BALANCE_TTL_SECS;
+            if !fresh {
+                // 过期：回旧值 + 后台刷（单飞/预算/事件都在那条链里；只用 sk，
+                // 不碰登录态 —— 充值窗口的 cookie 独占权不受影响）。
+                if let Some(key) = api_keys.first() {
+                    balance::spawn_stale_refresh(
+                        state.db.clone(),
+                        Some(app_handle.clone()),
+                        std::collections::HashMap::from([(relay.site_origin.clone(), key.clone())]),
+                    );
+                }
+            }
+            return Ok(balance::cached_row_balance_result(&entry));
+        }
+    }
 
     let usage = balance::resolve(
         balance::BalanceQuery {
@@ -107,9 +141,24 @@ pub(crate) async fn relay_balance_impl<R: tauri::Runtime>(
     .await
     .usage;
 
-    // 余额快照是扣费对账的旁路采样，挂在成功解析之后：写入条件与失败兜底都在
-    // `reconcile::capture_balance_snapshot` 里，这里只出一条调用，不拖垮余额显示。
-    reconcile::capture_balance_snapshot(&app_handle.state::<AppState>().db, relay_id, &usage);
+    {
+        // 真查的结果写回缓存（正/负都写）—— 行路径与看板/后台刷新写同一张表，
+        // 这是「一个事实一个 owner」的落点。快照采样保持只挂真查。
+        let state = app_handle.state::<AppState>();
+        let cached_value = usage
+            .data
+            .as_ref()
+            .and_then(|items| items.first())
+            .and_then(|item| item.remaining);
+        if let Err(e) = balance::upsert_site_balance(
+            &state.db,
+            &relay.site_origin,
+            (cached_value, chrono::Utc::now().timestamp()),
+        ) {
+            log::warn!("[site-balance] 行查询写缓存失败: {e}");
+        }
+        reconcile::capture_balance_snapshot(&state.db, relay_id, &usage);
+    }
 
     Ok(balance::row_balance_result(usage, true))
 }
@@ -125,6 +174,66 @@ mod tests {
             "/api/v1/user/profile",
             get(move || async move { Json(balance) }),
         )
+    }
+
+    /// 行级余额读路径接进 site_balance_cache 后的行为闸：
+    /// TTL 内第二次查询**秒回缓存**（mock 服务只被打一次），`force` 旁路缓存直查。
+    /// 这条守的是「开页不再每行转圈 / 抖动不再渲染成查询失败」的用户可见语义。
+    #[tokio::test]
+    async fn row_balance_serves_cache_within_ttl_and_force_bypasses() {
+        use std::sync::atomic::AtomicUsize;
+        use std::sync::atomic::Ordering;
+
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_for_router = hits.clone();
+        let counting_router = {
+            use axum::{routing::get, Json, Router};
+            let balance = serde_json::json!({
+                "code": 0, "message": "success",
+                "data": { "id": 7, "username": "u", "email": "u@example.com",
+                          "balance": 3.25, "frozen_balance": 0.0 }
+            });
+            Router::new().route(
+                "/api/v1/user/profile",
+                get(move || async move {
+                    hits_for_router.fetch_add(1, Ordering::SeqCst);
+                    Json(balance)
+                }),
+            )
+        };
+        let (origin, _server) = spawn_balance_server(counting_router).await;
+        let (app, relay_id) = saved_relay_app(&origin, discovery::BackendKind::Sub2Api);
+
+        // 第一次：缓存空 → 走真查（网络一次），结果写缓存。
+        let first = relay_balance_impl(app.handle(), relay_id, false)
+            .await
+            .expect("first resolve");
+        assert!(first.usage.success);
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+
+        // 第二次：TTL 内 → 秒回缓存，网络零新增。
+        let second = relay_balance_impl(app.handle(), relay_id, false)
+            .await
+            .expect("cached read");
+        assert!(second.usage.success, "缓存正条目也要能拼出成功展示");
+        assert_eq!(
+            second
+                .usage
+                .data
+                .as_ref()
+                .and_then(|i| i.first())
+                .and_then(|i| i.remaining),
+            Some(3.25),
+            "缓存读回同一个数"
+        );
+        assert_eq!(hits.load(Ordering::SeqCst), 1, "TTL 内不该再打网络");
+
+        // force：手动刷新语义 → 旁路缓存直查（网络第二次）。
+        let forced = relay_balance_impl(app.handle(), relay_id, true)
+            .await
+            .expect("forced resolve");
+        assert!(forced.usage.success);
+        assert_eq!(hits.load(Ordering::SeqCst), 2, "force 必须真的重新查");
     }
 
     #[tokio::test]
@@ -143,7 +252,7 @@ mod tests {
         .await;
         let (app, relay_id) = saved_relay_app(&origin, discovery::BackendKind::Sub2Api);
 
-        let result = relay_balance_impl(app.handle(), relay_id)
+        let result = relay_balance_impl(app.handle(), relay_id, false)
             .await
             .expect("成功解析必须 Ok");
 
@@ -170,7 +279,7 @@ mod tests {
         let (origin, server) = spawn_balance_server(router).await;
         let (app, relay_id) = saved_relay_app(&origin, discovery::BackendKind::Sub2Api);
 
-        let result = relay_balance_impl(app.handle(), relay_id)
+        let result = relay_balance_impl(app.handle(), relay_id, false)
             .await
             .expect("失败路回 success:false，仍是 Ok");
 
@@ -211,7 +320,7 @@ mod tests {
                 .expect("删表制造写入失败");
         }
 
-        let result = relay_balance_impl(app.handle(), relay_id)
+        let result = relay_balance_impl(app.handle(), relay_id, false)
             .await
             .expect("快照写入失败时余额命令仍必须 Ok");
         assert!(result.usage.success);

--- a/src-tauri/src/commands/relay/session.rs
+++ b/src-tauri/src/commands/relay/session.rs
@@ -390,7 +390,9 @@ async fn refresh_relay_outcome(
     } else {
         None
     };
-    let balance = relay_balance_impl(app_handle, relay_id).await;
+    // force：这是用户显式动作（刷新/获取密钥）链路的一环 —— 要真值不要缓存；
+    // 充值关窗那条路（refresh_after_purchase）已把旧缓存删掉，这里也不会读到旧值。
+    let balance = relay_balance_impl(app_handle, relay_id, true).await;
     RelayRefreshOutcome {
         name,
         row_id: relay_id,

--- a/src-tauri/src/relay/balance.rs
+++ b/src-tauri/src/relay/balance.rs
@@ -347,6 +347,52 @@ pub fn cached_site_balances(
     }
 }
 
+/// 读单站缓存（行级余额条的读路径）。`None` = 没进过缓存。
+pub fn cached_site_balance(
+    db: &crate::database::Database,
+    origin: &str,
+) -> Option<SiteBalanceEntry> {
+    let conn = db
+        .conn
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    conn.query_row(
+        "SELECT balance_usd, fetched_at FROM site_balance_cache WHERE site_origin = ?1",
+        rusqlite::params![origin],
+        |row| Ok((row.get::<_, Option<f64>>(0)?, row.get::<_, i64>(1)?)),
+    )
+    .ok()
+}
+
+/// 从缓存条目拼行级展示结果（正/负缓存同一入口）。
+///
+/// 负缓存（`balance = None`）的失败文案是泛化的 —— 具体错误原因不进缓存
+/// （会过期、也占库），前端 keep-last-good 与手动刷新（force 旁路）兜住展示。
+pub fn cached_row_balance_result(entry: &SiteBalanceEntry) -> RowBalanceResult {
+    let usage = match entry.0 {
+        Some(balance) => UsageResult {
+            success: true,
+            data: Some(vec![UsageData {
+                plan_name: None,
+                extra: None,
+                is_valid: None,
+                invalid_message: None,
+                total: None,
+                used: None,
+                remaining: Some(balance),
+                unit: Some("USD".to_string()),
+            }]),
+            error: None,
+        },
+        None => UsageResult {
+            success: false,
+            data: None,
+            error: Some("最近一次查询没有取到可用余额".to_string()),
+        },
+    };
+    row_balance_result(usage, true)
+}
+
 /// 幂等写一行（含负缓存）。
 pub fn upsert_site_balance(
     db: &crate::database::Database,

--- a/src/components/relay/RelaySection.tsx
+++ b/src/components/relay/RelaySection.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import {
   relayApi,
   PURCHASE_CLOSED,
+  SITE_BALANCES_UPDATED,
   VENDOR_LOGIN_ERROR,
   VENDOR_ACCOUNTS_CHANGED,
   PROVIDER_SWITCHED,
@@ -354,6 +355,12 @@ export function RelaySection({ appId, onOpenAddHub }: RelaySectionProps) {
     void queryClient.invalidateQueries({
       queryKey: rowBalanceKeys.row("relay", relayId),
     });
+  });
+
+  // 站点余额后台刷新完成（SWR 补值时机）：站点余额跨行/跨 app 共享，
+  // 失效全部行级余额 query —— 行条与看板读的是同一张缓存表，一起收到新值。
+  useTauriEvent(SITE_BALANCES_UPDATED, () => {
+    void queryClient.invalidateQueries({ queryKey: rowBalanceKeys.all });
   });
 
   /**

--- a/src/components/relay/__tests__/RelaySection.modelVerification.test.tsx
+++ b/src/components/relay/__tests__/RelaySection.modelVerification.test.tsx
@@ -41,6 +41,7 @@ vi.mock("@/lib/api", () => ({
   VENDOR_LOGIN_ERROR: "vendor-login-error",
   VENDOR_ACCOUNTS_CHANGED: "vendor-accounts-changed",
   PROVIDER_SWITCHED: "provider-switched",
+  SITE_BALANCES_UPDATED: "site-balances-updated",
 }));
 vi.mock("@/lib/api/vendor", () => ({
   DEEPSEEK_VENDOR_ID: "deepseek",

--- a/src/components/relay/__tests__/RowBalance.test.tsx
+++ b/src/components/relay/__tests__/RowBalance.test.tsx
@@ -87,7 +87,7 @@ describe("RowBalance", () => {
     );
 
     expect(await screen.findByText("42.50")).toBeInTheDocument();
-    expect(api.relayBalance).toHaveBeenCalledWith(1);
+    expect(api.relayBalance).toHaveBeenCalledWith(1, false);
   });
 
   /**

--- a/src/components/relay/useRowBalanceQuery.ts
+++ b/src/components/relay/useRowBalanceQuery.ts
@@ -58,10 +58,20 @@ export function useRowBalanceQuery(
 ) {
   const { enabled = true } = options;
 
+  // 手动刷新要真值：refetch 前把 force 置位，queryFn 消费一次即复位。
+  // （后端 relay 路径的缓存是 SWR —— TTL 内普通读秒回缓存；点刷新按钮必须
+  // 旁路它。vendor 路径后端无缓存，force 参数被忽略。）
+  const forceRef = useRef(false);
+
   const query = useQuery<RowBalanceResult>({
     queryKey: rowBalanceKeys.row(kind, rowId),
-    queryFn: async () =>
-      kind === "relay" ? relayApi.balance(rowId) : vendorApi.balance(rowId),
+    queryFn: async () => {
+      const force = forceRef.current;
+      forceRef.current = false;
+      return kind === "relay"
+        ? relayApi.balance(rowId, force)
+        : vendorApi.balance(rowId);
+    },
     enabled,
     refetchOnWindowFocus: false,
     // 与 `useUsageQuery` 同语义：后端只在**瞬时传输失败**时 reject，retry 在那时
@@ -99,6 +109,7 @@ export function useRowBalanceQuery(
     loading: query.isFetching,
     lastQueriedAt,
     refetch: async () => {
+      forceRef.current = true;
       await query.refetch();
     },
   };

--- a/src/lib/api/relay.ts
+++ b/src/lib/api/relay.ts
@@ -572,8 +572,12 @@ export const relayApi = {
    * ⚠️ **登录态过期也查得到**：后端前两步走 sk，不需要网页登录态。别在调用方
    * 按 `sessionExpired` 把这条路关掉。
    */
-  balance: (relayId: number): Promise<RowBalanceResult> =>
-    invoke("relay_balance", { relayId }),
+  /**
+   * `force = true` 绕过缓存直查（手动刷新按钮用）；缺省走 SWR ——
+   * 后端优先回 `site_balance_cache`（TTL 内秒回、过期回旧值并踢后台刷新）。
+   */
+  balance: (relayId: number, force = false): Promise<RowBalanceResult> =>
+    invoke("relay_balance", { relayId, force }),
 
   refresh: (relayId: number, app: AppId): Promise<RefreshResult> =>
     invoke("relay_refresh", { relayId, app }),

--- a/tests/components/ReconcileDialog.test.tsx
+++ b/tests/components/ReconcileDialog.test.tsx
@@ -234,7 +234,10 @@ describe("ReconcileDialog", () => {
       screen.getByRole("button", { name: "loongport.reconcile.sampleNow" }),
     );
     await waitFor(() =>
-      expect(invoke).toHaveBeenCalledWith("relay_balance", { relayId: 7 }),
+      expect(invoke).toHaveBeenCalledWith("relay_balance", {
+        relayId: 7,
+        force: false,
+      }),
     );
     // 采样完成前不重拉对账（先采样、后 invalidate 的顺序）。
     expect(reportCalls()).toHaveLength(1);

--- a/tests/lib/relayApiTargeting.test.ts
+++ b/tests/lib/relayApiTargeting.test.ts
@@ -80,6 +80,7 @@ describe("relayApi 的中转站定位参数", () => {
     await relayApi.balance(3);
     expect(invokeMock).toHaveBeenCalledWith("relay_balance", {
       relayId: 3,
+      force: false,
     });
   });
 


### PR DESCRIPTION
## 背景：用户实测反馈「生图页接入配置开页转圈/查询失败」

诊断实锤：#283/#286 建的 `site_balance_cache`（SWR：TTL 600s / 负缓存 / 单飞后台刷新 / 事件推送 / 启动预热）**只有看板在消费**；行级余额条（`relay_balance` 命令，中转站行与生图页档位视图共用）至今每次同步打全链路网络（登录态续期链 + 跨境往返）——同一个事实两条读路径，正是「数据源统一没改透」的那一块。

## 修法：行读路径接进同一张缓存（不是加轮询）

触发归属原则不变（合法触发仍是启动预热 + 业务事件 + 读时惰性 revalidate；PR #127 的禁轮询红线不碰——后台链只走 sk、不携带登录态）：

| 场景 | 行为 |
|---|---|
| 缓存新鲜（TTL 内，含负缓存） | **秒回缓存值，零网络**——开页不再转圈 |
| 缓存过期但有值 | 立即回旧值 + 踢后台单飞刷新（15s 预算），完成发 `SITE_BALANCES_UPDATED`，前端失效重读——SWR |
| 缺缓存（冷启动头几秒） | 走原全链路（今天的行为），**结果写回缓存**（正/负都写）——行路径从旁路变成又一个写入方 |
| `force`（手动刷新按钮 / 刷新·获取密钥链路） | 旁路缓存直查——用户显式动作要真值 |

配套：前端 `balance(force)` 透传、refetch 置位 force、`RelaySection` 监听 `SITE_BALANCES_UPDATED` 失效全部行余额 query（行条与看板同一次补值）；对账快照采样保持只挂真查（缓存命中没有新信息）。

## 用户可见效果

- 打开生图页/中转站页：余额条**立即**显示（缓存值），不再每行转圈；
- 跨境抖动不再渲染成「查询失败」（负缓存 + keep-last-good + 手动刷新兜底）；
- 点刷新按钮仍然真查（force）。

## 验证

六道闸全绿；新增行为闸：TTL 内第二次查询 mock 服务**零新增命中**、force 后真查一次。
