### PR TITLE
fix(ci): 修 release.yml 块标量缩进断裂（每次 push 的 failure 邮件根因）+ workflow 可解析闸

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,7 @@ jobs:
     name: Required Checks
     runs-on: ubuntu-latest
     if: always()
-    needs: [frontend, backend, backend-windows-wsl2]
+    needs: [frontend, backend, backend-windows-wsl2, workflow-lint]
     steps:
       - name: Gate on upstream results
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # 2026-09-07 实踩：release.yml 的正文块标量（body: |）里混进一行浅缩进文本，
+  # 整个文件 YAML 解析失败 ⇒ GitHub 对**每次 push** 报「workflow file issue」
+  # （0 秒失败、零 job、邮件轰炸），且下一次 tag push 会当场死在发版上。
+  # 本地六道闸不看 workflow 文件；frontend/backend job 又被路径过滤跳过
+  # （纯改 .github 的 PR 两边都不跑），所以这道闸必须独立、必跑。
+  workflow-lint:
+    name: Workflow syntax check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Parse all workflow files
+        run: |
+          python3 - <<'PY'
+          import glob, sys, yaml
+          failed = False
+          for path in sorted(glob.glob(".github/workflows/*.yml")):
+              try:
+                  yaml.safe_load(open(path))
+                  print(f"OK   {path}")
+              except Exception as e:
+                  failed = True
+                  print(f"FAIL {path}: {e}")
+          sys.exit(1 if failed else 0)
+          PY
+
   changes:
     name: Detect changed areas
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -879,7 +879,7 @@ jobs:
             - **Windows (x86_64)**: `LoongPort-${{ github.ref_name }}-Windows-Setup.exe`（安装版）或 `LoongPort-${{ github.ref_name }}-Windows-Portable.zip`（绿色版）
             - **Windows (ARM64)**: `LoongPort-${{ github.ref_name }}-Windows-arm64-Setup.exe`（安装版）或 `LoongPort-${{ github.ref_name }}-Windows-arm64-Portable.zip`（绿色版）
             - **Linux (x86_64)**: `LoongPort-${{ github.ref_name }}-Linux-x86_64.AppImage`（推荐）或 `LoongPort-${{ github.ref_name }}-Linux-x86_64.deb` / `.rpm`（手动安装，不参与应用内自动更新）
-  > ⚠️ **桌面版需要 Ubuntu 22.04 或更高**（依赖 webkit2gtk 4.1 与较新的 glibc）。**Ubuntu 20.04 及更老、或无桌面的服务器请用下面的 LoongPort-CLI**（静态单文件零依赖）。
+              > ⚠️ **桌面版需要 Ubuntu 22.04 或更高**（依赖 webkit2gtk 4.1 与较新的 glibc）。**Ubuntu 20.04 及更老、或无桌面的服务器请用下面的 LoongPort-CLI**（静态单文件零依赖）。
             - **Linux 服务器/老发行版 (x86_64)**: `LoongPort-CLI-${{ github.ref_name }}-Linux-x86_64.tar.gz`（静态单文件零依赖，Ubuntu 20.04 / 纯服务器可用：`loongport-cli --add-site <域名> --key <sk> [--app codex] [--model <id>]`）
 
             > 应用内会自动检查更新（启动后几秒，失败静默）；也可在「设置 → 关于」手动检查。


### PR DESCRIPTION
## Summary / 概述

修掉 GitHub 发 failure 邮件的根因，并加闸防再犯：

1. **根因**：`ae3cd3a1` 在 `release.yml` 的 `body: |` 块标量正文中插入的警告行只缩进了 **2 个空格**（块内容缩进是 12）——YAML 规则里浅缩进的非空行会终止块标量，这一行变成游离在 job 层的非法节点，**整个 release.yml 解析失败**。症状正是今天邮件里看到的：GitHub 对**每次 push**（分支与 main）报「workflow file issue」、0 秒失败、零个 job。tag push 还没撞上过这份坏文件（v6.17.1 在它之前），但**下一次发版会当场死**。修复 = 缩进对齐为列表项的延续内容（14 空格），文案原样保留。
2. **防再犯**：`ci.yml` 新增必跑的 `workflow-lint` job，用 PyYAML 解析全部 workflow 文件。本地六道闸不看 workflow 文件；frontend / backend job 又被路径过滤跳过（纯改 `.github` 的 PR 两边都不跑——正是本次事故的形态），所以这道闸必须独立且必跑。

## Related Issue / 关联 Issue

无

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查（未改前端代码）
- [x] `pnpm format:check` passes / 通过代码格式检查（未改前端代码）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（未改 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（无）
