### PR TITLE
fix(windows): NSIS 覆盖安装改为验证式等待可写，修每次升级弹「无法打开要写入的文件」

### DIFF
--- a/src-tauri/nsis/installer-hooks.nsh
+++ b/src-tauri/nsis/installer-hooks.nsh
@@ -1,11 +1,15 @@
-; LoongPort 从 per-user WiX/MSI 迁移到 NSIS 的一次性兼容层。
+; LoongPort 的 NSIS 安装钩子，目前承担两件事：
 ;
-; Tauri 自带的 NSIS 模板会检测旧 WiX 安装，但只枚举 HKLM 的 Uninstall 键；
-; LoongPort 的历史 MSI 使用 InstallScope="perUser"，产品登记在 HKCU，因此会被漏掉。
-; 这里不用 DisplayName 模糊匹配，而用历史 MSI 的稳定 UpgradeCode 精确枚举相关产品。
+; 1. 从 per-user WiX/MSI 迁移到 NSIS 的一次性兼容层。
+;    Tauri 自带的 NSIS 模板会检测旧 WiX 安装，但只枚举 HKLM 的 Uninstall 键；
+;    LoongPort 的历史 MSI 使用 InstallScope="perUser"，产品登记在 HKCU，因此会被漏掉。
+;    这里不用 DisplayName 模糊匹配，而用历史 MSI 的稳定 UpgradeCode 精确枚举相关产品。
 ;
-; UpgradeCode 来自 wix/per-user-main.wxs 的 {{upgrade_code}} 在正式构建中的展开值。
-; 它是已发布 MSI 的持久身份，不能修改或删除；否则老用户无法自动迁移。
+;    UpgradeCode 来自 wix/per-user-main.wxs 的 {{upgrade_code}} 在正式构建中的展开值。
+;    它是已发布 MSI 的持久身份，不能修改或删除；否则老用户无法自动迁移。
+;
+; 2. 覆盖安装/应用内更新前，等待 LoongPort.exe 真正可写（见
+;    WaitForMainBinaryWritable），替代模板「kill + 固定 Sleep 500」的盲等。
 !define LOONGPORT_WIX_UPGRADE_CODE "{f6ae9451-300e-59b9-9081-beb400b6cde1}"
 
 LangString LoongPortMsiMigrationPrompt ${LANG_ENGLISH} \
@@ -25,6 +29,77 @@ LangString LoongPortMsiMigrationFailed ${LANG_TRADCHINESE} \
   "舊版 LoongPort MSI 解除安裝失敗（錯誤 $R1）。安裝已停止，使用者資料未變更。請先在 Windows 設定中解除安裝 LoongPort，再重新執行安裝程式。"
 LangString LoongPortMsiMigrationFailed ${LANG_JAPANESE} \
   "旧版 LoongPort MSI のアンインストールに失敗しました（エラー $R1）。データを変更せずセットアップを中止します。Windows の設定から LoongPort をアンインストールして、もう一度実行してください。"
+
+LangString LoongPortInstallFileLocked ${LANG_ENGLISH} \
+  "Setup could not replace LoongPort because it is still in use. Please wait a moment and try again."
+LangString LoongPortInstallFileLocked ${LANG_SIMPCHINESE} \
+  "LoongPort 仍在使用中，暂时无法完成安装。请稍后重试。"
+LangString LoongPortInstallFileLocked ${LANG_TRADCHINESE} \
+  "LoongPort 仍在使用中，暫時無法完成安裝。請稍後重試。"
+LangString LoongPortInstallFileLocked ${LANG_JAPANESE} \
+  "LoongPort が使用中のため、インストールを完了できませんでした。しばらく待ってからもう一度実行してください。"
+
+; 覆盖安装前等待主程序文件真正可写。
+;
+; 背景：应用内更新链路是 tauri-plugin-updater 的 install() —— 启动安装器后
+; 立即 std::process::exit(0)，应用退出与安装器写文件是并发竞速；Tauri 模板
+; 的 CheckIfAppIsRunning 只做一次 kill + 固定 Sleep 500ms 就放行写文件，
+; 进程退出/杀软持锁超过 500ms 时 File 写入撞 sharing violation，弹出
+; 「无法打开要写入的文件 LoongPort.exe」中止/重试/忽略（每次升级必现的
+; 那个弹窗）。
+;
+; 本宏在本文件 PREINSTALL（先于模板的检查与 File 指令）执行验证式等待：
+;   1. 发现 LoongPort.exe 在跑就 kill —— 手动双击安装器覆盖安装同样受益；
+;   2. 用 CreateFileW(GENERIC_WRITE, 独占, OPEN_EXISTING) 探测目标文件，
+;      能打开才放行。探测不创建、不截断；对「进程已死但文件仍被占用」
+;      （如杀软扫描持锁）同样有效，这是模板 kill-only 逻辑覆盖不了的；
+;   3. 上限 60 × 250ms = 15 秒，超时给出明确提示并中止，而不是退回裸弹窗。
+;
+; 注意：${INSTALLMODE}/${MAINBINARYNAME} 是模板在 !insertmacro 展开点之后
+; 才生效的 defines，因此这段逻辑只能活在宏体内，不能挪到本文件顶层。
+!macro WaitForMainBinaryWritable
+  !define LoongPortWaitID ${__LINE__}
+
+  ; 全新安装：目标文件不存在，没有可等的锁，直接放行。
+  ${If} ${FileExists} "$INSTDIR\${MAINBINARYNAME}.exe"
+    StrCpy $R7 0
+
+    loongport_wait_loop_${LoongPortWaitID}:
+      !if "${INSTALLMODE}" == "currentUser"
+        nsis_tauri_utils::FindProcessCurrentUser "${MAINBINARYNAME}.exe"
+      !else
+        nsis_tauri_utils::FindProcess "${MAINBINARYNAME}.exe"
+      !endif
+      Pop $R8
+      ${If} $R8 = 0
+        !if "${INSTALLMODE}" == "currentUser"
+          nsis_tauri_utils::KillProcessCurrentUser "${MAINBINARYNAME}.exe"
+        !else
+          nsis_tauri_utils::KillProcess "${MAINBINARYNAME}.exe"
+        !endif
+        Pop $R8
+      ${EndIf}
+
+      System::Call 'kernel32::CreateFileW(w "$INSTDIR\${MAINBINARYNAME}.exe", i 0x40000000, i 0, p 0, i 3, i 0x80, p 0) p .r8'
+      ${If} $R8 <> -1
+        System::Call 'kernel32::CloseHandle(p r8)'
+        Goto loongport_wait_done_${LoongPortWaitID}
+      ${EndIf}
+
+      IntOp $R7 $R7 + 1
+      ${If} $R7 >= 60
+        MessageBox MB_ICONSTOP|MB_OK "$(LoongPortInstallFileLocked)"
+        SetErrorLevel 1
+        Abort
+      ${EndIf}
+      Sleep 250
+      Goto loongport_wait_loop_${LoongPortWaitID}
+
+    loongport_wait_done_${LoongPortWaitID}:
+  ${EndIf}
+
+  !undef LoongPortWaitID
+!macroend
 
 !macro NSIS_HOOK_PREINSTALL
   ; MsiEnumRelatedProducts 同时覆盖 per-user / per-machine 注册上下文，比遍历 HKCU/HKLM
@@ -46,4 +121,8 @@ LangString LoongPortMsiMigrationFailed ${LANG_JAPANESE} \
       Abort
     ${EndIf}
   ${EndIf}
+
+  ; 最后一步：确保主程序文件可写再交还模板写文件。
+  ; MSI 迁移可能耗时数秒，放在它之后能把「探测通过 → 模板写文件」的窗口压到最小。
+  !insertmacro WaitForMainBinaryWritable
 !macroend

--- a/src-tauri/src/services/app_update.rs
+++ b/src-tauri/src/services/app_update.rs
@@ -288,11 +288,12 @@ async fn install_bytes_and_restart(
         // （插件内部 std::process::exit(0)，绕过 TrayIcon::drop、不发
         // NIM_DELETE，会残留死图标——与托盘"退出"路径相同的问题）。
         // 因此清理只能放在 install 前执行，且必须显式移除托盘图标。
+        // 应用退出与安装器写文件的竞速由 NSIS 钩子（installer-hooks.nsh 的
+        // WaitForMainBinaryWritable）在安装器侧等待兜底，应用侧无需再睡。
         crate::save_window_state_before_exit(app);
         crate::cleanup_before_exit(app).await;
         crate::remove_tray_icon_before_exit(app);
         crate::destroy_single_instance_lock(app);
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
         update.install(bytes).map_err(|e| {
             format!(
                 "Windows 更新安装失败: {e}。已执行退出前清理，代理或 Live 接管可能已暂停；请重启应用或重新开启代理后再试。"


### PR DESCRIPTION
## Summary / 概述

修 Windows 端每次升级必弹的「无法打开要写入的文件 LoongPort.exe（中止/重试/忽略）」。

**根因**：应用内更新链路是 tauri-plugin-updater 的 `install()` —— 启动 NSIS 安装器（`/P /R /UPDATE`）后立即 `std::process::exit(0)`，应用退出与安装器写文件是并发竞速；Tauri 模板的 `CheckIfAppIsRunning` 兜底只做一次 kill + **固定 `Sleep 500`** 就放行 `File` 写主程序。进程退出或安全软件持锁超过 500ms 时写入撞 sharing violation，弹出 NSIS 核心中止/重试/忽略对话框（点「重试」等几秒能装过去，即竞速证据）。上游 dev 分支模板与 CLI 2.11.4 逐字一致，升级依赖无解。

**修法**（安装器侧验证式等待，owner 层修复）：在现有 `NSIS_HOOK_PREINSTALL` 钩子尾部加 `WaitForMainBinaryWritable` 宏，先于模板的检查与 `File` 指令执行：

1. 发现 `LoongPort.exe` 在跑就 kill —— 手动双击安装器覆盖安装同样受益；
2. 用 `CreateFileW(GENERIC_WRITE, 独占, OPEN_EXISTING)` 探测目标文件，**能打开才放行**（不创建、不截断）；对「进程已死但文件仍被占用」（安全软件扫描持锁）同样有效，这是模板 kill-only 逻辑覆盖不了的路径；
3. 上限 60 × 250ms = 15 秒，超时四语言明确提示并干净中止（尚未写任何文件），不再退回裸弹窗；
4. 全新安装（目标文件不存在）零等待直通，无行为变化。

完成后自动重启（`/R`）本就是 Passive 模式默认行为，不受影响。顺带删掉 `install_bytes_and_restart` Windows 分支里 `install()` 前的 `sleep(100ms)` —— 它睡在安装器启动之前，对竞速毫无作用。

## Related Issue / 关联 Issue

无（用户反馈：Windows 每次升级弹「无法打开要写入的文件」）

## Screenshots / 截图

纯安装器行为改动，无 UI 变化（新增的超时提示为四语言 MessageBox 文案）。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查（未动前端，N/A）
- [x] `pnpm format:check` passes / 通过代码格式检查（未动前端，N/A）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）（本地 fmt 过；改动在 `cfg(windows)` 块内，编译走 CI 三平台 Backend Checks）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（新增文案为 NSIS 安装器 LangString，四语言齐备）

## 验证 / Verification

- 本地 makensis 3.12 + nsis_tauri_utils 0.5.3 编译闸：钩子文件独立编译通过；并做了宏展开阴性对照（宏体注入 `!error` 确认在 `!insertmacro` 展开点被处理，排除「编译绿但宏未展开」假象）。
- 运行时行为需 Windows 真机回归：应用内升级、手动覆盖安装两条路径（下次发版后观察）。
