### PR TITLE
feat(ui): 当前在用卡片补 10% 淡底，长列表里扫得出来

### DIFF
--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -317,8 +317,9 @@ export function ProviderCard({
           ? "hover:border-emerald-500/50"
           : "hover:border-border-active",
         shouldUseGreen &&
-          "border-emerald-500/60 shadow-sm shadow-emerald-500/10",
-        shouldUseBlue && "border-blue-500/60 shadow-sm shadow-blue-500/10",
+          "border-emerald-500/60 bg-emerald-500/10 shadow-sm shadow-emerald-500/10",
+        shouldUseBlue &&
+          "border-blue-500/60 bg-blue-500/10 shadow-sm shadow-blue-500/10",
         !hasStateHighlight && "hover:shadow-sm",
         dragHandleProps?.isDragging &&
           "cursor-grabbing border-primary shadow-lg scale-105 z-10",

--- a/src/components/relay/RelayRow.tsx
+++ b/src/components/relay/RelayRow.tsx
@@ -46,7 +46,7 @@ import { useTierVerification } from "./model-verification/TierVerificationProvid
  * （CLAUDE.md §一「什么时候可以不复用」正是这一条）。
  *
  * 但**视觉 token 全部抄它**，判据是「和旧页面放一起看不出是两个人写的」：
- * `rounded-xl border p-4`、选中态 `border-blue-500/60 shadow-sm shadow-blue-500/10`
+ * `rounded-xl border p-4`、选中态 `border-blue-500/60 bg-blue-500/10 shadow-sm shadow-blue-500/10`
  * （`ProviderCard.tsx:299-306`）、当前项用裸 `Check`（不是 `CheckCircle2`）。
  *
  * ## 折叠没有动画，这是事实不是遗漏
@@ -186,7 +186,7 @@ export function RelayRow({
           dragHandleProps?.isDragging
             ? "cursor-grabbing border-primary shadow-lg"
             : relay.isCurrent
-              ? "border-blue-500/60 shadow-sm shadow-blue-500/10 hover:border-blue-500"
+              ? "border-blue-500/60 bg-blue-500/10 shadow-sm shadow-blue-500/10 hover:border-blue-500"
               : "hover:border-border-active",
         )}
       >
@@ -670,7 +670,7 @@ function TierItem({
         // 「它脱离自动维护了，出问题你得自己回退」。判据是尺子1：用仓里已有的
         // 颜色语义，别新造一套。
         tier.isCurrent
-          ? "border-blue-500/60 shadow-sm shadow-blue-500/10"
+          ? "border-blue-500/60 bg-blue-500/10 shadow-sm shadow-blue-500/10"
           : userEdited
             ? "border-amber-500/50 bg-amber-500/5 hover:border-amber-500/70"
             : "hover:border-border-active",
@@ -752,7 +752,8 @@ function TierItem({
             当前档位那一支**照上游做成禁用的灰色按钮**（`ProviderActions.tsx:188-197`
             的 `isCurrent` 分支：`variant="secondary"` + `Check` + `bg-gray-200`），
             不再是一段裸文字 —— 两者在同一屏并排时，文字与按钮混排看着像没对齐。
-            当前态本身由行的蓝色边框表达（与上游卡片同一个做法）。 */}
+            当前态本身由行的蓝色边框+淡底表达（形状与本卡里的模型芯片选中态、
+            easymode 的 emerald 选中一致 —— 分组多时 1px 描边扫不出来，底色才扫得出来）。 */}
         {tier.isCurrent ? (
           <Button
             type="button"

--- a/src/components/relay/VendorRow.tsx
+++ b/src/components/relay/VendorRow.tsx
@@ -145,7 +145,7 @@ export function VendorRow({
           : isCurrent
             ? // 当前在用的行用蓝框，与 `TierItem` 的当前态同一个 token
               // （`ProviderCard.tsx:306`）—— 用户扫一眼列表首先要找到在用的那个。
-              "border-blue-500/60 shadow-sm shadow-blue-500/10"
+              "border-blue-500/60 bg-blue-500/10 shadow-sm shadow-blue-500/10"
             : userEdited
               ? // 已手动维护：amber，与 `RelayRow` 的档位行同一套语义
                 // （蓝 = 在用、绿 = 代理接管都已有主，amber = 需要留意）。
@@ -578,7 +578,7 @@ function PlanItem({
         "group/tier flex flex-wrap items-center gap-2 rounded-lg border border-border px-3 py-2 transition-all",
         // 三态优先级：当前在用 > 已手动维护 > 普通（同 `TierItem`）。
         plan.isCurrent
-          ? "border-blue-500/60 shadow-sm shadow-blue-500/10"
+          ? "border-blue-500/60 bg-blue-500/10 shadow-sm shadow-blue-500/10"
           : userEdited
             ? "border-amber-500/50 bg-amber-500/5 hover:border-amber-500/70"
             : "hover:border-border-active",

--- a/src/components/relay/__tests__/RefreshActions.test.tsx
+++ b/src/components/relay/__tests__/RefreshActions.test.tsx
@@ -255,7 +255,7 @@ describe("行上的刷新动作", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("当前档位所在的中转站复用浅蓝当前态外框", () => {
+  it("当前档位所在的中转站复用浅蓝当前态（边框+淡底）", () => {
     renderRelayRow(vi.fn(), {
       isCurrent: true,
       tiers: [{ ...tier, isCurrent: true }],
@@ -264,6 +264,7 @@ describe("行上的刷新动作", () => {
     const row = screen.getByText("Relay").closest(".rounded-xl");
     expect(row).toHaveClass(
       "border-blue-500/60",
+      "bg-blue-500/10",
       "shadow-sm",
       "shadow-blue-500/10",
     );


### PR DESCRIPTION
## 问题

分组（档位）多的站点，用户扫一眼列表找不到当前在用的那一档：

- 当前态只有 1px 蓝描边（`border-blue-500/60`），没有底色
- 带「使用中」Check 的按钮是 hover 才显形的，不悬停就只剩那根细线

## 改法

给所有「当前在用」卡片补 `bg-blue-500/10`，描边保留——不是新发明形状：

- 同一张档位卡里的**模型芯片选中态**早已是 `border-blue-500/60 bg-blue-500/10`
- easymode 的 emerald 选中（TierList / EasyBoard / AppModeSegmented）也全是「边框+/10 淡底」
- 档位行的 amber 手动维护态同样是 `border-amber-500/50 bg-amber-500/5`

也就是说「状态卡片 = 描边 + 淡底」本就是这套设计语言的既有形状，唯独「当前在用」缺了底色。alpha 底在深浅两主题下都自动成立，无需 dark: 特判。

## 波及面（同一语义一次对齐）

| 位置 | 状态 |
| --- | --- |
| `ProviderCard` 蓝分支（在用） | + `bg-blue-500/10` |
| `ProviderCard` 绿分支（代理接管） | + `bg-emerald-500/10`（同形状收口） |
| `RelayRow` 站行 isCurrent | + `bg-blue-500/10` |
| `RelayRow` 档位行 isCurrent | + `bg-blue-500/10` |
| `VendorRow` 账号行 / 套餐行 isCurrent | + `bg-blue-500/10` |

## 验证

- `pnpm typecheck` / `pnpm format:check` 绿
- `RefreshActions` 契约测试同步钉住新 token，7/7 过