### PR TITLE
fix(relay): 广场开关只藏推荐列表，不再摘掉整个广场 tab

### DIFF
--- a/src/components/relay/AddHubPage.tsx
+++ b/src/components/relay/AddHubPage.tsx
@@ -4,8 +4,7 @@ import { ArrowLeft, Plus } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { PLAZA_VISIBLE_DEFAULT, type AppId } from "@/lib/api";
-import { useSettingsQuery } from "@/lib/query";
+import type { AppId } from "@/lib/api";
 import { useVendorSupportedQuery } from "@/lib/query/vendor";
 import {
   AddProviderForm,
@@ -53,19 +52,14 @@ export function AddHubPage({
 }) {
   const { t } = useTranslation();
   const vendorSupported = useVendorSupportedQuery(sourceAppId);
-  // 广场开关（默认值由后端按首启归因播种，设置页可手动翻转）。false 时广场
-  // tab 整个不出现 —— 添加站点的路只剩官方 API 与手动添加（搜索框照样可加）。
-  // 未加载/未播种都按「展示」处理（未归因默认），且用派生值而非初值快照，
-  // 设置晚到也能把已落在「广场」上的选中态拨回「手动添加」。
-  const { data: settings } = useSettingsQuery();
-  const plazaVisible = settings?.plazaVisible ?? PLAZA_VISIBLE_DEFAULT;
+  // 广场 tab 常驻：设置里的广场开关只控制广场页内推荐列表的显隐
+  //（`RelayDirectoryPage` 消费 `plazaVisible`），不再摘掉整个 tab ——
+  // 搜索框手填直连是广场页的一部分，关列表不能把添加站点的路一起关掉。
   const [tab, setTab] = useState<AddHubTab>(initialTab);
-  const effectiveTab: AddHubTab =
-    !plazaVisible && tab === "directory" ? "manual" : tab;
 
   return (
     <Tabs
-      value={effectiveTab}
+      value={tab}
       onValueChange={(v) => setTab(v as AddHubTab)}
       className="mx-auto flex h-full w-full max-w-[1180px] flex-col px-6 pb-6"
     >
@@ -81,11 +75,9 @@ export function AddHubPage({
           <ArrowLeft className="h-4 w-4" />
         </Button>
         <TabsList>
-          {plazaVisible && (
-            <TabsTrigger value="directory">
-              {t("loongport.sections.relay")}
-            </TabsTrigger>
-          )}
+          <TabsTrigger value="directory">
+            {t("loongport.sections.relay")}
+          </TabsTrigger>
           {vendorSupported && (
             <TabsTrigger value="official">
               {t("loongport.sections.official")}
@@ -98,16 +90,14 @@ export function AddHubPage({
         </TabsList>
       </div>
 
-      {plazaVisible && (
-        <TabsContent value="directory" className="mt-0 min-h-0 flex-1">
-          <RelayDirectoryPage
-            sourceAppId={sourceAppId}
-            onBack={onBack}
-            embedded
-            firstVisit={firstVisit}
-          />
-        </TabsContent>
-      )}
+      <TabsContent value="directory" className="mt-0 min-h-0 flex-1">
+        <RelayDirectoryPage
+          sourceAppId={sourceAppId}
+          onBack={onBack}
+          embedded
+          firstVisit={firstVisit}
+        />
+      </TabsContent>
 
       {vendorSupported && (
         <TabsContent value="official" className="mt-0 min-h-0 flex-1">

--- a/src/components/relay/__tests__/AddHubPage.test.tsx
+++ b/src/components/relay/__tests__/AddHubPage.test.tsx
@@ -4,14 +4,10 @@ import { describe, expect, it, vi } from "vitest";
 import { AddHubPage } from "../AddHubPage";
 
 /**
- * 广场开关在聚合页的表现：false = 广场 tab 整个不出现、默认落「手动添加」。
- * 默认值由后端按首启归因播种（站长引流来的用户默认关），这里是它的消费端。
+ * 广场开关的消费端在 `RelayDirectoryPage`（只藏推荐列表）。
+ * 聚合页这里守的是另一件事：「中转站」tab 常驻 —— 摘 tab 会把搜索框直连
+ * 这条添加站点的路一起关掉，那是 2026-09-08 修正掉的旧语义。
  */
-const settingsQueryMock = vi.hoisted(() => vi.fn());
-
-vi.mock("@/lib/query", () => ({
-  useSettingsQuery: () => settingsQueryMock(),
-}));
 vi.mock("@/lib/query/vendor", () => ({
   useVendorSupportedQuery: () => ({ data: false }),
 }));
@@ -35,34 +31,9 @@ function renderHub() {
   );
 }
 
-describe("AddHubPage 广场开关", () => {
-  it("未播种（默认）时广场 tab 存在，添加站点默认落广场", () => {
-    settingsQueryMock.mockReturnValue({ data: { plazaVisible: null } });
+describe("AddHubPage 中转站 tab 常驻", () => {
+  it("默认落「中转站」广场页，tab 不随广场开关消失", () => {
     renderHub();
     expect(screen.getByTestId("relay-directory")).toBeInTheDocument();
-  });
-
-  it("开关关闭时广场 tab 不渲染、默认落「手动添加」", () => {
-    settingsQueryMock.mockReturnValue({ data: { plazaVisible: false } });
-    renderHub();
-    expect(screen.queryByTestId("relay-directory")).not.toBeInTheDocument();
-    expect(screen.getByTestId("add-provider-form")).toBeInTheDocument();
-  });
-
-  it("设置晚到（先渲染、后变 false）也能把选中态拨回手动添加", () => {
-    settingsQueryMock.mockReturnValue({ data: undefined });
-    const view = renderHub();
-    expect(screen.getByTestId("relay-directory")).toBeInTheDocument();
-
-    settingsQueryMock.mockReturnValue({ data: { plazaVisible: false } });
-    view.rerender(
-      <AddHubPage
-        sourceAppId="codex"
-        onBack={() => undefined}
-        onAddProvider={() => undefined as never}
-      />,
-    );
-    expect(screen.queryByTestId("relay-directory")).not.toBeInTheDocument();
-    expect(screen.getByTestId("add-provider-form")).toBeInTheDocument();
   });
 });

--- a/src/components/relay/directory/RelayDirectoryPage.tsx
+++ b/src/components/relay/directory/RelayDirectoryPage.tsx
@@ -15,7 +15,7 @@ import {
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { relayApi, settingsApi } from "@/lib/api";
+import { PLAZA_VISIBLE_DEFAULT, relayApi, settingsApi } from "@/lib/api";
 import { crowdApi } from "@/lib/api/crowd";
 import type { AppId } from "@/lib/api";
 import type { RelayDirectoryItem, RelayImportError } from "@/lib/api/relay";
@@ -81,6 +81,9 @@ export function RelayDirectoryPage({
   // 兜底与后端默认值同向（2026-09-07 起默认开）：字段实际总在，只有极端的
   // 缺键情形才会落到兜底。
   const crowdEnabled = appSettings?.crowdMetricsEnabled ?? true;
+  // 广场开关只藏推荐列表本身：关掉时列表为空（不拉清单）、页头同步时间与
+  // 刷新按钮退场，但搜索框与「搜不到就地直连」保留 —— 关列表不等于关广场。
+  const plazaVisible = appSettings?.plazaVisible ?? PLAZA_VISIBLE_DEFAULT;
   // 详情弹窗的实测深数据（w7/时段/分布）：共建门禁内 —— 行级观测徽章公开，
   // 由列表 DTO 的 item.crowd 承载，不走这份门禁内快照。
   const crowdSnapshotQuery = useQuery({
@@ -97,6 +100,9 @@ export function RelayDirectoryPage({
   const directoryQuery = useQuery({
     queryKey: relayDirectoryKeys.listing(),
     queryFn: () => relayApi.listDirectory(),
+    // 列表被广场开关藏起来时连清单都不发请求；即便命中旧缓存，下方的
+    // filtered 守卫也保证一行都不渲染。
+    enabled: plazaVisible,
     staleTime: Infinity,
     gcTime: Infinity,
   });
@@ -117,8 +123,12 @@ export function RelayDirectoryPage({
 
   const listing = directoryQuery.data ?? null;
   const filtered = useMemo(
-    () => filterDirectoryItems(listing?.items ?? [], view.search),
-    [listing?.items, view.search],
+    () =>
+      filterDirectoryItems(
+        plazaVisible ? (listing?.items ?? []) : [],
+        view.search,
+      ),
+    [plazaVisible, listing?.items, view.search],
   );
   const paged = pageDirectoryItems(filtered, view.page);
   const range = visibleDirectoryRange(
@@ -262,28 +272,32 @@ export function RelayDirectoryPage({
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
-          {syncedAt && (
-            <span>
-              {t("loongport.directory.source.syncedAt", { time: syncedAt })}
-            </span>
+          {plazaVisible && (
+            <>
+              {syncedAt && (
+                <span>
+                  {t("loongport.directory.source.syncedAt", { time: syncedAt })}
+                </span>
+              )}
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                disabled={directoryQuery.isPending || refreshMutation.isPending}
+                onClick={() => refreshMutation.mutate()}
+                aria-label={t("loongport.directory.actions.refresh")}
+              >
+                <RefreshCw
+                  className={
+                    directoryQuery.isFetching || refreshMutation.isPending
+                      ? "h-4 w-4 animate-spin"
+                      : "h-4 w-4"
+                  }
+                />
+              </Button>
+            </>
           )}
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8"
-            disabled={directoryQuery.isPending || refreshMutation.isPending}
-            onClick={() => refreshMutation.mutate()}
-            aria-label={t("loongport.directory.actions.refresh")}
-          >
-            <RefreshCw
-              className={
-                directoryQuery.isFetching || refreshMutation.isPending
-                  ? "h-4 w-4 animate-spin"
-                  : "h-4 w-4"
-              }
-            />
-          </Button>
         </div>
       </div>
 
@@ -314,7 +328,7 @@ export function RelayDirectoryPage({
       </div>
 
       <section className="min-h-0 flex-1 overflow-hidden rounded-lg border border-border-default bg-background shadow-sm">
-        {directoryQuery.isPending && !listing ? (
+        {plazaVisible && directoryQuery.isPending && !listing ? (
           <div className="flex h-48 items-center justify-center gap-2 text-sm text-muted-foreground">
             <Loader2 className="h-4 w-4 animate-spin" />
             {t("loongport.directory.loading")}

--- a/src/components/relay/directory/__tests__/RelayDirectoryPage.test.tsx
+++ b/src/components/relay/directory/__tests__/RelayDirectoryPage.test.tsx
@@ -41,6 +41,7 @@ const {
 }));
 
 vi.mock("@/lib/api", () => ({
+  PLAZA_VISIBLE_DEFAULT: true,
   relayApi: {
     listDirectory,
     refreshDirectory,
@@ -48,6 +49,12 @@ vi.mock("@/lib/api", () => ({
     importDirectorySite,
     refresh,
   },
+}));
+
+const useSettingsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/useSettings", () => ({
+  useSettings: () => useSettingsMock(),
 }));
 
 vi.mock("../../openInBrowser", () => ({ openInBrowser }));
@@ -159,6 +166,9 @@ function listing(
 describe("RelayDirectoryPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // settings=null：两个消费字段都落兜底（crowdEnabled=true、plazaVisible=true），
+    // 与此前未 mock 该 hook 时的实际行为一致。
+    useSettingsMock.mockReturnValue({ settings: null });
     listDirectory.mockImplementation(() => Promise.resolve(listing()));
     refreshDirectory.mockImplementation(() => Promise.resolve(listing()));
     importSite.mockResolvedValue({
@@ -341,6 +351,33 @@ describe("RelayDirectoryPage", () => {
       expect(importSite).toHaveBeenCalledWith("https://my-own-relay.example"),
     );
     expect(importDirectorySite).not.toHaveBeenCalled();
+  });
+
+  it("hides only the recommended list when the plaza switch is off", async () => {
+    // 广场开关关：列表为空、不发清单请求；搜索框与「搜不到就地直连」保留 ——
+    // 关的是推荐列表，不是整个广场页。
+    useSettingsMock.mockReturnValue({ settings: { plazaVisible: false } });
+    const user = userEvent.setup();
+    renderDirectory({ sourceAppId: "codex", onBack: () => {} });
+
+    await screen.findByText("loongport.directory.empty");
+    expect(listDirectory).not.toHaveBeenCalled();
+    expect(
+      screen.getByPlaceholderText("loongport.directory.searchPlaceholder"),
+    ).toBeInTheDocument();
+
+    await user.type(
+      screen.getByPlaceholderText("loongport.directory.searchPlaceholder"),
+      "https://my-own-relay.example",
+    );
+    await user.click(
+      await screen.findByRole("button", {
+        name: /loongport.directory.addAsSite/,
+      }),
+    );
+    await waitFor(() =>
+      expect(importSite).toHaveBeenCalledWith("https://my-own-relay.example"),
+    );
   });
 
   it("searches and paginates twelve rows per page", async () => {

--- a/src/components/settings/PlazaSettings.tsx
+++ b/src/components/settings/PlazaSettings.tsx
@@ -8,12 +8,14 @@ import { PLAZA_VISIBLE_DEFAULT, settingsApi } from "@/lib/api";
 import { useSettingsQuery } from "@/lib/query";
 
 /**
- * 「中转站广场」开关（设置 → 常规的最底部）。
+ * 「广场推荐列表」开关（设置 → 常规的最底部）。
  *
- * 这是广场可见性的**唯一**用户入口：默认值由后端按首启归因播种（站长引流
- * 来的用户默认关），用户在这里翻转的结果永远优先。它**不走**表单的全量
- * 保存 —— `plazaVisible` 是后端专有字段（旧快照回写会抹掉刚播的种），改它
- * 走窄命令 `plaza_set_visible`，改完手动失效 settings 查询。
+ * 只控制广场页内推荐列表的显隐（广场页与搜索框直连常驻，见
+ * `RelayDirectoryPage` 的消费）。这是该开关的**唯一**用户入口：默认值由
+ * 后端按首启归因播种（站长引流来的用户默认关），用户在这里翻转的结果永远
+ * 优先。它**不走**表单的全量保存 —— `plazaVisible` 是后端专有字段（旧快照
+ * 回写会抹掉刚播的种），改它走窄命令 `plaza_set_visible`，改完手动失效
+ * settings 查询。
  */
 export function PlazaSettings() {
   const { t } = useTranslation();

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -916,7 +916,7 @@
     "crowdMetrics": "Crowd-measured site stats",
     "crowdMetricsDescription": "Upload site-level hourly aggregates (first-token time, error rate, …) and unlock user-measured stats in the directory. No prompts, keys, or account info.",
     "plazaVisibility": "Relay directory",
-    "plazaVisibilityToggle": "Show relay directory",
+    "plazaVisibilityToggle": "Show recommended relay list",
     "plazaVisibilityDescription": "Show the recommended relay list on the add-site page; sites can still be added manually via the search box"
   },
   "apps": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -916,7 +916,7 @@
     "crowdMetrics": "サイト実測データの共同利用",
     "crowdMetricsDescription": "サイト単位の集計指標（初トークン時間・エラー率など、時間別）を共有し、広場のユーザー実測データを解放します。プロンプト・キー・アカウント情報は含みません。",
     "plazaVisibility": "中継サイト一覧",
-    "plazaVisibilityToggle": "中継サイト一覧を表示",
+    "plazaVisibilityToggle": "広場のおすすめリストを表示",
     "plazaVisibilityDescription": "サイト追加ページに中継サイトのおすすめリストを表示。オフにしても検索ボックスから手動で追加できます"
   },
   "apps": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -917,7 +917,7 @@
     "crowdMetrics": "站點實測資料共建",
     "crowdMetricsDescription": "上傳站點級聚合指標（首字耗時、錯誤率等，按小時聚合），並解鎖廣場的使用者實測資料。不含提示詞、金鑰或帳號資訊。",
     "plazaVisibility": "中轉站廣場",
-    "plazaVisibilityToggle": "顯示中轉站廣場",
+    "plazaVisibilityToggle": "顯示廣場推薦列表",
     "plazaVisibilityDescription": "在新增站點頁展示中轉站推薦列表；關閉後仍可透過搜尋框手動新增站點"
   },
   "apps": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -916,7 +916,7 @@
     "crowdMetrics": "站点实测数据共建",
     "crowdMetricsDescription": "上传站点级聚合指标（首字耗时、错误率等，按小时聚合），并解锁广场的用户实测数据。不含提示词、密钥或账号信息。",
     "plazaVisibility": "中转站广场",
-    "plazaVisibilityToggle": "显示中转站广场",
+    "plazaVisibilityToggle": "显示广场推荐列表",
     "plazaVisibilityDescription": "在添加站点页展示中转站推荐列表；关闭后仍可通过搜索框手动添加站点"
   },
   "apps": {


### PR DESCRIPTION
## 问题

设置 → 常规的「显示中转站广场」开关，关闭时的实际行为是把聚合页里整个「中转站」tab 摘掉（搜索框、列表、页脚全消失，只剩官方 API 与手动添加）。但它的语义应该是：**只隐藏白名单推荐列表（列表为空），广场页本身保留**——设置里那句描述「在添加站点页展示中转站推荐列表；关闭后仍可通过搜索框手动添加站点」写的就是这个语义，实现做反了。

## 修正

- **AddHubPage**：「中转站」tab 常驻，删掉 plazaVisible 摘 tab 与「设置晚到拨回手动添加」的派生选中态。
- **RelayDirectoryPage**（开关的新消费端）：关闭时——
  - 清单查询 `enabled: false`（不发请求；即便命中旧缓存，filtered 守卫也保证一行不渲染）；
  - 列表渲染空态（复用 `directory.empty`，其后半句「搜索框可以直接添加」正是要的行为）；
  - 页头同步时间与刷新按钮退场（藏列表时无数据可刷）；
  - 搜索框与「搜不到就地转添加」直连保留。
- **设置开关文案**对齐新语义：显示中转站广场 → 显示广场推荐列表（×4 locale，只改值不改键）。
- 首启归因播种逻辑不变：站长引流用户默认关 = 看不到推荐列表，但广场页与手填直连照常可用。

## 测试

- `AddHubPage` 套件改守「tab 常驻」新语义（原「关闭摘 tab / 拨回手动」用例随行为一起删）。
- `RelayDirectoryPage` 新增用例：开关关闭 → 空态 + 不发清单请求 + 搜索直连照常工作。
- `pnpm typecheck` / `pnpm format:check` / 全量 `pnpm vitest run`（191 文件 1294 测试）全绿。