### PR TITLE
feat(codex): 官方额度面板补全局重置倒计时

### DIFF
--- a/src-tauri/src/commands/codex_reset.rs
+++ b/src-tauri/src/commands/codex_reset.rs
@@ -1,0 +1,11 @@
+//! Codex 全局重置预告：读社区 feed（含缓存），供额度面板展示。
+//!
+//! 按需拉取（与 get_subscription_quota 同款节奏：面板打开/手动刷新时由前端
+//! invoke），服务层带 1 小时缓存与旧缓存兜底，见 `services/codex_reset.rs`。
+
+use crate::services::codex_reset;
+
+#[tauri::command]
+pub async fn get_codex_reset_feed() -> Result<codex_reset::CodexResetFeed, String> {
+    codex_reset::get_feed().await
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -100,3 +100,5 @@ pub use s3_sync::*;
 pub use usage::*;
 pub use webdav_sync::*;
 pub use workspace::*;
+pub mod codex_reset;
+pub use codex_reset::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1788,6 +1788,8 @@ pub fn run() {
             commands::get_codex_oauth_models,
             commands::get_xai_oauth_models,
             commands::get_xai_oauth_quota,
+            // codex global reset feed（社区预告）
+            commands::get_codex_reset_feed,
             commands::get_coding_plan_quota,
             commands::get_balance,
             // New MCP via config.json (SSOT)

--- a/src-tauri/src/services/codex_reset.rs
+++ b/src-tauri/src/services/codex_reset.rs
@@ -1,0 +1,126 @@
+//! Codex 全局重置预告（挂在官方订阅额度展示下方）。
+//!
+//! OpenAI 会对付费订阅做不定期「善意全局重置」，由 Codex 负责人在 X 上公告
+//! ——没有固定时刻，官方也不提供接口。数据走**网站的同源代理**
+//! `https://loongport.dev/api/codex-reset`：拉取社区源（codex-reset.com）、
+//! 归一与「预计落地时间」解析都在那一处唯源实现（网站卡片与 App 共用，
+//! 上游换了只改网站）。本模块只做：按需 GET + 1 小时缓存 + 网络失败回退
+//! 旧缓存（宁可旧，不报错打断额度面板）。
+//!
+//! 隐私：只读公开社区数据，不带任何本机信息。
+
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+/// 网站代理端点（与 relay/remote_config.rs 的 CONFIG_URL 同款「app 信自家
+/// 服务」的依赖形态；Rust 侧 reqwest 非浏览器，无 CORS 顾虑）。
+const FEED_URL: &str = "https://loongport.dev/api/codex-reset";
+const CACHE_TTL: Duration = Duration::from_secs(3600);
+const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// 归一化形状（与网站投影逐字段对齐，camelCase）。所有字段可缺省——
+/// 拿不到就少显示，`Option` 全给前端自己取舍。
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+#[serde(rename_all = "camelCase", default)]
+pub struct CodexResetFeed {
+    /// 上次已验证重置（epoch 秒）+ 原帖链接
+    pub last_verified_at: Option<i64>,
+    pub last_verified_url: Option<String>,
+    /// 最新一条重置公告（epoch 秒 + 原帖链接 + 原文摘要）
+    pub announcement_at: Option<i64>,
+    pub announcement_url: Option<String>,
+    pub announcement_summary: Option<String>,
+    /// 公告文本窄解析出的预计落地时间（epoch 秒）；解析不出为 None
+    pub landing_at: Option<i64>,
+    pub fetched_at: i64,
+}
+
+static CACHE: OnceLock<Mutex<Option<(Instant, CodexResetFeed)>>> = OnceLock::new();
+
+fn cache_cell() -> &'static Mutex<Option<(Instant, CodexResetFeed)>> {
+    CACHE.get_or_init(|| Mutex::new(None))
+}
+
+/// 读缓存；新鲜直接用，过期/没有则拉一次。网络失败时回退旧缓存（若有），
+/// 旧缓存也没有才 Err——面板对 Err 的处理是整块不渲染（宁缺毋认）。
+pub async fn get_feed() -> Result<CodexResetFeed, String> {
+    {
+        let cell = cache_cell().lock().expect("codex reset cache poisoned");
+        if let Some((at, feed)) = cell.as_ref() {
+            if at.elapsed() < CACHE_TTL {
+                return Ok(feed.clone());
+            }
+        }
+    }
+    match fetch_feed().await {
+        Ok(feed) => {
+            *cache_cell().lock().expect("codex reset cache poisoned") =
+                Some((Instant::now(), feed.clone()));
+            Ok(feed)
+        }
+        Err(error) => {
+            let cell = cache_cell().lock().expect("codex reset cache poisoned");
+            if let Some((_, feed)) = cell.as_ref() {
+                log::warn!("codex-reset feed 拉取失败（回退旧缓存）: {error}");
+                return Ok(feed.clone());
+            }
+            Err(error)
+        }
+    }
+}
+
+async fn fetch_feed() -> Result<CodexResetFeed, String> {
+    let client = reqwest::Client::builder()
+        .timeout(FETCH_TIMEOUT)
+        .build()
+        .map_err(|e| e.to_string())?;
+    let resp = client
+        .get(FEED_URL)
+        .header("User-Agent", "LoongPort")
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+    if !resp.status().is_success() {
+        return Err(format!("feed status {}", resp.status()));
+    }
+    resp.json::<CodexResetFeed>()
+        .await
+        .map_err(|e| format!("feed 形状不认识: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 契约闸：网站投影的 camelCase 字段必须逐个对得上（跨语言唯源握手）。
+    /// 解析逻辑的测试唯源在 website 仓 `src/lib/codexReset.test.ts`。
+    #[test]
+    fn website_projection_deserializes_field_by_field() {
+        let raw = serde_json::json!({
+            "lastVerifiedAt": 1787625586,
+            "lastVerifiedUrl": "https://x.com/s/1",
+            "announcementAt": 1787796297,
+            "announcementUrl": "https://x.com/s/2",
+            "announcementSummary": "Lands around 6pm PST today",
+            "landingAt": 1787803200,
+            "fetchedAt": 1787796300
+        });
+        let feed: CodexResetFeed = serde_json::from_value(raw).unwrap();
+        assert_eq!(feed.last_verified_at, Some(1787625586));
+        assert_eq!(
+            feed.announcement_summary.as_deref(),
+            Some("Lands around 6pm PST today")
+        );
+        assert_eq!(feed.landing_at, Some(1787803200));
+        assert_eq!(feed.fetched_at, 1787796300);
+    }
+
+    /// 极简/缺字段响应不炸：serde `default` 全空，前端按可缺省渲染。
+    #[test]
+    fn sparse_projection_deserializes_to_defaults() {
+        let feed: CodexResetFeed = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(feed, CodexResetFeed::default());
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -58,3 +58,4 @@ pub use usage_stats::{
     DailyStats, LogFilters, ModelStats, PaginatedLogs, ProviderLimitStatus, ProviderStats,
     RequestLogDetail, UsageSummary, UsageSummaryByApp,
 };
+pub mod codex_reset;

--- a/src/components/CodexGlobalReset.tsx
+++ b/src/components/CodexGlobalReset.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from "react";
+import { ExternalLink, Timer } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useCodexResetFeed } from "@/lib/query/codexReset";
+
+/**
+ * Codex 全局重置预告（挂在官方订阅额度展示下方）。
+ *
+ * OpenAI 的「善意全局重置」不定期、由负责人在 X 公告；这里展示社区
+ * （codex-reset.com）聚合的预告：
+ * - 有可解析的预计落地时间 → **活的倒计时**（逐秒走到预计时刻）；
+ * - 没有预告/已过期 → 上次已验证重置时间 + 公告原文链接，不猜下一次。
+ * 数据拿不到时整块不渲染（宁缺毋认）。
+ */
+const CodexGlobalReset: React.FC = () => {
+  const { t } = useTranslation();
+  const { data: feed } = useCodexResetFeed();
+  const [now, setNow] = useState(() => Date.now());
+
+  const landing = feed?.landingAt ?? null;
+  const counting = landing != null && landing * 1000 > now;
+
+  // 倒计时逐秒走；无倒计时时不挂定时器。
+  useEffect(() => {
+    if (!counting) return;
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, [counting]);
+
+  if (!feed || (!feed.announcementAt && !feed.lastVerifiedAt)) return null;
+
+  const eta = counting ? formatCountdown(landing! * 1000 - now) : null;
+  const lastVerified =
+    feed.lastVerifiedAt != null ? new Date(feed.lastVerifiedAt * 1000) : null;
+
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+      <span className="inline-flex items-center gap-1 font-medium text-foreground">
+        <Timer className="size-3.5" aria-hidden="true" />
+        {t("loongport.codexReset.label")}
+      </span>
+      {eta ? (
+        <span
+          className="tabular-nums text-foreground"
+          title={t("loongport.codexReset.etaTitle")}
+        >
+          {t("loongport.codexReset.eta", { time: eta })}
+        </span>
+      ) : lastVerified ? (
+        <span title={t("loongport.codexReset.lastResetTitle")}>
+          {t("loongport.codexReset.lastReset", {
+            time: lastVerified.toLocaleDateString(),
+          })}
+        </span>
+      ) : null}
+      {feed.announcementUrl && (
+        <a
+          href={feed.announcementUrl}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="inline-flex items-center gap-1 underline-offset-4 hover:underline"
+          title={feed.announcementSummary ?? undefined}
+        >
+          {t("loongport.codexReset.announcement")}
+          <ExternalLink className="size-3" aria-hidden="true" />
+        </a>
+      )}
+      <span>{t("loongport.codexReset.source")}</span>
+    </div>
+  );
+};
+
+/** 剩余毫秒 → 人话倒计时：`3 天 04:12:09` / `05:12:09` / `42 秒`。 */
+export function formatCountdown(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const days = Math.floor(total / 86400);
+  const hours = Math.floor((total % 86400) / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  const seconds = total % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const hms = `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+  if (days > 0) return `${days}d ${hms}`;
+  if (total >= 3600) return hms;
+  if (total >= 60) return `${pad(minutes)}:${pad(seconds)}`;
+  return `${total}s`;
+}
+
+export default CodexGlobalReset;

--- a/src/components/CodexOauthAccountQuota.tsx
+++ b/src/components/CodexOauthAccountQuota.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Loader2 } from "lucide-react";
 import { useCodexOauthQuotaByAccountId } from "@/lib/query/subscription";
 import { SubscriptionQuotaView } from "@/components/SubscriptionQuotaFooter";
+import CodexGlobalReset from "@/components/CodexGlobalReset";
 
 interface CodexOauthAccountQuotaProps {
   /** cc-switch 自管的 ChatGPT 账号 ID */
@@ -42,13 +43,16 @@ const CodexOauthAccountQuota: React.FC<CodexOauthAccountQuotaProps> = ({
   }
 
   return (
-    <SubscriptionQuotaView
-      quota={quota}
-      loading={loading}
-      refetch={refetch}
-      appIdForExpiredHint="codex_oauth"
-      inline={false}
-    />
+    <div>
+      <SubscriptionQuotaView
+        quota={quota}
+        loading={loading}
+        refetch={refetch}
+        appIdForExpiredHint="codex_oauth"
+        inline={false}
+      />
+      <CodexGlobalReset />
+    </div>
   );
 };
 

--- a/src/components/CodexOauthQuotaFooter.tsx
+++ b/src/components/CodexOauthQuotaFooter.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { ProviderMeta } from "@/types";
 import { useCodexOauthQuota } from "@/lib/query/subscription";
 import { SubscriptionQuotaView } from "@/components/SubscriptionQuotaFooter";
+import CodexGlobalReset from "@/components/CodexGlobalReset";
 
 interface CodexOauthQuotaFooterProps {
   meta?: ProviderMeta;
@@ -34,13 +35,16 @@ const CodexOauthQuotaFooter: React.FC<CodexOauthQuotaFooterProps> = ({
   });
 
   return (
-    <SubscriptionQuotaView
-      quota={quota}
-      loading={loading}
-      refetch={refetch}
-      appIdForExpiredHint="codex_oauth"
-      inline={inline}
-    />
+    <div>
+      <SubscriptionQuotaView
+        quota={quota}
+        loading={loading}
+        refetch={refetch}
+        appIdForExpiredHint="codex_oauth"
+        inline={inline}
+      />
+      <CodexGlobalReset />
+    </div>
   );
 };
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3580,6 +3580,15 @@
       "copy": "Copy",
       "copied": "Copied",
       "registerNote": "The BestAPI sign-up window is open with the promo code pre-filled."
+    },
+    "codexReset": {
+      "label": "Global reset",
+      "eta": "Reset expected in {{time}}",
+      "etaTitle": "Community-predicted time; actual reset is up to OpenAI",
+      "lastReset": "Last verified reset: {{time}}",
+      "lastResetTitle": "Most recent reset confirmed by the community",
+      "announcement": "Announcement",
+      "source": "Community tracker · codex-reset.com"
     }
   },
   "firstRunNotice": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3580,6 +3580,15 @@
       "copy": "コピー",
       "copied": "コピーしました",
       "registerNote": "BestAPI の登録ウィンドウが開き、プロモコードは自動入力されます。"
+    },
+    "codexReset": {
+      "label": "グローバルリセット",
+      "eta": "{{time}}後にリセット予定",
+      "etaTitle": "コミュニティによる予測時間です。実際の時間は公式による",
+      "lastReset": "前回確認済みリセット：{{time}}",
+      "lastResetTitle": "コミュニティで確認された直近のリセット",
+      "announcement": "最新のお知らせ",
+      "source": "コミュニティ予測 · codex-reset.com"
     }
   },
   "firstRunNotice": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3581,6 +3581,15 @@
       "copy": "複製",
       "copied": "已複製",
       "registerNote": "BestAPI 註冊視窗已開啟，優惠碼會自動填好。"
+    },
+    "codexReset": {
+      "label": "全域重置",
+      "eta": "預計 {{time}} 後重置",
+      "etaTitle": "社群預告的預計時間，實際以官方為準",
+      "lastReset": "上次已驗證重置：{{time}}",
+      "lastResetTitle": "最近一次被社群確認的全域重置",
+      "announcement": "最新公告",
+      "source": "社群預告 · codex-reset.com"
     }
   },
   "firstRunNotice": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -3580,6 +3580,15 @@
       "copy": "复制",
       "copied": "已复制",
       "registerNote": "BestAPI 注册窗口已打开，优惠码会自动填好。"
+    },
+    "codexReset": {
+      "label": "全局重置",
+      "eta": "预计 {{time}} 后重置",
+      "etaTitle": "社区预告的预计时间，实际以官方为准",
+      "lastReset": "上次已验证重置：{{time}}",
+      "lastResetTitle": "最近一次被社区确认的全局重置",
+      "announcement": "最新公告",
+      "source": "社区预告 · codex-reset.com"
     }
   },
   "firstRunNotice": {

--- a/src/lib/api/codexReset.ts
+++ b/src/lib/api/codexReset.ts
@@ -1,0 +1,19 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/** 全局重置预告（社区数据源 codex-reset.com 的公开 feed）。所有字段可缺省。 */
+export interface CodexResetFeed {
+  /** 上次已验证重置（epoch 秒）+ 原帖链接 */
+  lastVerifiedAt: number | null;
+  lastVerifiedUrl: string | null;
+  /** 最新一条重置公告（epoch 秒 + 原帖链接 + 原文摘要） */
+  announcementAt: number | null;
+  announcementUrl: string | null;
+  announcementSummary: string | null;
+  /** 公告文本窄解析出的预计落地时间（epoch 秒）；解析不出为 null */
+  landingAt: number | null;
+  fetchedAt: number;
+}
+
+export const codexResetApi = {
+  getFeed: (): Promise<CodexResetFeed> => invoke("get_codex_reset_feed"),
+};

--- a/src/lib/query/codexReset.ts
+++ b/src/lib/query/codexReset.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { codexResetApi } from "@/lib/api/codexReset";
+
+/**
+ * 全局重置预告。数据以天计（公告不定期），staleTime 放宽到 30 分钟——
+ * 后端另有 1 小时缓存 + 旧缓存兜底，双保险下网络抖动对 UI 无感。
+ * 查询失败返回 undefined（组件整体不渲染，宁缺毋认）。
+ */
+export const codexResetKeys = {
+  all: ["codexReset"] as const,
+};
+
+export function useCodexResetFeed() {
+  return useQuery({
+    queryKey: codexResetKeys.all,
+    queryFn: codexResetApi.getFeed,
+    staleTime: 30 * 60 * 1000,
+    retry: 1,
+  });
+}

--- a/tests/config/codexResetLocales.test.ts
+++ b/tests/config/codexResetLocales.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import en from "@/i18n/locales/en.json";
+import ja from "@/i18n/locales/ja.json";
+import zhTW from "@/i18n/locales/zh-TW.json";
+import zh from "@/i18n/locales/zh.json";
+
+/** Codex 全局重置预告（额度面板下方一行）：四语言必须齐全，漏一个 locale
+ *  会直接显示 key 名（照 xaiOauthLocales.test.ts 的形状）。 */
+const requiredKeys = [
+  "loongport.codexReset.label",
+  "loongport.codexReset.eta",
+  "loongport.codexReset.etaTitle",
+  "loongport.codexReset.lastReset",
+  "loongport.codexReset.lastResetTitle",
+  "loongport.codexReset.announcement",
+  "loongport.codexReset.source",
+];
+
+const locales: Record<string, unknown> = { zh, en, ja, "zh-TW": zhTW };
+
+describe("codexReset locales", () => {
+  it.each(Object.keys(locales))("%s 覆盖全部 codexReset key", (lang) => {
+    const dict = locales[lang] as Record<string, unknown>;
+    const has = (path: string) =>
+      path
+        .split(".")
+        .reduce<unknown>(
+          (acc, k) => (acc as Record<string, unknown>)?.[k],
+          dict,
+        ) != null;
+    for (const key of requiredKeys) {
+      expect(has(key), `${lang} 缺 ${key}`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## 概要

用户需求：app 里除已有的 5 小时窗/每周重置外，也要显示 Codex 全局重置（OpenAI 不定期「善意重置」）的**倒计时**。

- **架构按用户拍板**：数据层唯源在网站 `/api/codex-reset`（拉社区源 codex-reset.com + 落地时间窄解析都在那一处，已上线）；app 只 GET 已归一化接口（与 config.loongport.dev 同款依赖形态）+ 1 小时缓存 + 网络失败回退旧缓存
- 官方订阅额度两处展示位（认证中心账号卡 / 供应商卡脚）下方挂「全局重置」行：有预告给**逐秒倒计时**，无预告给上次已验证重置 + 公告原文链接（重置不定期，不猜下一次）
- 契约闸：Rust serde 契约测试钉住网站投影 camelCase 字段（解析逻辑测试唯源在 website 仓 vitest）
- i18n 四语言 + codexReset locales 闸

## 验证

- [x] pnpm ci:rust 全绿（fmt/clippy/全量 cargo test）
- [x] vitest 1300 绿 + tsc + format:check
- [x] 依赖的网站接口已上线并实测（landingAt 解析正确）