### PR TITLE
fix(relay): 站点余额缓存改按「站点+账号」复合键，修同站双账号互相覆盖

### DIFF
--- a/src-tauri/src/commands/auto_mode.rs
+++ b/src-tauri/src/commands/auto_mode.rs
@@ -470,19 +470,16 @@ pub(crate) async fn tier_board_impl(state: &AppState, app_type: &str) -> Result<
     // services::site_balance_refresh 与 relay::balance::spawn_stale_refresh）。
     // 此前这里是同步网络扇出 —— 20-30 家里一家超时型挂掉，整板就等它
     // 30-90s，且冷启动/窗口聚焦每次重演（用户反馈「每次打开软件省心模式
-    // 卡好久」）。
-    let (tier_origins, _site_keys) =
+    // 卡好久」）。缓存键是站点+账号：同站两个账号的档位各查各的钱包。
+    let (tier_keys, _site_keys) =
         crate::services::site_balance_refresh::tier_site_keys(app_type, &ranked);
     let cached = crate::relay::balance::cached_site_balances(db);
-    let balances: std::collections::HashMap<String, Option<f64>> = tier_origins
+    let balances: std::collections::HashMap<String, Option<f64>> = tier_keys
         .iter()
-        .map(|(tier_id, origin)| {
+        .map(|(tier_id, key)| {
             (
                 tier_id.clone(),
-                cached
-                    .get(origin)
-                    .map(|(balance, _)| *balance)
-                    .unwrap_or(None),
+                cached.get(key).map(|(balance, _)| *balance).unwrap_or(None),
             )
         })
         .collect();
@@ -648,7 +645,7 @@ mod tests {
         let state = AppState::new(db.clone());
 
         let id = crate::relay::provision::provider_id_for("https://cache.example", Some(1), 1);
-        let tier = crate::provider::Provider::with_id(
+        let mut tier = crate::provider::Provider::with_id(
             id.clone(),
             "缓存档".to_string(),
             json!({
@@ -659,6 +656,11 @@ mod tests {
             }),
             None,
         );
+        // 缓存键带账号维度：档位要带归属，看板才知道去 (origin, account) 哪条读
+        tier.meta = Some(crate::provider::ProviderMeta {
+            loongport_account_id: Some(1),
+            ..Default::default()
+        });
         db.save_provider("claude", &tier).unwrap();
 
         // 无缓存：余额 None（显示 —）
@@ -669,7 +671,7 @@ mod tests {
         let now = chrono::Utc::now().timestamp();
         crate::relay::balance::upsert_site_balance(
             &db,
-            "https://cache.example",
+            &("https://cache.example".to_string(), 1),
             (Some(12.34), now),
         )
         .unwrap();

--- a/src-tauri/src/commands/relay/balance.rs
+++ b/src-tauri/src/commands/relay/balance.rs
@@ -106,22 +106,29 @@ pub(crate) async fn relay_balance_impl<R: tauri::Runtime>(
         (relay, base_url, api_keys)
     };
 
+    // 缓存键 = (site_origin, account_id)。未登录（`account_id == None`）的行进不了
+    // 缓存：钱包事实归账号所有，没有账号维度就只能走真查，绝不能挂到别的账号
+    // 条目上 —— 同站两个账号曾经在这里互相顶掉对方的余额。
     if !force {
-        let state = app_handle.state::<AppState>();
-        if let Some(entry) = balance::cached_site_balance(&state.db, &relay.site_origin) {
-            let fresh = chrono::Utc::now().timestamp() - entry.1 <= balance::SITE_BALANCE_TTL_SECS;
-            if !fresh {
-                // 过期：回旧值 + 后台刷（单飞/预算/事件都在那条链里；只用 sk，
-                // 不碰登录态 —— 充值窗口的 cookie 独占权不受影响）。
-                if let Some(key) = api_keys.first() {
-                    balance::spawn_stale_refresh(
-                        state.db.clone(),
-                        Some(app_handle.clone()),
-                        std::collections::HashMap::from([(relay.site_origin.clone(), key.clone())]),
-                    );
+        if let Some(account_id) = relay.account_id {
+            let state = app_handle.state::<AppState>();
+            let key: balance::SiteAccountKey = (relay.site_origin.clone(), account_id);
+            if let Some(entry) = balance::cached_site_balance(&state.db, &key) {
+                let fresh =
+                    chrono::Utc::now().timestamp() - entry.1 <= balance::SITE_BALANCE_TTL_SECS;
+                if !fresh {
+                    // 过期：回旧值 + 后台刷（单飞/预算/事件都在那条链里；只用 sk，
+                    // 不碰登录态 —— 充值窗口的 cookie 独占权不受影响）。
+                    if let Some(sk) = api_keys.first() {
+                        balance::spawn_stale_refresh(
+                            state.db.clone(),
+                            Some(app_handle.clone()),
+                            std::collections::HashMap::from([(key, sk.clone())]),
+                        );
+                    }
                 }
+                return Ok(balance::cached_row_balance_result(&entry));
             }
-            return Ok(balance::cached_row_balance_result(&entry));
         }
     }
 
@@ -143,19 +150,22 @@ pub(crate) async fn relay_balance_impl<R: tauri::Runtime>(
 
     {
         // 真查的结果写回缓存（正/负都写）—— 行路径与看板/后台刷新写同一张表，
-        // 这是「一个事实一个 owner」的落点。快照采样保持只挂真查。
+        // 这是「一个事实一个 owner」的落点。未登录行没有账号维度，只采样不缓存。
+        // 快照采样保持只挂真查。
         let state = app_handle.state::<AppState>();
         let cached_value = usage
             .data
             .as_ref()
             .and_then(|items| items.first())
             .and_then(|item| item.remaining);
-        if let Err(e) = balance::upsert_site_balance(
-            &state.db,
-            &relay.site_origin,
-            (cached_value, chrono::Utc::now().timestamp()),
-        ) {
-            log::warn!("[site-balance] 行查询写缓存失败: {e}");
+        if let Some(account_id) = relay.account_id {
+            if let Err(e) = balance::upsert_site_balance(
+                &state.db,
+                &(relay.site_origin.clone(), account_id),
+                (cached_value, chrono::Utc::now().timestamp()),
+            ) {
+                log::warn!("[site-balance] 行查询写缓存失败: {e}");
+            }
         }
         reconcile::capture_balance_snapshot(&state.db, relay_id, &usage);
     }
@@ -234,6 +244,126 @@ mod tests {
             .expect("forced resolve");
         assert!(forced.usage.success);
         assert_eq!(hits.load(Ordering::SeqCst), 2, "force 必须真的重新查");
+    }
+
+    /// ⭐ 同站双账号端到端：A 行的余额查询不能命中、也不能覆盖 B 行的缓存
+    /// （缓存键 = 站点 + 账号）。修复前两行共用一个缓存槽，后查的账号把先查的
+    /// 顶掉 —— 界面上两行显示同一个数。
+    #[tokio::test]
+    async fn same_site_two_accounts_do_not_share_cache_entries() {
+        // mock 按 bearer token 回不同余额：token-a → 1.0，token-b → 2.0
+        let router = {
+            use axum::http::HeaderMap;
+            use axum::routing::get;
+            use axum::Json;
+            axum::Router::new().route(
+                "/api/v1/user/profile",
+                get(|headers: HeaderMap| async move {
+                    let auth = headers
+                        .get(axum::http::header::AUTHORIZATION)
+                        .and_then(|value| value.to_str().ok())
+                        .unwrap_or_default();
+                    let balance = if auth.contains("token-b") { 2.0 } else { 1.0 };
+                    Json(serde_json::json!({
+                        "code": 0, "message": "success",
+                        "data": { "id": 7, "username": "u", "email": "u@example.com",
+                                  "balance": balance, "frozen_balance": 0.0 }
+                    }))
+                }),
+            )
+        };
+        let (origin, _server) = spawn_balance_server(router).await;
+
+        // 同站两行两个账号（7 / token-a，8 / token-b）
+        let db = std::sync::Arc::new(crate::database::Database::memory().expect("内存库"));
+        let (row_a, row_b) = {
+            let conn = db.conn.lock().expect("锁内存库");
+            let row_a = creds::save_site_with_backend(
+                &conn,
+                &origin,
+                "A",
+                &origin,
+                discovery::BackendKind::Sub2Api,
+            )
+            .expect("建 A 行");
+            creds::save_credentials(
+                &conn,
+                row_a,
+                creds::AccountIdentity {
+                    id: 7,
+                    label: "A",
+                    login_identifier: "a",
+                },
+                "token-a",
+                Some("refresh-a"),
+                None,
+                creds::SessionEnvironment::default(),
+            )
+            .expect("存 A 登录态");
+            let row_b = creds::save_site_with_backend(
+                &conn,
+                &origin,
+                "B",
+                &origin,
+                discovery::BackendKind::Sub2Api,
+            )
+            .expect("建 B 行");
+            creds::save_credentials(
+                &conn,
+                row_b,
+                creds::AccountIdentity {
+                    id: 8,
+                    label: "B",
+                    login_identifier: "b",
+                },
+                "token-b",
+                Some("refresh-b"),
+                None,
+                creds::SessionEnvironment::default(),
+            )
+            .expect("存 B 登录态");
+            (row_a, row_b)
+        };
+        let app = tauri::test::mock_builder()
+            .manage(AppState::new(db))
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("mock app");
+
+        let remaining = |result: &balance::RowBalanceResult| {
+            result
+                .usage
+                .data
+                .as_ref()
+                .and_then(|items| items.first())
+                .and_then(|item| item.remaining)
+                .expect("成功路径必有余额")
+        };
+
+        // A 首查：真查落缓存（origin, 7) = 1.0
+        let a_first = relay_balance_impl(app.handle(), row_a, false)
+            .await
+            .expect("A 首查");
+        assert_eq!(remaining(&a_first), 1.0);
+
+        // B 查：不得命中 A 的缓存，必须真查到自己的 2.0（修复前这里秒回 A 的 1.0）
+        let b_first = relay_balance_impl(app.handle(), row_b, false)
+            .await
+            .expect("B 查询");
+        assert_eq!(
+            remaining(&b_first),
+            2.0,
+            "B 行必须查到 B 账号的钱包，不能读到 A 的缓存"
+        );
+
+        // A 再查：仍读自己的 1.0 —— B 的写入没有顶掉 A 的缓存行
+        let a_second = relay_balance_impl(app.handle(), row_a, false)
+            .await
+            .expect("A 再查");
+        assert_eq!(
+            remaining(&a_second),
+            1.0,
+            "B 的查询/写缓存不得影响 A 的缓存行"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/relay/windows.rs
+++ b/src-tauri/src/commands/relay/windows.rs
@@ -206,11 +206,13 @@ pub(crate) async fn open_sub2api_site_window<R: tauri::Runtime>(
     let close_handle = app_handle.clone();
     let close_site = site_account.site_origin.clone();
     let close_api_base = site_account.api_base_url.clone();
+    let close_account = site_account.account_id;
     built.on_window_event(move |event| {
         if matches!(event, tauri::WindowEvent::Destroyed) {
             let _ = handle_for_close.emit(PURCHASE_CLOSED, closed_relay_id);
             let handle = close_handle.clone();
             let (site, api_base) = (close_site.clone(), close_api_base.clone());
+            let account_id = close_account;
             // db 在事件内取：开窗路径不碰全局 state（headless 窗口测试没有 manage）
             tauri::async_runtime::spawn(async move {
                 let db = handle.state::<AppState>().db.clone();
@@ -219,6 +221,7 @@ pub(crate) async fn open_sub2api_site_window<R: tauri::Runtime>(
                     Some(handle),
                     &site,
                     &api_base,
+                    account_id,
                 );
             });
         }

--- a/src-tauri/src/database/loongport_schema.rs
+++ b/src-tauri/src/database/loongport_schema.rs
@@ -48,7 +48,7 @@ use crate::error::AppError;
 /// LoongPort 自己的 schema 版本。加迁移时 +1。
 ///
 /// **与 `SCHEMA_VERSION`（上游那个）无关**，两者各自独立计数。
-pub(crate) const LOONGPORT_SCHEMA_VERSION: i32 = 19;
+pub(crate) const LOONGPORT_SCHEMA_VERSION: i32 = 20;
 
 /// 存版本号的表。**只有一行**（`id = 1`）。
 ///
@@ -291,6 +291,18 @@ pub(crate) fn apply(conn: &Connection) -> Result<(), AppError> {
                 log::info!("LoongPort 数据迁移 v18 → v19（站点余额缓存表）");
                 crate::relay::balance::create_site_balance_cache_table(conn)?;
                 set_version(conn, 19)?;
+            }
+            19 => {
+                log::info!("LoongPort 数据迁移 v19 → v20（站点余额缓存改按站点+账号复合键）");
+                // v19 的表主键只有 site_origin，同站两个账号会共用一行缓存互相顶掉
+                // 余额。它是 TTL 600s 的纯缓存，直接弃旧表重建，不搬数据 —— 重建后
+                // 由冷启补刷 / 首次读取重新落值。
+                conn.execute("DROP TABLE IF EXISTS site_balance_cache", [])
+                    .map_err(|error| {
+                        AppError::Database(format!("删旧站点余额缓存表失败: {error}"))
+                    })?;
+                crate::relay::balance::create_site_balance_cache_table(conn)?;
+                set_version(conn, 20)?;
             }
             other => {
                 return Err(AppError::Database(format!(
@@ -991,18 +1003,64 @@ mod tests {
             "前提：升级前本表不存在"
         );
 
-        apply(&conn).expect("迁移到 v19");
+        apply(&conn).expect("迁移到最新");
 
         assert!(
             Database::table_exists(&conn, "site_balance_cache").expect("查表"),
             "v18 → v19 必须建出站点余额缓存表"
         );
         conn.execute(
+            "INSERT INTO site_balance_cache (site_origin, account_id, balance_usd, fetched_at)
+             VALUES ('https://a.example', 7, 1.5, 0)",
+            [],
+        )
+        .expect("迁移后必须可写（复合键形态）");
+        assert_eq!(current_version(&conn).unwrap(), LOONGPORT_SCHEMA_VERSION);
+    }
+
+    /// ⭐ v19→v20 余额缓存换复合键形态：停在 v19 的老库（旧主键只有 site_origin）
+    /// 升级后必须重建出「站点+账号」复合键的表；旧缓存行允许直接丢弃（纯缓存，
+    /// 重建后重新落值）。
+    #[test]
+    fn v19_to_v20_rebuilds_balance_cache_with_composite_key() {
+        let conn = mem();
+        ensure_version_table(&conn).expect("建版本表");
+        // 造一个停在 v19、持有**旧形态**表和数据的库
+        conn.execute(
+            "CREATE TABLE site_balance_cache (
+                site_origin TEXT PRIMARY KEY,
+                balance_usd REAL,
+                fetched_at INTEGER NOT NULL
+            )",
+            [],
+        )
+        .expect("建旧形态表");
+        conn.execute(
             "INSERT INTO site_balance_cache (site_origin, balance_usd, fetched_at)
              VALUES ('https://a.example', 1.5, 0)",
             [],
         )
-        .expect("迁移后必须可写");
+        .expect("塞一条旧缓存");
+        set_version(&conn, 19).expect("设为 v19");
+
+        apply(&conn).expect("迁移到 v20");
+
+        // 复合键形态可写：同站两个账号各占一行不冲突（旧单列主键下第二条会顶掉第一条）
+        conn.execute(
+            "INSERT INTO site_balance_cache (site_origin, account_id, balance_usd, fetched_at)
+             VALUES ('https://a.example', 331, 4.0, 1),
+                    ('https://a.example', 354, 9.0, 1)",
+            [],
+        )
+        .expect("复合键下同站双账号必须能共存");
+        let rows: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM site_balance_cache WHERE site_origin = 'https://a.example'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(rows, 2, "旧单键缓存行已被弃表清掉，新行双账号共存");
         assert_eq!(current_version(&conn).unwrap(), LOONGPORT_SCHEMA_VERSION);
     }
 

--- a/src-tauri/src/relay/balance.rs
+++ b/src-tauri/src/relay/balance.rs
@@ -285,23 +285,34 @@ fn wallet_usage(balance: f64) -> UsageResult {
 // 站点余额缓存（省心看板 SWR）
 // ============================================================================
 
-/// 看板余额的缓存表：`origin → (余额, 拉取时刻)`，每站一行。
+/// 看板余额的缓存表：`(origin, 账号) → (余额, 拉取时刻)`，每站**每账号**一行。
 ///
-/// 由 `create_tables_on_conn`（全新库）与 LoongPort 迁移 v18 → v19（老库）
-/// 共同调用，两边建的必须是同一形态 —— 见 `database/loongport_schema.rs`
+/// 由 `create_tables_on_conn`（全新库）与 LoongPort 迁移 v19 → v20（老库，弃旧表
+/// 重建）共同调用，两边建的必须是同一形态 —— 见 `database/loongport_schema.rs`
 /// 的头注释。
 pub fn create_site_balance_cache_table(conn: &rusqlite::Connection) -> Result<(), AppError> {
     conn.execute(
         "CREATE TABLE IF NOT EXISTS site_balance_cache (
-            site_origin TEXT PRIMARY KEY,
+            site_origin TEXT NOT NULL,
+            account_id INTEGER NOT NULL,
             balance_usd REAL,
-            fetched_at INTEGER NOT NULL
+            fetched_at INTEGER NOT NULL,
+            PRIMARY KEY (site_origin, account_id)
         )",
         [],
     )
     .map_err(|e| AppError::Database(format!("创建 site_balance_cache 表失败: {e}")))?;
     Ok(())
 }
+
+/// 缓存键：站点 origin × 账号 id。
+///
+/// 钱包余额归**账号**所有 —— 同一个站挂两个账号是两个独立事实，只按站点键控
+/// 会让后写的账号把先写的顶掉（档位层 `provision::provider_id_for` 修过同款
+/// 前科，见它那边的注释）。账号维度取自行的 `RelayAccount::account_id` /
+/// 档位的 `meta.loongport_account_id`；没有账号身份的（未登录行、vendor 档）
+/// 不参与这张缓存，各走自己的真查路径。
+pub type SiteAccountKey = (String, i64);
 
 /// 缓存 TTL（秒）：超过视为 stale，看板读到时踢一次后台刷新。
 pub const SITE_BALANCE_TTL_SECS: i64 = 600;
@@ -314,28 +325,29 @@ const SITE_BALANCE_FETCH_BUDGET_SECS: u64 = 15;
 /// 没有负缓存的话，查不出余额的站每次打开看板都会重查一遍。
 pub type SiteBalanceEntry = (Option<f64>, i64);
 
-/// 读全表（行数 = 站点数，个位到几十）。
+/// 读全表（行数 = 站点×账号，个位到几十）。
 pub fn cached_site_balances(
     db: &crate::database::Database,
-) -> std::collections::HashMap<String, SiteBalanceEntry> {
+) -> std::collections::HashMap<SiteAccountKey, SiteBalanceEntry> {
     // 非 Result 返回值的锁惯例：毒锁取内值（与 commands::auto_mode 的直查一致），
     // 读缓存失败按「无缓存」处理 —— 看板照常返回，stale 判定自然触发刷新。
     let conn = db
         .conn
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let mut stmt =
-        match conn.prepare("SELECT site_origin, balance_usd, fetched_at FROM site_balance_cache") {
-            Ok(stmt) => stmt,
-            Err(e) => {
-                log::warn!("读 site_balance_cache 失败（按无缓存处理）: {e}");
-                return std::collections::HashMap::new();
-            }
-        };
+    let mut stmt = match conn
+        .prepare("SELECT site_origin, account_id, balance_usd, fetched_at FROM site_balance_cache")
+    {
+        Ok(stmt) => stmt,
+        Err(e) => {
+            log::warn!("读 site_balance_cache 失败（按无缓存处理）: {e}");
+            return std::collections::HashMap::new();
+        }
+    };
     let rows = stmt.query_map([], |row| {
         Ok((
-            row.get::<_, String>(0)?,
-            (row.get::<_, Option<f64>>(1)?, row.get::<_, i64>(2)?),
+            (row.get::<_, String>(0)?, row.get::<_, i64>(1)?),
+            (row.get::<_, Option<f64>>(2)?, row.get::<_, i64>(3)?),
         ))
     });
     match rows {
@@ -347,18 +359,19 @@ pub fn cached_site_balances(
     }
 }
 
-/// 读单站缓存（行级余额条的读路径）。`None` = 没进过缓存。
+/// 读单条缓存（行级余额条的读路径）。`None` = 没进过缓存。
 pub fn cached_site_balance(
     db: &crate::database::Database,
-    origin: &str,
+    key: &SiteAccountKey,
 ) -> Option<SiteBalanceEntry> {
     let conn = db
         .conn
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     conn.query_row(
-        "SELECT balance_usd, fetched_at FROM site_balance_cache WHERE site_origin = ?1",
-        rusqlite::params![origin],
+        "SELECT balance_usd, fetched_at FROM site_balance_cache
+         WHERE site_origin = ?1 AND account_id = ?2",
+        rusqlite::params![key.0, key.1],
         |row| Ok((row.get::<_, Option<f64>>(0)?, row.get::<_, i64>(1)?)),
     )
     .ok()
@@ -396,62 +409,63 @@ pub fn cached_row_balance_result(entry: &SiteBalanceEntry) -> RowBalanceResult {
 /// 幂等写一行（含负缓存）。
 pub fn upsert_site_balance(
     db: &crate::database::Database,
-    origin: &str,
+    key: &SiteAccountKey,
     entry: SiteBalanceEntry,
 ) -> Result<(), AppError> {
     let conn = crate::database::lock_conn!(db.conn);
     conn.execute(
-        "INSERT INTO site_balance_cache (site_origin, balance_usd, fetched_at)
-         VALUES (?1, ?2, ?3)
-         ON CONFLICT(site_origin) DO UPDATE SET
+        "INSERT INTO site_balance_cache (site_origin, account_id, balance_usd, fetched_at)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT(site_origin, account_id) DO UPDATE SET
             balance_usd = excluded.balance_usd,
             fetched_at = excluded.fetched_at",
-        rusqlite::params![origin, entry.0, entry.1],
+        rusqlite::params![key.0, key.1, entry.0, entry.1],
     )
     .map_err(|e| AppError::Database(format!("写 site_balance_cache 失败: {e}")))?;
     Ok(())
 }
 
-/// 删指定站的缓存行 —— 充值等「余额已确定变化」的时刻用：旧值必然错了，
+/// 删指定键的缓存行 —— 充值等「余额已确定变化」的时刻用：旧值必然错了，
 /// 留着只会误导，删掉后由紧随的单站刷新重新落值。
 pub fn drop_site_cache(
     db: &crate::database::Database,
-    origins: &std::collections::HashSet<String>,
+    keys: &std::collections::HashSet<SiteAccountKey>,
 ) {
     let conn = db
         .conn
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    for origin in origins {
+    for (origin, account_id) in keys {
         if let Err(e) = conn.execute(
-            "DELETE FROM site_balance_cache WHERE site_origin = ?1",
-            rusqlite::params![origin],
+            "DELETE FROM site_balance_cache WHERE site_origin = ?1 AND account_id = ?2",
+            rusqlite::params![origin, account_id],
         ) {
-            log::warn!("[site-balance] 删缓存失败 {origin}: {e}");
+            log::warn!("[site-balance] 删缓存失败 {origin}/#{account_id}: {e}");
         }
     }
 }
 
-/// 哪些站需要刷新：没进过缓存的 + `fetched_at` 超 TTL 的（纯函数）。
+/// 哪些键需要刷新：没进过缓存的 + `fetched_at` 超 TTL 的（纯函数）。
 fn stale_balance_sites(
-    wanted: &std::collections::HashMap<String, String>,
-    cached: &std::collections::HashMap<String, SiteBalanceEntry>,
+    wanted: &std::collections::HashMap<SiteAccountKey, String>,
+    cached: &std::collections::HashMap<SiteAccountKey, SiteBalanceEntry>,
     now: i64,
-) -> Vec<(String, String)> {
+) -> Vec<(SiteAccountKey, String)> {
     wanted
         .iter()
-        .filter(|(origin, _)| match cached.get(*origin) {
+        .filter(|(key, _)| match cached.get(*key) {
             Some((_, fetched_at)) => now - *fetched_at > SITE_BALANCE_TTL_SECS,
             None => true,
         })
-        .map(|(origin, key)| (origin.clone(), key.clone()))
+        .map(|(key, sk)| (key.clone(), sk.clone()))
         .collect()
 }
 
-/// 单飞集合：正在后台刷新的 origin。看板查询可能高频触发（多 app + 窗口聚焦），
+/// 单飞集合：正在后台刷新的 (origin, 账号)。看板查询可能高频触发（多 app + 窗口聚焦），
 /// 没有这道闸会叠出一串重复扇出。
-static REFRESH_INFLIGHT: std::sync::OnceLock<std::sync::Mutex<std::collections::HashSet<String>>> =
-    std::sync::OnceLock::new();
+static REFRESH_INFLIGHT: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashSet<SiteAccountKey>>,
+> = std::sync::OnceLock::new();
 
 /// 读时惰性刷新（SWR 的 revalidate）：筛出 stale 站点交给后台任务 ——
 /// sk 直查 → 写缓存 → 发 [`crate::events::SITE_BALANCES_UPDATED`] 让前端补值。
@@ -466,7 +480,7 @@ static REFRESH_INFLIGHT: std::sync::OnceLock<std::sync::Mutex<std::collections::
 pub fn spawn_stale_refresh<R: tauri::Runtime>(
     db: std::sync::Arc<crate::database::Database>,
     app_handle: Option<tauri::AppHandle<R>>,
-    wanted: std::collections::HashMap<String, String>,
+    wanted: std::collections::HashMap<SiteAccountKey, String>,
 ) {
     let now = chrono::Utc::now().timestamp();
     let stale = {
@@ -481,7 +495,7 @@ pub fn spawn_stale_refresh<R: tauri::Runtime>(
         };
         let fresh: Vec<_> = stale
             .into_iter()
-            .filter(|(origin, _)| guard.insert(origin.clone()))
+            .filter(|(key, _)| guard.insert(key.clone()))
             .collect();
         fresh
     };
@@ -490,35 +504,39 @@ pub fn spawn_stale_refresh<R: tauri::Runtime>(
     }
 
     tokio::spawn(async move {
-        let origins: Vec<String> = stale.iter().map(|(origin, _)| origin.clone()).collect();
-        let results = futures::future::join_all(stale.into_iter().map(|(origin, key)| async move {
+        let keys: Vec<SiteAccountKey> = stale.iter().map(|(key, _)| key.clone()).collect();
+        let results = futures::future::join_all(stale.into_iter().map(|(key, sk)| async move {
             let fetched = match tokio::time::timeout(
                 std::time::Duration::from_secs(SITE_BALANCE_FETCH_BUDGET_SECS),
-                fetch_site_balance(&origin, &key),
+                fetch_site_balance(&key.0, &sk),
             )
             .await
             {
                 Ok(balance) => balance,
                 Err(_elapsed) => {
-                    log::warn!("[site-balance] {origin} 余额链超预算（{SITE_BALANCE_FETCH_BUDGET_SECS}s），本次记负缓存");
+                    log::warn!(
+                        "[site-balance] {}#{} 余额链超预算（{SITE_BALANCE_FETCH_BUDGET_SECS}s），本次记负缓存",
+                        key.0,
+                        key.1
+                    );
                     None
                 }
             };
-            (origin, fetched)
+            (key, fetched)
         }))
         .await;
 
         let now = chrono::Utc::now().timestamp();
-        for (origin, balance) in results {
-            if let Err(e) = upsert_site_balance(&db, &origin, (balance, now)) {
-                log::warn!("[site-balance] 写缓存失败 {origin}: {e}");
+        for (key, balance) in results {
+            if let Err(e) = upsert_site_balance(&db, &key, (balance, now)) {
+                log::warn!("[site-balance] 写缓存失败 {}#{}: {e}", key.0, key.1);
             }
         }
 
         if let Some(inflight) = REFRESH_INFLIGHT.get() {
             if let Ok(mut guard) = inflight.lock() {
-                for origin in origins {
-                    guard.remove(&origin);
+                for key in keys {
+                    guard.remove(&key);
                 }
             }
         }
@@ -566,23 +584,52 @@ mod tests {
     fn site_balance_cache_roundtrips_including_negative_entries() {
         let db = cache_db();
         let now = 1_000_000_i64;
-        upsert_site_balance(&db, "https://a.example", (Some(9.5), now)).unwrap();
-        upsert_site_balance(&db, "https://dead.example", (None, now)).unwrap();
+        upsert_site_balance(&db, &("https://a.example".into(), 7), (Some(9.5), now)).unwrap();
+        upsert_site_balance(&db, &("https://dead.example".into(), 7), (None, now)).unwrap();
 
         let cached = cached_site_balances(&db);
-        assert_eq!(cached.get("https://a.example"), Some(&(Some(9.5), now)));
         assert_eq!(
-            cached.get("https://dead.example"),
+            cached.get(&("https://a.example".to_string(), 7)),
+            Some(&(Some(9.5), now))
+        );
+        assert_eq!(
+            cached.get(&("https://dead.example".to_string(), 7)),
             Some(&(None, now)),
             "负缓存（查过无值）也要占位，否则死站每次打开都重查"
         );
-        assert!(!cached.contains_key("https://never.example"));
+        assert!(!cached.contains_key(&("https://never.example".to_string(), 7)));
 
-        // 覆盖写：同站新值顶旧值
-        upsert_site_balance(&db, "https://a.example", (Some(8.0), now + 1)).unwrap();
+        // 覆盖写：同键新值顶旧值
+        upsert_site_balance(&db, &("https://a.example".into(), 7), (Some(8.0), now + 1)).unwrap();
         assert_eq!(
-            cached_site_balances(&db).get("https://a.example"),
+            cached_site_balances(&db).get(&("https://a.example".to_string(), 7)),
             Some(&(Some(8.0), now + 1))
+        );
+    }
+
+    /// ⭐ 同站双账号是两个事实：A 的写入绝不能顶掉 B 的缓存行（键里必须有账号）。
+    #[test]
+    fn same_site_two_accounts_keep_independent_cache_rows() {
+        let db = cache_db();
+        let now = 1_000_000_i64;
+        upsert_site_balance(&db, &("https://a.example".into(), 331), (Some(4.0), now)).unwrap();
+        upsert_site_balance(&db, &("https://a.example".into(), 354), (Some(9.0), now)).unwrap();
+
+        let cached = cached_site_balances(&db);
+        assert_eq!(
+            cached.get(&("https://a.example".to_string(), 331)),
+            Some(&(Some(4.0), now)),
+            "后写另一账号不能顶掉先写账号的行"
+        );
+        assert_eq!(
+            cached.get(&("https://a.example".to_string(), 354)),
+            Some(&(Some(9.0), now))
+        );
+
+        // 单键读也只读到自己账号那条
+        assert_eq!(
+            cached_site_balance(&db, &("https://a.example".into(), 331)),
+            Some((Some(4.0), now))
         );
     }
 
@@ -593,25 +640,28 @@ mod tests {
         let fresh = now - (SITE_BALANCE_TTL_SECS - 1);
         let stale = now - (SITE_BALANCE_TTL_SECS + 1);
         let mut wanted = std::collections::HashMap::new();
-        wanted.insert("https://fresh.example".to_string(), "k1".to_string());
-        wanted.insert("https://stale.example".to_string(), "k2".to_string());
-        wanted.insert("https://missing.example".to_string(), "k3".to_string());
+        wanted.insert(("https://fresh.example".to_string(), 1), "k1".to_string());
+        wanted.insert(("https://stale.example".to_string(), 1), "k2".to_string());
+        wanted.insert(("https://missing.example".to_string(), 1), "k3".to_string());
         wanted.insert(
-            "https://fresh-negative.example".to_string(),
+            ("https://fresh-negative.example".to_string(), 1),
             "k4".to_string(),
         );
         let mut cached = std::collections::HashMap::new();
-        cached.insert("https://fresh.example".to_string(), (Some(1.0), fresh));
-        cached.insert("https://stale.example".to_string(), (Some(2.0), stale));
-        cached.insert("https://fresh-negative.example".to_string(), (None, fresh));
+        cached.insert(("https://fresh.example".to_string(), 1), (Some(1.0), fresh));
+        cached.insert(("https://stale.example".to_string(), 1), (Some(2.0), stale));
+        cached.insert(
+            ("https://fresh-negative.example".to_string(), 1),
+            (None, fresh),
+        );
 
         let mut stale_sites = stale_balance_sites(&wanted, &cached, now);
         stale_sites.sort();
         assert_eq!(
             stale_sites,
             vec![
-                ("https://missing.example".to_string(), "k3".to_string()),
-                ("https://stale.example".to_string(), "k2".to_string()),
+                (("https://missing.example".to_string(), 1), "k3".to_string()),
+                (("https://stale.example".to_string(), 1), "k2".to_string()),
             ],
             "TTL 内的正/负缓存都不刷；缺缓存与超 TTL 的要刷"
         );
@@ -625,7 +675,7 @@ mod tests {
         let mut wanted = std::collections::HashMap::new();
         // .example 是保留 TLD，DNS 必然快速失败（离线环境同样快速失败）
         wanted.insert(
-            "https://nonexistent.example".to_string(),
+            ("https://nonexistent.example".to_string(), 7),
             "sk-x".to_string(),
         );
 
@@ -633,7 +683,8 @@ mod tests {
 
         for _ in 0..250 {
             let cached = cached_site_balances(&db);
-            if let Some((balance, _)) = cached.get("https://nonexistent.example") {
+            if let Some((balance, _)) = cached.get(&("https://nonexistent.example".to_string(), 7))
+            {
                 assert_eq!(*balance, None, "不可达站必须是负缓存而不是有值");
                 return;
             }

--- a/src-tauri/src/relay/newapi_purchase.rs
+++ b/src-tauri/src/relay/newapi_purchase.rs
@@ -278,12 +278,14 @@ pub(crate) fn build_window<R: tauri::Runtime>(
     let close_handle = app_handle.clone();
     let close_site = relay.site_origin.clone();
     let close_api_base = relay.api_base_url.clone();
+    let close_account = relay.account_id;
     built.on_window_event(move |event| {
         if matches!(event, tauri::WindowEvent::Destroyed) {
             let _ = handle_for_close.emit(PURCHASE_CLOSED, closed_relay_id);
             let _ = shutdown.send(true);
             let handle = close_handle.clone();
             let (site, api_base) = (close_site.clone(), close_api_base.clone());
+            let account_id = close_account;
             // db 在事件内取：开窗路径不碰全局 state（headless 窗口测试没有 manage）
             tauri::async_runtime::spawn(async move {
                 let db = handle.state::<AppState>().db.clone();
@@ -292,6 +294,7 @@ pub(crate) fn build_window<R: tauri::Runtime>(
                     Some(handle),
                     &site,
                     &api_base,
+                    account_id,
                 );
             });
         }

--- a/src-tauri/src/services/site_balance_refresh.rs
+++ b/src-tauri/src/services/site_balance_refresh.rs
@@ -33,25 +33,36 @@ pub(crate) fn origin_of(base_url: &str) -> Option<String> {
 }
 
 /// 档位 → 站点余额查询材料的解析（纯本地，无网络）：
-/// - `tier_origins`：档位 id → 站点 origin（https 端点才参与，http/本地/无 sk
-///   自然跳过 —— 单元测试零网络）；
-/// - `site_keys`：origin → 该站第一把 sk（同站多档共用一份站点余额）。
+/// - `tier_keys`：档位 id → 缓存键 `(origin, account_id)`（https 端点才参与，
+///   http/本地/无 sk 自然跳过 —— 单元测试零网络）；
+/// - `site_keys`：缓存键 → 该账号第一把 sk（同账号多档共用一份钱包余额；
+///   同站**不同账号**是不同键，见 [`balance::SiteAccountKey`]）。
+///
+/// 档位没有账号归属（`meta.loongport_account_id` 为 `None`）就不进这条链：
+/// vendor 档的账号身份是字符串（另一套体系），未记账号的老托管档则定位不了
+/// 该显示谁的钱包 —— 宁可不查，不能挂到别的账号头上。
 ///
 /// 网络查询本身在 [`balance::spawn_stale_refresh`]（后台 SWR）。
 pub(crate) fn tier_site_keys(
     app_type: &str,
     tiers: &[Provider],
-) -> (HashMap<String, String>, HashMap<String, String>) {
-    let mut tier_origins = HashMap::new();
+) -> (
+    HashMap<String, balance::SiteAccountKey>,
+    HashMap<balance::SiteAccountKey, String>,
+) {
+    let mut tier_keys = HashMap::new();
     let mut site_keys = HashMap::new();
     let app = match AppType::from_str(app_type) {
         Ok(app) => app,
-        Err(_) => return (tier_origins, site_keys),
+        Err(_) => return (tier_keys, site_keys),
     };
     let Some(adapter) = crate::proxy::providers::get_adapter(&app) else {
-        return (tier_origins, site_keys);
+        return (tier_keys, site_keys);
     };
     for tier in tiers {
+        let Some(account_id) = tier.meta.as_ref().and_then(|m| m.loongport_account_id) else {
+            continue;
+        };
         let (base, auth) = match (adapter.extract_base_url(tier), adapter.extract_auth(tier)) {
             (Ok(base), Some(auth)) => (base, auth),
             _ => continue,
@@ -62,16 +73,17 @@ pub(crate) fn tier_site_keys(
         if !origin.starts_with("https://") {
             continue;
         }
-        tier_origins.insert(tier.id.clone(), origin.clone());
-        site_keys.entry(origin).or_insert(auth.api_key);
+        let key: balance::SiteAccountKey = (origin, account_id);
+        tier_keys.insert(tier.id.clone(), key.clone());
+        site_keys.entry(key).or_insert(auth.api_key);
     }
-    (tier_origins, site_keys)
+    (tier_keys, site_keys)
 }
 
 /// 全部托管档（跨 app）的站点查询材料。模式无关：只看「有哪些托管档」，
 /// 不看用户在用省心还是自主 —— 两种模式底下是同一批站点数据。
-fn collect_all_site_keys(db: &Database) -> HashMap<String, String> {
-    let mut merged: HashMap<String, String> = HashMap::new();
+fn collect_all_site_keys(db: &Database) -> HashMap<balance::SiteAccountKey, String> {
+    let mut merged: HashMap<balance::SiteAccountKey, String> = HashMap::new();
     for app in AppType::all() {
         let Ok(providers) = db.get_all_providers(app.as_str()) else {
             continue;
@@ -84,8 +96,8 @@ fn collect_all_site_keys(db: &Database) -> HashMap<String, String> {
             continue;
         }
         let (_, site_keys) = tier_site_keys(app.as_str(), &tiers);
-        for (origin, key) in site_keys {
-            merged.entry(origin).or_insert(key);
+        for (key, sk) in site_keys {
+            merged.entry(key).or_insert(sk);
         }
     }
     merged
@@ -101,26 +113,34 @@ pub fn startup_kick<R: tauri::Runtime>(
     balance::spawn_stale_refresh(db.clone(), app_handle, wanted);
 }
 
-/// 充值窗关闭：先删该站缓存行（充值后旧值必错），再立即单站补刷 ——
+/// 充值窗关闭：先删该账号的缓存行（充值后旧值必错），再立即单账号补刷 ——
 /// 事件驱动、单站、秒级，与关窗刷行余额（JWT 路）互补。
+///
+/// 只动**充值那个账号**的缓存行：同站另一个账号的钱包没变，不该跟着作废重查。
+/// 行没登录（`account_id` 为 `None`）时新键控下本来就没有它的缓存行，无事可做。
 pub fn refresh_after_purchase<R: tauri::Runtime>(
     db: &Arc<Database>,
     app_handle: Option<tauri::AppHandle<R>>,
     relay_site_origin: &str,
     relay_api_base: &str,
+    account_id: Option<i64>,
 ) {
-    let origins: HashSet<String> = [relay_site_origin, relay_api_base]
+    let Some(account_id) = account_id else {
+        return;
+    };
+    let keys: HashSet<balance::SiteAccountKey> = [relay_site_origin, relay_api_base]
         .into_iter()
         .filter_map(origin_of)
+        .map(|origin| (origin, account_id))
         .collect();
-    if origins.is_empty() {
+    if keys.is_empty() {
         return;
     }
-    balance::drop_site_cache(db, &origins);
+    balance::drop_site_cache(db, &keys);
 
-    let wanted: HashMap<String, String> = collect_all_site_keys(db)
+    let wanted: HashMap<balance::SiteAccountKey, String> = collect_all_site_keys(db)
         .into_iter()
-        .filter(|(origin, _)| origins.contains(origin))
+        .filter(|(key, _)| keys.contains(key))
         .collect();
     if wanted.is_empty() {
         return;
@@ -146,96 +166,156 @@ mod tests {
         assert_eq!(origin_of("https://"), None);
     }
 
-    /// 冷启补刷的站点收集：同站多档去重、只认托管档、http 端点不参与（零网络）。
+    /// 带 `loongport_account_id` 归属的托管档（真档位 provision 起就带，见
+    /// `ProviderMeta::loongport_account_id` 的文档）。
+    fn managed_tier(id: &str, base: &str, account_id: Option<i64>) -> Provider {
+        let mut provider = Provider::with_id(
+            id.to_string(),
+            id.to_string(),
+            serde_json::json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": base,
+                    "ANTHROPIC_AUTH_TOKEN": "sk-test-not-a-real-key",
+                }
+            }),
+            None,
+        );
+        provider.meta = Some(crate::provider::ProviderMeta {
+            loongport_account_id: account_id,
+            ..Default::default()
+        });
+        provider
+    }
+
+    /// 冷启补刷的站点收集：同账号多档去重、同站不同账号分开、只认托管档、
+    /// http 端点不参与、无账号归属不进链（零网络）。
     #[test]
     fn collect_all_site_keys_dedupes_and_filters() {
         let db = Database::memory().unwrap();
-        let tier = |id: &str, app: &str, base: &str| {
-            db.save_provider(
-                app,
-                &Provider::with_id(
-                    id.to_string(),
-                    id.to_string(),
-                    serde_json::json!({
-                        "env": {
-                            "ANTHROPIC_BASE_URL": base,
-                            "ANTHROPIC_AUTH_TOKEN": "sk-test-not-a-real-key",
-                        }
-                    }),
-                    None,
-                ),
-            )
-            .unwrap();
+        let tier = |provider: Provider, app: &str| {
+            db.save_provider(app, &provider).unwrap();
         };
-        // 同站两档（不同分组）：origin 去重成一把 key
+        // 同站同账号两档（不同分组）：去重成一个键
         tier(
-            &crate::relay::provision::provider_id_for("https://a.example", Some(1), 1),
+            managed_tier(
+                &crate::relay::provision::provider_id_for("https://a.example", Some(1), 1),
+                "https://a.example",
+                Some(1),
+            ),
             "claude",
-            "https://a.example",
         );
         tier(
-            &crate::relay::provision::provider_id_for("https://a.example", Some(1), 2),
+            managed_tier(
+                &crate::relay::provision::provider_id_for("https://a.example", Some(1), 2),
+                "https://a.example/v1",
+                Some(1),
+            ),
             "claude",
-            "https://a.example/v1",
+        );
+        // 同站另一个账号的档：独立成键，不许被同站去重吞掉
+        tier(
+            managed_tier(
+                &crate::relay::provision::provider_id_for("https://a.example", Some(2), 1),
+                "https://a.example",
+                Some(2),
+            ),
+            "claude",
         );
         // 非托管档与 http 档：不进收集
-        tier("manual-tier", "claude", "https://b.example");
         tier(
-            &crate::relay::provision::provider_id_for("http://c.example", Some(1), 3),
+            managed_tier("manual-tier", "https://b.example", Some(1)),
             "claude",
-            "http://c.example",
+        );
+        tier(
+            managed_tier(
+                &crate::relay::provision::provider_id_for("http://c.example", Some(1), 3),
+                "http://c.example",
+                Some(1),
+            ),
+            "claude",
+        );
+        // 无账号归属的托管档：定位不了钱包归谁，不进链
+        tier(
+            managed_tier(
+                &crate::relay::provision::provider_id_for("https://d.example", Some(1), 1),
+                "https://d.example",
+                None,
+            ),
+            "claude",
         );
 
         let wanted = collect_all_site_keys(&db);
-        assert_eq!(wanted.len(), 1, "只留 a.example（同站去重、http/手工排除）");
-        assert!(wanted.contains_key("https://a.example"));
+        assert_eq!(
+            wanted.len(),
+            2,
+            "只留 a.example 的两个账号（同账号去重、http/手工/无归属排除）"
+        );
+        assert!(wanted.contains_key(&("https://a.example".to_string(), 1)));
+        assert!(wanted.contains_key(&("https://a.example".to_string(), 2)));
     }
 
-    /// 充值关窗编排：旧缓存行被删、该站被单站补刷（不可达站最终落负缓存）。
+    /// 充值关窗编排：旧缓存行被删、该账号被单账号补刷（不可达站最终落负缓存）。
     /// 充值后旧值必然错 —— 删而不刷会让看板显示"—"直到下次启动，所以两步都要。
     #[tokio::test]
     async fn refresh_after_purchase_drops_and_refetches_that_site() {
         let db = Arc::new(Database::memory().unwrap());
-        // 该站一个托管档（https、不可达 —— .example 保留域 DNS 快速失败）
-        let id = crate::relay::provision::provider_id_for("https://gone.example", Some(1), 1);
-        db.save_provider(
-            "claude",
-            &Provider::with_id(
-                id,
-                "充值站".to_string(),
-                serde_json::json!({
-                    "env": {
-                        "ANTHROPIC_BASE_URL": "https://gone.example",
-                        "ANTHROPIC_AUTH_TOKEN": "sk-test-not-a-real-key",
-                    }
-                }),
-                None,
-            ),
+        // 该站两个账号各一档（https、不可达 —— .example 保留域 DNS 快速失败）
+        for (account_id, group_id) in [(1, 1), (2, 1)] {
+            db.save_provider(
+                "claude",
+                &managed_tier(
+                    &crate::relay::provision::provider_id_for(
+                        "https://gone.example",
+                        Some(account_id),
+                        group_id,
+                    ),
+                    "https://gone.example",
+                    Some(account_id),
+                ),
+            )
+            .unwrap();
+        }
+        // 充值前的旧值（不同 fetched_at，用远过去时间避开与刷新结果撞值）；
+        // 顺带给**没充值的那个账号**放一条新鲜缓存，守「只动充值账号」的边界。
+        crate::relay::balance::upsert_site_balance(
+            &db,
+            &("https://gone.example".into(), 1),
+            (Some(1.23), 100),
         )
         .unwrap();
-        // 充值前的旧值（不同 fetched_at，用远过去时间避开与刷新结果撞值）
-        crate::relay::balance::upsert_site_balance(&db, "https://gone.example", (Some(1.23), 100))
-            .unwrap();
+        crate::relay::balance::upsert_site_balance(
+            &db,
+            &("https://gone.example".into(), 2),
+            (Some(9.99), 100),
+        )
+        .unwrap();
 
         crate::services::site_balance_refresh::refresh_after_purchase(
             &db,
             None::<tauri::AppHandle>,
             "https://panel.gone.example",
             "https://gone.example",
+            Some(1),
         );
 
         for _ in 0..250 {
             let entry = crate::relay::balance::cached_site_balances(&db)
-                .get("https://gone.example")
+                .get(&("https://gone.example".to_string(), 1))
                 .copied();
             // 旧值(1.23, 100)被删，最终落到补刷结果（负缓存、新 fetched_at）
             if let Some((balance, fetched_at)) = entry {
                 assert_eq!(balance, None, "不可达站补刷结果 = 负缓存");
                 assert!(fetched_at > 1_000, "必须是补刷写的新行，不是充值前旧值");
+                assert_eq!(
+                    crate::relay::balance::cached_site_balances(&db)
+                        .get(&("https://gone.example".to_string(), 2)),
+                    Some(&(Some(9.99), 100)),
+                    "充值只失效充值账号的缓存，同站另一账号不动"
+                );
                 return;
             }
             tokio::time::sleep(std::time::Duration::from_millis(20)).await;
         }
-        panic!("充值关窗没有完成「删旧值 + 单站补刷」");
+        panic!("充值关窗没有完成「删旧值 + 单账号补刷」");
     }
 }


### PR DESCRIPTION
## 根因

`site_balance_cache`（#283/#286 建的看板余额 SWR 缓存，#331 行级读路径接入）主键只有 `site_origin`，而钱包余额的事实身份是 **(站点, 账号)** —— `loongport_relay` 自己就以 `(site_origin, account_id)` 为唯一键（同站多账号是设计内场景）。结果同站两个账号共用一行缓存：

- 行级查询：A 账号先查落缓存 → B 账号 TTL 内查询**秒回 A 的余额**；谁后写谁赢
- 看板收集：`site_keys.entry(origin).or_insert(...)` 同站只留第一把 sk（遍历序随机挑账号），后台刷新拿任意账号的 key 覆盖唯一那行

档位层 `provision::provider_id_for` 修过同款身份塌缩前科（注释在档），余额缓存重蹈覆辙。全库排查过其余持久化表 / 内存缓存 / 前端 query key：无同类问题（usage_cache 按 tier、breaker 按 provider、快照按 relay_id、前端按 rowId）。

## 修法（修根，非打补丁）

- 表主键升级 `(site_origin, account_id)`；迁移 v19→v20 **弃旧表重建**（TTL 600s 纯缓存，不搬数据，冷启补刷重新落值）
- 缓存层全套 API（读全表/单键读/upsert/删/stale 判定/单飞集合）改 `SiteAccountKey` 复合键
- 行级读路径：`relay.account_id` 进缓存键；未登录行不进缓存、只走真查
- 看板收集：档位从 `meta.loongport_account_id` 取账号维度；无账号归属不进链（vendor 档字符串身份是另一套体系；顺带消掉 vendor 档对厂商 API 域的无效余额探测，如 api.deepseek.com 负缓存噪音）
- 充值关窗只失效**充值账号**的缓存行，同站另一账号不动

## 回归闸

- 缓存层：同站双账号独立缓存行（`same_site_two_accounts_keep_independent_cache_rows`）
- 行级端到端：mock 按 token 回不同余额，A/B 两行互不命中互不覆盖（`same_site_two_accounts_do_not_share_cache_entries`）
- 迁移：v19→v20 复合键形态、旧单键行被弃（`v19_to_v20_rebuilds_balance_cache_with_composite_key`）
- 收集层：同站双账号分键、无归属/http/手工档排除
- 充值边界：充值只动本账号缓存行（测试内断言另一账号缓存原样）

`cargo test --lib` 3812 全绿；`cargo clippy --all-targets --all-features` 零告警；`cargo fmt` 已过。