### PR TITLE
docs: 站点连接握手页（connect.html）——默认浏览器登录态接力

### DIFF
--- a/docs/station-connect/README.md
+++ b/docs/station-connect/README.md
@@ -1,0 +1,97 @@
+# 站点连接握手（connect.html）
+
+让用户在**自己的默认浏览器**里完成中转站登录后，把登录态接力给 LoongPort 桌面应用。
+背景与设计动机见文末「为什么需要这个页面」。
+
+站长接入只需要做一件事：**把这个文件挂到自己站点的域名下**。
+
+## 接入三步
+
+1. 下载本目录的 [`connect.html`](./connect.html)；
+2. 部署为站点同源路径，推荐约定路径 `/.well-known/loongport/connect`（任意路径也可用，
+   只是约定路径可以让客户端自动发现）；
+3. 完事。用户在浏览器登录站点后打开该页面，点「打开 LoongPort」即完成接力。
+
+nginx 示例（一条 location）：
+
+```nginx
+location = /.well-known/loongport/connect {
+    default_type text/html;
+    alias /opt/your-site/loongport-connect.html;
+}
+```
+
+Caddy 示例：
+
+```caddy
+handle_path /.well-known/loongport/connect {
+    root * /opt/your-site
+    file_server {
+        file loongport-connect.html  # 文件请改名对齐，或直接沿用 connect.html
+    }
+}
+```
+
+> 静态托管/对象存储同理：能以自己域名的一个 URL 提供 `text/html` 即可。
+> 页面无任何外部依赖、无构建步骤、不向任何服务器发请求。
+
+## 契约规格
+
+**页面 URL**：`https://<站点>/.well-known/loongport/connect?state=<nonce>`
+
+- `state`：可选。由客户端发起接力时生成，页面原样透传，客户端用它把回调绑定到
+  自己发起的那次流程。
+
+**回调**（页面在用户点击按钮后发起的重定向）：
+
+```
+loongport://connect
+    ?origin=<页面自己的 origin>
+    &state=<透传>
+    &kind=<sub2api | newapi-session | newapi-access-token>
+    &token=<登录凭据>
+    &expires_at=<可选，sub2api 毫秒时间戳字符串，原样透传>
+```
+
+页面按站点家族自动检测凭据形状：
+
+| kind | 家族 | 凭据来源 |
+|---|---|---|
+| `sub2api` | sub2api | `localStorage.auth_token`（键名事实源：sub2api `frontend/src/stores/auth.ts`） |
+| `newapi-session` | new-api | 会话 cookie `session`（仅当站点未设 `HttpOnly` 时可读） |
+| `newapi-access-token` | new-api | `localStorage.user` JSON 里的 `access_token`（one-api 血统的系统访问令牌） |
+
+用户资料（昵称、账号 id）**不在契约里**：客户端拿到凭据后自己调站点的
+profile 端点获取，避免经手多余的个人数据。
+
+## 安全模型
+
+- **HTTPS-only**：页面检测到非 HTTPS（本机调试除外）直接拒绝工作。
+- **显式确认**：移交必须由用户点击按钮触发（同时满足浏览器对自定义 scheme
+  跳转的 user activation 要求）；页面不自动重定向。
+- **state 绑定**：客户端发起时生成 nonce、回调时校验，防止其它页面凭空塞凭据。
+- **不移交 refresh token**。sub2api 的 refresh token 是一次性轮换设计，浏览器的
+  会话与客户端的会话不能共享同一把——移交等于让用户浏览器里的登录态静默失效。
+  因此接力产物是**短期会话**（access token 到期后需要重新接力或改用客户端内
+  登录）。这是有意为之的边界，不是遗漏。
+- 凭据只出现在「页面 → 本机应用」的一次重定向里，不落任何中间服务器。
+
+## 已知边界
+
+- **new-api 家族是尽力而为**：`session` cookie 通常带 `HttpOnly`，静态页读不到；
+  `access_token` 依赖站点/用户开启。两路都不通时页面按未登录处理。new-api 的
+  可靠解是上游契约（见下），握手页只覆盖「cookie 可读或 access_token 存在」的站。
+- **客户端接收器随版本落地**：`loongport://connect` 的消费端在 LoongPort 后续
+  版本中发布；未安装应用的用户点击后浏览器不会有反应（页面会给出安装指引）。
+  站长先接入不会有任何副作用。
+
+## 为什么需要这个页面
+
+桌面应用无法读取用户浏览器的 cookie——这是操作系统与浏览器的安全边界，
+任何绕过它的行为都属于凭据窃取。因此「跳到默认浏览器登录」之后把登录态
+拿回来，唯一正当的通道是一个**同源页面自愿移交**：站长在自家域名挂一个
+握手页，读同源凭据、经用户确认后重定向回应用。
+
+这也是上游的正解未落地前的临时形态。长期方案是为两个上游（sub2api /
+new-api）提案的「一次性授权码」契约：站点后台原生生成短时效 code，客户端
+用 code 换 token——届时站长零维护、覆盖全部站点，握手页退役。

--- a/docs/station-connect/connect.html
+++ b/docs/station-connect/connect.html
@@ -1,0 +1,173 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>连接 LoongPort</title>
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center;
+    font: 15px/1.7 system-ui, -apple-system, "Segoe UI", "PingFang SC", "Microsoft YaHei", sans-serif;
+    padding: 24px; box-sizing: border-box;
+  }
+  main { max-width: 520px; width: 100%; }
+  h1 { font-size: 20px; margin: 0 0 8px; }
+  .card {
+    border: 1px solid rgba(127,127,127,.35); border-radius: 12px; padding: 20px 22px;
+    background: rgba(127,127,127,.06);
+  }
+  ul { margin: 10px 0; padding-left: 18px; }
+  code { word-break: break-all; }
+  .note { color: rgba(127,127,127,1); font-size: 13px; }
+  button {
+    font: inherit; font-weight: 600; padding: 10px 22px; border-radius: 8px; cursor: pointer;
+    border: none; background: #2563eb; color: #fff; margin-top: 12px;
+  }
+  button:disabled { opacity: .5; cursor: default; }
+  a { color: #2563eb; }
+  [hidden] { display: none !important; }
+</style>
+</head>
+<body>
+<main class="card">
+  <h1>连接 LoongPort</h1>
+  <p id="status">正在检查本站登录态…</p>
+
+  <div id="ready" hidden>
+    <p>将把本站登录凭据交给你本机安装的 LoongPort 桌面应用：</p>
+    <ul>
+      <li>站点：<code id="origin"></code></li>
+      <li>凭据类型：<code id="kind"></code></li>
+      <li>凭据预览：<code id="preview"></code></li>
+      <li id="expires-row">有效期至：<code id="expires"></code></li>
+    </ul>
+    <p class="note">
+      本页不向任何服务器发送数据，点击后仅请求打开本机的 LoongPort。
+      续期凭据（refresh token）不会被移交，你在当前浏览器的登录会话不受影响。
+    </p>
+    <button id="connect">打开 LoongPort</button>
+    <p class="note" id="fallback" hidden>
+      点击后没有弹出「打开 LoongPort」的询问？说明本机未安装应用或浏览器拦截了协议，
+      请先<a href="https://loongport.dev" target="_blank" rel="noopener">安装 LoongPort</a>。
+    </p>
+  </div>
+
+  <div id="nologin" hidden>
+    <p>未检测到本站登录态。请先<a href="/">登录本站</a>，再回到本页。</p>
+    <p class="note">登录后本页无需刷新即可继续（会自动检测）。</p>
+  </div>
+
+  <div id="insecure" hidden>
+    <p>此页面必须通过 HTTPS 访问才能移交登录凭据。</p>
+  </div>
+</main>
+
+<script>
+(function () {
+  'use strict';
+
+  // 与 LoongPort 客户端约定的回调（tauri.conf.json 已注册的 OS 级 scheme）。
+  var CALLBACK_SCHEME = 'loongport://connect';
+
+  var qs = new URLSearchParams(location.search);
+  var state = qs.get('state') || '';
+
+  // sub2api 家族键名（事实源：sub2api frontend src/stores/auth.ts）。
+  var SUB2API_TOKEN_KEY = 'auth_token';
+  var SUB2API_EXPIRES_KEY = 'token_expires_at';
+  // new-api 家族：会话 cookie 名 session；localStorage 'user' JSON 内含 access_token。
+  var NEWAPI_SESSION_COOKIE = 'session';
+  var NEWAPI_USER_KEY = 'user';
+
+  function readCreds() {
+    try {
+      var t = localStorage.getItem(SUB2API_TOKEN_KEY);
+      if (t && t.trim()) {
+        return {
+          kind: 'sub2api',
+          token: t.trim(),
+          expiresAt: (localStorage.getItem(SUB2API_EXPIRES_KEY) || '').trim(),
+        };
+      }
+    } catch (_) { /* 私有模式等极端情况按未登录处理 */ }
+
+    var m = document.cookie.match(new RegExp('(?:^|;\\s*)' + NEWAPI_SESSION_COOKIE + '=([^;]+)'));
+    if (m) {
+      return { kind: 'newapi-session', token: decodeURIComponent(m[1]), expiresAt: '' };
+    }
+
+    try {
+      var raw = localStorage.getItem(NEWAPI_USER_KEY);
+      if (raw) {
+        var u = JSON.parse(raw);
+        if (u && typeof u.access_token === 'string' && u.access_token.trim()) {
+          return { kind: 'newapi-access-token', token: u.access_token.trim(), expiresAt: '' };
+        }
+      }
+    } catch (_) { /* 值不完整时按未登录处理 */ }
+
+    return null;
+  }
+
+  function render(creds) {
+    // 三个状态区互斥：轮询会在登录态出现/消失时来回切，每次都归位。
+    document.getElementById('status').hidden = true;
+    document.getElementById('nologin').hidden = !!creds;
+    document.getElementById('ready').hidden = !creds;
+    if (!creds) return;
+    document.getElementById('origin').textContent = location.origin;
+    document.getElementById('kind').textContent = creds.kind;
+    document.getElementById('preview').textContent = creds.token.slice(0, 8) + '…' + creds.token.slice(-4);
+    var expiresRow = document.getElementById('expires-row');
+    if (creds.expiresAt) {
+      // sub2api 存的是毫秒时间戳字符串，归一展示；原样随回调透传。
+      var ms = Number(creds.expiresAt);
+      document.getElementById('expires').textContent = Number.isSafeInteger(ms) && ms > 0
+        ? new Date(ms).toLocaleString()
+        : creds.expiresAt;
+    } else {
+      expiresRow.hidden = true;
+    }
+
+    document.getElementById('connect').addEventListener('click', function () {
+      // 显式用户点击（也是浏览器允许跳转自定义 scheme 所需的 user activation）。
+      // 手工拼串而非 new URL()：非特殊 scheme 的解析行为各浏览器不一致。
+      var params = [
+        'origin=' + encodeURIComponent(location.origin),
+        'state=' + encodeURIComponent(state),
+        'kind=' + encodeURIComponent(creds.kind),
+        'token=' + encodeURIComponent(creds.token),
+      ];
+      if (creds.expiresAt) params.push('expires_at=' + encodeURIComponent(creds.expiresAt));
+      location.href = CALLBACK_SCHEME + '?' + params.join('&');
+      document.getElementById('fallback').hidden = false;
+      document.getElementById('connect').disabled = true;
+    });
+  }
+
+  var localHost = location.hostname === 'localhost' || location.hostname === '127.0.0.1';
+  if (location.protocol !== 'https:' && !localHost) {
+    document.getElementById('status').hidden = true;
+    document.getElementById('insecure').hidden = false;
+    return;
+  }
+
+  // 未登录时轮询检测：用户去登录页登完回到本页，无需手动刷新即可继续。
+  // 按值签名比较——readCreds 每次返回新对象，比身份会每秒误判一次变更；
+  // 初始哨兵取 null：未登录的签名是 ''，取值相同的话首次渲染会被跳过。
+  var signature = null;
+  function scan() {
+    var creds = readCreds();
+    var next = creds ? creds.kind + ':' + creds.token : '';
+    if (next !== signature) {
+      signature = next;
+      render(creds);
+    }
+  }
+  scan();
+  window.setInterval(scan, 1000);
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 背景

用户希望「跳默认浏览器登录中转站」。默认浏览器里的登录态桌面应用读不到（浏览器安全边界，绕过即凭据窃取），唯一正当通道是**站长自挂同源握手页**：读本站凭据、用户显式确认后经 `loongport://connect`（tauri.conf.json 已注册的 OS 级 scheme）回传本机应用。上游正解（一次性授权码契约）另提 sub2api / new-api 两家，本页为落地前的临时形态。

## 内容

- `docs/station-connect/connect.html`：单文件零依赖握手页。站长反代挂一条 `location` 即接入（约定路径 `/.well-known/loongport/connect`）
- 双家族自动检测：sub2api（`localStorage.auth_token`，键名事实源 = sub2api `auth.ts`）；new-api（`session` cookie 尽力而为 / `localStorage.user.access_token`）
- 安全边界：HTTPS-only、显式点击确认、state 透传绑定；**有意不移交 refresh token**（一次性轮换，移交等于弄死用户浏览器会话）；用户资料不进契约（客户端拿凭据后自己拉 profile，沿「只管登录态」设计）
- `README.md`：契约规格 + 站长接入三步（nginx/caddy 示例）+ 已知边界（new-api httpOnly 尽力而为、客户端接收器随下版落地、先接无副作用）

## 验证

真浏览器冒烟（本地静态服务 + Playwright）四条分支全过：未登录引导 / sub2api 就绪（含轮询自动检测、不刷新页面）/ new-api access_token 分支 / 点击后未安装回落提示与按钮禁用。修复过程中抓到并修掉两个实际 bug：签名哨兵初值撞未登录态致首渲染跳过；render 面板互斥残渣引用未定义变量。

纯文档/静态资源 PR（无 Rust/TS 代码面）。