### PR TITLE
feat(relay): 行级「在默认浏览器中登录」发起端 + 深链 state 绑定

### DIFF
--- a/src-tauri/src/commands/relay/login.rs
+++ b/src-tauri/src/commands/relay/login.rs
@@ -1119,6 +1119,30 @@ pub async fn relay_login(
     ))
 }
 
+/// 在**默认浏览器**中登录这一行（站点握手页接力，契约见 `docs/station-connect`）。
+///
+/// 与 [`relay_login`]（应用内登录窗）是同一终点的两条入口：这条复用用户浏览器里
+/// 已有的会话，免输密码；代价是短期会话（无 refresh）。发起即返回 —— 登录在浏览器
+/// 里完成，凭据经 `loongport://connect` 深链回来由 [`crate::relay::browser_connect`]
+/// 验证落库，前端收 `ONBOARDING_REGISTER_COMPLETED` 收尾（toast + 档位预配 + 刷新）。
+///
+/// `Err` = 站点没部署握手页 / 网络问题（前端 toast 引导走应用内登录窗）。
+#[tauri::command]
+pub async fn relay_browser_login(
+    app_handle: tauri::AppHandle,
+    relay_id: i64,
+) -> Result<(), String> {
+    let site_origin = {
+        let state = app_handle.state::<AppState>();
+        with_conn(&state, |conn| creds::get(conn, relay_id))?
+            .ok_or_else(|| AppError::Config(format!("找不到 id 为 {relay_id} 的中转站")))?
+            .site_origin
+    };
+    crate::relay::browser_connect::begin_browser_login(&app_handle, &site_origin)
+        .await
+        .map_err(|error| error.to_string())
+}
+
 async fn login_via_browser(
     app_handle: &tauri::AppHandle,
     target_id: i64,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1708,6 +1708,7 @@ pub fn run() {
             commands::relay_import_directory_site,
             commands::relay_import_site,
             commands::relay_login,
+            commands::relay_browser_login,
             commands::relay_refresh,
             commands::relay_refresh_all,
             commands::relay_list_relays,

--- a/src-tauri/src/relay/browser_connect.rs
+++ b/src-tauri/src/relay/browser_connect.rs
@@ -18,8 +18,9 @@
 //!
 //! - URL 参数全部按不可信处理：认证只认「拿 token 打站点 profile 成功」；
 //! - 不接受任何 refresh 凭据（浏览器会话与 app 会话不能共享一次性轮换的凭据）；
-//! - `state` 目前透传不校验（app 侧发起按钮未落地，用户手动开握手页没有
-//!   nonce 可绑）；发起端上线后在此补绑定校验；
+//! - `state` 绑定：`begin_browser_login` 发起时登记 nonce+origin（10 分钟 TTL），
+//!   带发起凭证的回调必须与发起完全匹配且一次性；无 `state` 的回调视为用户
+//!   手动打开握手页，放行（认证事实仍是 profile 验证）；
 //! - 坏 token / 坏站点 = 拒收且不落行；用户可见错误走 `deeplink-error`。
 
 use crate::error::AppError;
@@ -67,6 +68,9 @@ pub(crate) struct ConnectHandshake {
     pub origin: String,
     pub kind: ConnectKind,
     pub token: String,
+    /// 发起端（`begin_browser_login`）生成的 nonce，握手页原样透传；
+    /// `None` = 用户手动打开的握手页。
+    pub state: Option<String>,
     /// `newapi-session` 换 token 需要的账号 id（`New-Api-User` 头）。
     pub user_id: Option<i64>,
     /// sub2api 的毫秒时间戳字符串（原样透传，落库前归一成秒）。
@@ -85,6 +89,7 @@ pub(crate) fn parse_connect_url(url: &url::Url) -> Result<ConnectHandshake, AppE
     let mut origin = None;
     let mut kind = None;
     let mut token = None;
+    let mut state = None;
     let mut user_id = None;
     let mut expires_at = None;
     for (key, value) in url.query_pairs() {
@@ -92,9 +97,10 @@ pub(crate) fn parse_connect_url(url: &url::Url) -> Result<ConnectHandshake, AppE
             "origin" => origin = Some(value.into_owned()),
             "kind" => kind = Some(value.into_owned()),
             "token" => token = Some(value.into_owned()),
+            "state" => state = Some(value.into_owned()),
             "user_id" => user_id = Some(value.into_owned()),
             "expires_at" => expires_at = Some(value.into_owned()),
-            // 未知参数（含 state）忽略：握手页与消费端版本可以不同步。
+            // 未知参数忽略：握手页与消费端版本可以不同步。
             _ => {}
         }
     }
@@ -149,9 +155,128 @@ pub(crate) fn parse_connect_url(url: &url::Url) -> Result<ConnectHandshake, AppE
         origin,
         kind,
         token,
+        state: state.filter(|s| !s.trim().is_empty()),
         user_id,
         expires_at: expires_at.filter(|s| !s.trim().is_empty()),
     })
+}
+
+// ============================================================================
+// 发起端：行级「在默认浏览器中登录」按钮 → 握手页带 nonce 打开
+// ============================================================================
+
+/// 一次发起中的浏览器接力。`begin_browser_login` 写入、`validate_state_binding`
+/// 消费；nonce 把回调绑定到「app 自己发起的那次流程 + 那个站点」。
+#[derive(Debug, Clone)]
+struct PendingConnect {
+    state: String,
+    origin: String,
+    /// unix 秒。过期的 pending 视同没有（懒清理，不设后台任务）。
+    expires_at: i64,
+}
+
+const PENDING_CONNECT_TTL_SECS: i64 = 600;
+
+/// 站点握手页的约定路径（契约见 docs/station-connect/README.md）。
+const WELL_KNOWN_CONNECT_PATH: &str = "/.well-known/loongport/connect";
+
+static PENDING_CONNECT: std::sync::OnceLock<std::sync::Mutex<Option<PendingConnect>>> =
+    std::sync::OnceLock::new();
+
+/// 探测站点握手页部署了没有（只认 2xx；超时短，别让用户干等）。
+/// 没部署就别把用户扔到浏览器里看 404 —— 在门口拦下并引导走应用内登录。
+async fn probe_connect_page(site_origin: &str) -> Result<(), AppError> {
+    let page_url = format!("{site_origin}{WELL_KNOWN_CONNECT_PATH}");
+    let status = crate::relay::sub2api::build_client()?
+        .get(&page_url)
+        .timeout(std::time::Duration::from_secs(3))
+        .send()
+        .await
+        .map_err(|e| AppError::Config(format!("探测站点握手页失败（{site_origin}）: {e}")))?
+        .status();
+    if !status.is_success() {
+        return Err(AppError::Config(format!(
+            "该站未部署浏览器登录页（HTTP {status}）。可让站长按 docs/station-connect 接入，或改用应用内登录"
+        )));
+    }
+    Ok(())
+}
+
+/// 发起浏览器接力登录：探测握手页 → 登记 nonce → 用默认浏览器打开带 state 的页面。
+///
+/// 用户在浏览器完成登录并点击移交后，深链回来走 [`apply_connect`]。
+#[cfg(feature = "gui")]
+pub async fn begin_browser_login<R: tauri::Runtime>(
+    app_handle: &tauri::AppHandle<R>,
+    site_origin: &str,
+) -> Result<(), AppError> {
+    probe_connect_page(site_origin).await?;
+
+    let state = uuid::Uuid::new_v4().simple().to_string();
+    {
+        let pending = PENDING_CONNECT.get_or_init(Default::default);
+        let mut guard = pending
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *guard = Some(PendingConnect {
+            state: state.clone(),
+            origin: site_origin.to_string(),
+            expires_at: chrono::Utc::now().timestamp() + PENDING_CONNECT_TTL_SECS,
+        });
+    }
+
+    use tauri_plugin_opener::OpenerExt;
+    app_handle
+        .opener()
+        .open_url(
+            format!("{site_origin}{WELL_KNOWN_CONNECT_PATH}?state={state}"),
+            None::<String>,
+        )
+        .map_err(|e| AppError::Config(format!("打开默认浏览器失败: {e}")))?;
+    Ok(())
+}
+
+/// state 绑定裁决（验证前的准入闸，纯状态机便于测试）：
+///
+/// - 有进行中的发起（未过期）：state 匹配且 origin 一致 → 放行并**消费**（一次性）；
+///   无 state（用户手动开页）→ 放行（用户驱动的流程，pending 留着等真正的绑定回调）；
+///   state/origin 对不上 → **拒收**（别的页面往回调里塞凭据）。
+/// - 没有进行中的发起：无 state 放行（手动流程）；带 state → 拒收
+///   （发起已过期/不存在，stale nonce 不该再被认）。
+fn validate_state_binding(handshake: &ConnectHandshake, now: i64) -> Result<(), AppError> {
+    let pending_slot = PENDING_CONNECT.get_or_init(Default::default);
+    let mut guard = pending_slot
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let pending = match guard.as_ref() {
+        Some(p) if p.expires_at > now => Some(p),
+        Some(_) => {
+            // 懒清理过期发起。
+            *guard = None;
+            None
+        }
+        None => None,
+    };
+
+    match (pending, handshake.state.as_deref()) {
+        (None, None) => Ok(()),
+        (None, Some(_)) => Err(AppError::InvalidInput(
+            "回调带着已失效的发起凭证（发起过期或不存在），请重新发起".into(),
+        )),
+        (Some(_), None) => Ok(()),
+        (Some(p), Some(state)) => {
+            if state == p.state && handshake.origin == p.origin {
+                // 绑定流程兑现：消费掉，一次发起只认一次回调。
+                *guard = None;
+                Ok(())
+            } else {
+                Err(AppError::InvalidInput(
+                    "回调与本次发起不匹配（站点或发起凭证不对），已拒收".into(),
+                ))
+            }
+        }
+    }
 }
 
 /// 落库结果：前端 toast + 档位预配（`ONBOARDING_REGISTER_COMPLETED`）要用的两件事。
@@ -338,6 +463,13 @@ pub async fn apply_connect<R: tauri::Runtime>(app_handle: &tauri::AppHandle<R>, 
         handshake.origin,
         handshake.kind
     );
+
+    // 准入闸：state 绑定（有发起在途时严格匹配 origin+nonce；见 validate_state_binding）。
+    if let Err(error) = validate_state_binding(&handshake, chrono::Utc::now().timestamp()) {
+        log::warn!("[browser-connect] {error}");
+        emit_deeplink_error(app_handle, url_str, &error);
+        return;
+    }
 
     let state = app_handle.state::<AppState>();
     match connect(&state, &handshake).await {
@@ -708,5 +840,113 @@ mod tests {
     /// 测试 URL 里的 origin 需要 percent-encode（host 带端口时 `:` 与参数分隔冲突）。
     fn urlencoding_lite(s: &str) -> String {
         s.replace(':', "%3A").replace('/', "%2F")
+    }
+
+    // ==================== 发起端与 state 绑定 ====================
+
+    fn reset_pending(state: Option<(&str, &str, i64)>) {
+        let slot = PENDING_CONNECT.get_or_init(Default::default);
+        let mut guard = slot.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        *guard = state.map(|(state, origin, expires_at)| PendingConnect {
+            state: state.to_string(),
+            origin: origin.to_string(),
+            expires_at,
+        });
+    }
+
+    fn handshake_with(origin: &str, state: Option<&str>) -> ConnectHandshake {
+        ConnectHandshake {
+            origin: origin.to_string(),
+            kind: ConnectKind::Sub2Api,
+            token: "t".into(),
+            state: state.map(str::to_string),
+            user_id: None,
+            expires_at: None,
+        }
+    }
+
+    /// ⭐ state 绑定状态机：共享全局 pending，必须串行跑。
+    #[test]
+    #[serial_test::serial]
+    fn state_binding_full_lifecycle() {
+        let now = 10_000_i64;
+
+        // 无发起：无 state 放行（手动开页），带 state 拒收（stale nonce 不认）
+        reset_pending(None);
+        assert!(validate_state_binding(&handshake_with("https://a.example", None), now).is_ok());
+        assert!(
+            validate_state_binding(&handshake_with("https://a.example", Some("stale")), now)
+                .is_err()
+        );
+
+        // 有发起：匹配的 state+origin 放行且**一次性消费**
+        reset_pending(Some(("nonce-1", "https://a.example", now + 60)));
+        let matched = handshake_with("https://a.example", Some("nonce-1"));
+        assert!(validate_state_binding(&matched, now).is_ok());
+        assert!(
+            validate_state_binding(&matched, now).is_err(),
+            "绑定兑现后 pending 已消费，重放同一个回调必须被拒"
+        );
+
+        // 有发起：错 state / 错 origin 拒收，但 pending 不被消耗（真正的回调仍可兑现）
+        reset_pending(Some(("nonce-2", "https://a.example", now + 60)));
+        assert!(
+            validate_state_binding(&handshake_with("https://a.example", Some("evil")), now)
+                .is_err()
+        );
+        assert!(
+            validate_state_binding(&handshake_with("https://b.example", Some("nonce-2")), now)
+                .is_err()
+        );
+        assert!(
+            validate_state_binding(&handshake_with("https://a.example", Some("nonce-2")), now)
+                .is_ok()
+        );
+
+        // 有发起：无 state（手动开页）放行，pending 留给真正的绑定回调
+        reset_pending(Some(("nonce-3", "https://a.example", now + 60)));
+        assert!(validate_state_binding(&handshake_with("https://b.example", None), now).is_ok());
+        assert!(
+            validate_state_binding(&handshake_with("https://a.example", Some("nonce-3")), now)
+                .is_ok()
+        );
+
+        // 过期发起：视同没有（懒清理）—— 无 state 放行、带 state 拒收
+        reset_pending(Some(("nonce-4", "https://a.example", now - 1)));
+        assert!(validate_state_binding(&handshake_with("https://a.example", None), now).is_ok());
+        assert!(
+            validate_state_binding(&handshake_with("https://a.example", Some("nonce-4")), now)
+                .is_err()
+        );
+
+        reset_pending(None);
+    }
+
+    /// 探测闸：握手页在（2xx）放行到「打开浏览器」，不在（404）给出可行动的错误。
+    #[tokio::test]
+    async fn probe_accepts_deployed_page_and_rejects_missing() {
+        use axum::routing::get;
+        let (origin, _server) = spawn_server(
+            axum::Router::new()
+                .route(
+                    "/.well-known/loongport/connect",
+                    get(|| async { "<html>connect</html>" }),
+                )
+                .route(
+                    "/.well-known/missing",
+                    get(|| async { axum::http::StatusCode::NOT_FOUND }),
+                ),
+        )
+        .await;
+
+        assert!(probe_connect_page(&origin).await.is_ok());
+        let err = probe_connect_page(&format!("{origin}/well-known"))
+            .await
+            .err();
+        // 路径拼错 → 404 → 错误信息要能指导行动（提站点未部署）
+        assert!(
+            err.is_some_and(|e| e.to_string().contains("未部署")),
+            "未部署站点的错误要指明原因"
+        );
     }
 }

--- a/src/components/relay/RelayRow.tsx
+++ b/src/components/relay/RelayRow.tsx
@@ -5,6 +5,7 @@ import {
   Check,
   ChevronDown,
   ChevronRight,
+  ExternalLink,
   FileDown,
   GripVertical,
   Layers3,
@@ -105,6 +106,7 @@ export interface RelayRowProps {
   onPurchase: () => void;
   /** 带登录态开这一行的用量页（「查看用量」，入口资格由后端判定）。 */
   onOpenUsage: (() => void) | undefined;
+  onBrowserLogin?: (() => void) | undefined;
   /** 站点配置应用/恢复成功后刷新列表（档位 settings 与标注变了）。 */
   onSiteConfigApplied: () => void | Promise<void>;
   /**
@@ -155,6 +157,7 @@ export function RelayRow({
   onSelectTierModel,
   onPurchase,
   onOpenUsage,
+  onBrowserLogin,
   onSiteConfigApplied,
   onCheckTier,
   isCheckingTier,
@@ -313,6 +316,22 @@ export function RelayRow({
                 aria-label={t("loongport.row.openUsageHint")}
               >
                 <Activity className="h-3.5 w-3.5" />
+              </Button>
+            )}
+            {/* 「在浏览器中登录」入口（站点握手页接力）。与登录窗是同一终点的
+                另一条路：复用用户浏览器里已有的会话，免输密码。所有行都有 ——
+                站点没部署握手页时后端探测会报错并引导走应用内登录。 */}
+            {onBrowserLogin && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 shrink-0 p-1 text-muted-foreground hover:text-foreground"
+                onClick={onBrowserLogin}
+                title={t("loongport.row.browserLoginHint")}
+                aria-label={t("loongport.row.browserLoginHint")}
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
               </Button>
             )}
             {/* 「导入站点配置」入口。资格 = 当前行至少有一个档位 —— 没有档位的行

--- a/src/components/relay/RelaySection.tsx
+++ b/src/components/relay/RelaySection.tsx
@@ -748,6 +748,17 @@ export function RelaySection({ appId, onOpenAddHub }: RelaySectionProps) {
       }
     });
 
+  /** 浏览器接力登录：发起即返回（不等待登录完成），成功提示去浏览器操作。 */
+  const handleBrowserLogin = (relayId: number) =>
+    run(`browserLogin:${relayId}`, async () => {
+      try {
+        await relayApi.browserLogin(relayId);
+        toast.success(t("loongport.row.browserLoginOpened"));
+      } catch (e) {
+        toast.error(String(e));
+      }
+    });
+
   const handleSwitchTier = (_relayId: number, tier: TierInfo) => {
     if (tier.isCurrent) return;
     void doSwitch(tier);
@@ -861,6 +872,7 @@ export function RelaySection({ appId, onOpenAddHub }: RelaySectionProps) {
           }
           onPurchase={(relayId) => void handlePurchase(relayId)}
           onOpenUsage={(relayId) => void handleOpenUsage(relayId)}
+          onBrowserLogin={(relayId) => void handleBrowserLogin(relayId)}
           // 档位的 providerId 就是 provider 表的主键，直接喂给上游那条命令。
           // 名字用 displayName（那是用户在这一行看到的），检测结果的 toast 里会带它。
           onCheckTier={(tier) =>

--- a/src/components/relay/RelayTierList.tsx
+++ b/src/components/relay/RelayTierList.tsx
@@ -85,6 +85,7 @@ export interface RelayTierListProps {
   onPurchase: (relayId: number) => void;
   /** 「查看用量」开窗；undefined = 该行没有入口资格（不渲染按钮）。 */
   onOpenUsage: ((relayId: number) => void) | undefined;
+  onBrowserLogin: ((relayId: number) => void) | undefined;
   /** 检测某个档位的连通性。 */
   onCheckTier: (tier: TierInfo) => void;
   /** 某个档位是不是正在检测中。 */
@@ -168,6 +169,7 @@ export function RelayTierList({
   onReorder,
   onPurchase,
   onOpenUsage,
+  onBrowserLogin,
   onCheckTier,
   isCheckingTier,
   onResetTier,
@@ -285,6 +287,9 @@ export function RelayTierList({
                   onPurchase={() => onPurchase(op.id)}
                   onOpenUsage={
                     onOpenUsage ? () => onOpenUsage(op.id) : undefined
+                  }
+                  onBrowserLogin={
+                    onBrowserLogin ? () => onBrowserLogin(op.id) : undefined
                   }
                   onCheckTier={onCheckTier}
                   isCheckingTier={isCheckingTier}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3232,6 +3232,8 @@
       "refetchGroups": "Update available groups",
       "purchaseHint": "Open the relay service's top-up page",
       "openUsageHint": "Open the relay site's usage page (signed in)",
+      "browserLoginHint": "Sign in via your default browser (reuses your existing browser session)",
+      "browserLoginOpened": "Login page opened in your browser — LoongPort will connect automatically once you sign in",
       "lowBalanceHint": "Balance is low. Select to top up",
       "remove": "Delete account and connection profiles",
       "removeInUseHint": "Some connection profiles are in use — you can still delete, with confirmation",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3232,6 +3232,8 @@
       "refetchGroups": "利用可能なグループを更新",
       "purchaseHint": "中継サービスのチャージページを開く",
       "openUsageHint": "中継サイトの使用量ページを開く（ログイン済み）",
+      "browserLoginHint": "既定のブラウザでログイン（ブラウザの既存セッションを再利用）",
+      "browserLoginOpened": "ブラウザでログインページを開きました。ログイン後、LoongPort に自動接続します",
       "lowBalanceHint": "残高が少なくなっています。クリックしてチャージ",
       "remove": "アカウントと接続プロファイルを削除",
       "removeInUseHint": "使用中の接続プロファイルがあります。確認のうえ削除できます",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3233,6 +3233,8 @@
       "refetchGroups": "更新可用群組",
       "purchaseHint": "開啟中轉站儲值頁面",
       "openUsageHint": "開啟中轉站用量頁面（帶登入態）",
+      "browserLoginHint": "在預設瀏覽器中登入（沿用瀏覽器裡已有的登入）",
+      "browserLoginOpened": "已在瀏覽器開啟登入頁，完成登入後會自動連回 LoongPort",
       "lowBalanceHint": "餘額較低，點一下儲值",
       "remove": "刪除帳號與連線設定檔",
       "removeInUseHint": "有連線設定檔正在使用——仍可刪除，需在彈出視窗中確認",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -3232,6 +3232,8 @@
       "refetchGroups": "更新可用分组",
       "purchaseHint": "打开中转站充值页面",
       "openUsageHint": "打开中转站用量页面（带登录态）",
+      "browserLoginHint": "在默认浏览器中登录（复用浏览器里已有的登录）",
+      "browserLoginOpened": "已在浏览器打开登录页，完成登录后会自动连接回 LoongPort",
       "lowBalanceHint": "余额较低，点击充值",
       "remove": "删除账号及接入配置",
       "removeInUseHint": "有接入配置正在使用——仍可删除，需在弹窗中确认",

--- a/src/lib/api/relay.ts
+++ b/src/lib/api/relay.ts
@@ -467,6 +467,14 @@ export const relayApi = {
     invoke("relay_login", { relayId, app }),
 
   /**
+   * 在默认浏览器中登录这一行（站点握手页接力）：发起即返回，登录在浏览器完成，
+   * 凭据经 loongport://connect 深链回来落库，收尾由 ONBOARDING_REGISTER_COMPLETED
+   * 事件驱动（toast + 档位预配 + 列表刷新）。Err = 站点未部署握手页/网络问题。
+   */
+  browserLogin: (relayId: number): Promise<void> =>
+    invoke("relay_browser_login", { relayId }),
+
+  /**
    * 「中转站 × 分组」页的数据源：一次拿到全部中转站 + 各自在该 app 下的档位。
    *
    * `app` 传当前 tab 的 app_type（如 `"codex"`）。

--- a/tests/components/RelayRowModels.test.tsx
+++ b/tests/components/RelayRowModels.test.tsx
@@ -68,6 +68,7 @@ function renderRow(models: string[], onSelectTierModel = vi.fn()) {
           onSelectTierModel={onSelectTierModel}
           onPurchase={vi.fn()}
           onOpenUsage={undefined}
+          onBrowserLogin={undefined}
           onCheckTier={vi.fn()}
           isCheckingTier={() => false}
           onResetTier={vi.fn()}


### PR DESCRIPTION
## 背景

#349 落了 `loongport://connect` 消费端与握手页（#348），但发起端缺失——用户得手动打开握手页。本 PR 补齐最后一环：行级按钮一键发起 + 深链 state 绑定（此前 state 透传不校验的明确欠账）。

## 实现

**后端**（`relay/browser_connect.rs` + `commands/relay/login.rs` 薄命令）：

- `relay_browser_login(relay_id)`：探测 `{origin}/.well-known/loongport/connect`（3s 预算；非 2xx 在门口拦下——不把用户扔去浏览器看 404，错误信息引导走应用内登录窗）→ 登记 nonce+origin（`PENDING_CONNECT`，10 分钟 TTL，懒清理）→ `tauri-plugin-opener` 开默认浏览器（带 `state`）
- 消费端准入闸 `validate_state_binding`（纯状态机）：
  - 发起在途：`state`+`origin` 完全匹配 → 放行且**一次性消费**（重放同回调被拒）；错 state/错 origin → 拒收但发起保留；无 state（手动开页）→ 放行
  - 无发起：无 state 放行；带 state（stale nonce）→ 拒收

**前端**：

- `RelayRow` 悬停动作组加 `ExternalLink` 图标按钮（照「查看用量」三层样例：api → RelaySection handler → RelayTierList → RelayRow）；发起即返回 + toast「已在浏览器打开登录页」；登录完成后的收尾仍走 `ONBOARDING_REGISTER_COMPLETED`（与注册窗共用的 toast+预配+刷新）
- i18n 四语言；prop 声明为可选（`dragHandleProps?` 先例）

## 测试

- state 绑定全生命周期（serial：匹配消费一次性/错参拒收不耗发起/手动无 state 放行/stale 拒收/过期懒清理）
- 探测闸（2xx 放行 / 404 错误信息可行动）
- 3820 全绿、clippy --all-targets --all-features 零告警、tsc + prettier 过