### PR TITLE
fix(import): cc-switch 源库 schema 超出支持范围时静默收起导入入口

### DIFF
--- a/src-tauri/src/relay/cc_switch_import.rs
+++ b/src-tauri/src/relay/cc_switch_import.rs
@@ -6,6 +6,13 @@
 //! 库。**绝不动源库** —— 这是「导入」不是「迁移」，cc-switch 可能还在被 cc-switch app 用。
 //! 集成测试用「导入前后源文件字节一致」钉着这条。
 //!
+//! ## 版本闸：cc-switch 比本仓新时收起入口
+//!
+//! cc-switch 升级可能把源库 `user_version` 推到本仓 [`SCHEMA_VERSION`] 之后，导入路径的
+//! 迁移层会拒（「数据库版本过新」）。与其让用户点了才见报错，预览直接给最终事实
+//! `can_import = user_version ≤ SCHEMA_VERSION`，前端据此隐藏全部入口 —— 判据与迁移闸
+//! 同一个常量，跟上游吸收新 schema 后入口自动恢复，不用改前端。
+//!
 //! ## 覆盖式：复用上游导入路径
 //!
 //! providers / MCP / prompts / skills 以 cc-switch 为准整体替换，走
@@ -41,7 +48,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use crate::app_config::AppType;
-use crate::database::Database;
+use crate::database::{Database, SCHEMA_VERSION};
 use crate::error::AppError;
 use crate::provider::{Provider, ProviderMeta};
 use crate::relay::provider_fingerprint;
@@ -67,7 +74,10 @@ pub struct SkippedProvider {
 #[serde(rename_all = "camelCase")]
 pub struct ImportPlan {
     pub source_exists: bool,
-    pub source_version: Option<i64>,
+    /// 这份源库**当前应用能不能导**：源库在，且 `user_version` ≤ 内置 [`SCHEMA_VERSION`]
+    /// （与导入路径里迁移层版本闸同一个常量）。前端据此决定入口显隐 —— cc-switch 比
+    /// 本仓新时静默收起入口，别把「数据库版本过新」留给用户点了之后才弹。
+    pub can_import: bool,
     pub providers: ProviderPlan,
     pub mcp_servers: i64,
     pub prompts: i64,
@@ -334,7 +344,7 @@ pub fn plan_import(db: &Database, source_path: &Path) -> Result<ImportPlan, AppE
     if !source_path.exists() {
         return Ok(ImportPlan {
             source_exists: false,
-            source_version: None,
+            can_import: false,
             providers: ProviderPlan {
                 will_import: 0,
                 skipped: Vec::new(),
@@ -386,7 +396,7 @@ pub fn plan_import(db: &Database, source_path: &Path) -> Result<ImportPlan, AppE
 
     Ok(ImportPlan {
         source_exists: true,
-        source_version: Some(version),
+        can_import: version <= i64::from(SCHEMA_VERSION),
         providers: ProviderPlan {
             will_import: classified.will_import.len() + classified.cannot_fingerprint.len(),
             skipped: skipped_list,
@@ -886,9 +896,11 @@ mod tests {
 
     /// 建一个 cc-switch 源库文件：与托管档位同指纹的 codex provider、一个不同 sk 的、
     /// 一条 MCP、一条 cc-switch 自己的 settings（不该盖掉 LoongPort 的）。
-    fn create_source_db(path: &std::path::Path) {
+    /// `user_version` 由调用方给 —— 版本闸测试要拿「比本仓新 / 在范围内」两种形态。
+    fn create_source_db(path: &std::path::Path, user_version: i64) {
         let conn = Connection::open(path).expect("建源库");
-        conn.execute_batch("PRAGMA user_version=16;").unwrap();
+        conn.execute_batch(&format!("PRAGMA user_version={user_version};"))
+            .unwrap();
 
         create_providers_table(&conn);
         // 与托管档位（sk-managed @ bestapi.store）同指纹 ⇒ 导入时跳过。
@@ -954,6 +966,32 @@ mod tests {
         .unwrap();
     }
 
+    /// cc-switch 比本仓新（源库 `user_version` 超过 [`SCHEMA_VERSION`]）⇒ 预览必须给
+    /// `can_import=false` —— 前端据此隐藏全部入口，别让用户点了才见「数据库版本过新」。
+    /// 纯读路径（不碰 home 目录），不用 `#[serial]`。
+    #[test]
+    fn plan_import_gates_on_source_schema_version() {
+        let db = Database::memory().expect("内存库");
+
+        // 比本仓支持的新：上游又发版推了 schema。
+        let newer = tempfile::NamedTempFile::new().unwrap();
+        create_source_db(newer.path(), i64::from(SCHEMA_VERSION) + 1);
+        let plan = plan_import(&db, newer.path()).expect("预览不该失败");
+        assert!(plan.source_exists, "源库在");
+        assert!(!plan.can_import, "超版本的源库必须判不可导");
+
+        // 恰好等于 SCHEMA_VERSION：可导（≤ 是闭区间）。
+        let current = tempfile::NamedTempFile::new().unwrap();
+        create_source_db(current.path(), i64::from(SCHEMA_VERSION));
+        let plan = plan_import(&db, current.path()).expect("预览不该失败");
+        assert!(plan.can_import, "等于 SCHEMA_VERSION 必须可导");
+
+        // 没有源库：不可导（入口本就不显）。
+        let plan = plan_import(&db, Path::new("/nonexistent/cc-switch.db")).expect("预览不该失败");
+        assert!(!plan.source_exists);
+        assert!(!plan.can_import);
+    }
+
     /// ⭐ 核心闸：导入把 cc-switch 的搬进来，同时托管档位回填、冲突项删掉、
     /// LoongPort 自己的表/settings 保留、**源库字节不变**、**「已手动维护」判定不变**。
     /// ⚠️ `#[serial]`：本测试要临时改进程级 `CC_SWITCH_TEST_HOME`（备份/设置读写用），
@@ -999,7 +1037,8 @@ mod tests {
 
         // ── cc-switch 源库文件 ──
         let src = tempfile::NamedTempFile::new().expect("临时源库");
-        create_source_db(src.path());
+        // 16（旧于当前 SCHEMA_VERSION）：顺带覆盖「导入路径把旧版本迁上来」的链路。
+        create_source_db(src.path(), 16);
         let before = std::fs::read(src.path()).expect("读源库字节");
 
         let report = {

--- a/src/components/settings/CcSwitchImportDialog.tsx
+++ b/src/components/settings/CcSwitchImportDialog.tsx
@@ -136,7 +136,7 @@ export function CcSwitchImportDialog({
               <Button
                 type="button"
                 disabled={
-                  isImporting || status === "loading" || !preview?.sourceExists
+                  isImporting || status === "loading" || !preview?.canImport
                 }
                 onClick={handleConfirm}
               >
@@ -174,6 +174,19 @@ function PreviewBody({
         {t("settings.ccSwitchImport.noSource", {
           defaultValue:
             "未检测到 cc-switch 数据（~/.cc-switch/cc-switch.db）。",
+        })}
+      </p>
+    );
+  }
+
+  // 源库在但版本导不动（cc-switch 比当前应用新）—— 入口平时已隐藏，这里是「预览拉取后
+  // 源库被 cc-switch 升上去了」的竞态兜底：一条极简说明，确认键在上面已被禁用。
+  if (!preview.canImport) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        {t("settings.ccSwitchImport.versionUnsupported", {
+          defaultValue:
+            "这份 cc-switch 数据需要更新版本的 LoongPort 才能导入。",
         })}
       </p>
     );

--- a/src/components/settings/CcSwitchImportEntry.tsx
+++ b/src/components/settings/CcSwitchImportEntry.tsx
@@ -11,10 +11,11 @@ import { CcSwitchImportDialog } from "@/components/settings/CcSwitchImportDialog
 /**
  * 「从 cc-switch 导入」的总入口：**图标旁的小按钮 + 首次启动弹窗**。
  *
- * - **图标旁按钮**：LoongPort 品牌名旁边的小下载图标，检测到 `~/.cc-switch/cc-switch.db`
- *   才显示（`preview.sourceExists`），点了打开导入确认框。
- * - **首启弹窗**：第一次打开时（`ccSwitchImportPrompted` 还没置过）如果检测到 cc-switch
- *   数据，自动弹出「是否一键导入」的确认框；确认或关闭都记下「问过了」，
+ * - **图标旁按钮**：LoongPort 品牌名旁边的小下载图标，检测到**可导**的
+ *   `~/.cc-switch/cc-switch.db`（`preview.canImport`：源库在、且版本没超出当前应用支持
+ *   范围）才显示，点了打开导入确认框；cc-switch 比本仓新时静默不显示。
+ * - **首启弹窗**：第一次打开时（`ccSwitchImportPrompted` 还没置过）如果检测到可导的
+ *   cc-switch 数据，自动弹出「是否一键导入」的确认框；确认或关闭都记下「问过了」，
  *   下次启动不再打扰 —— 与 `StatsNoticeDialog` 的 `statsNoticeConfirmed` 同一个惯例。
  */
 export function CcSwitchImportEntry() {
@@ -27,13 +28,13 @@ export function CcSwitchImportEntry() {
 
   useEffect(() => {
     let cancelled = false;
-    // 两个事实都要：有没有 cc-switch 数据（决定弹不弹/显不显按钮）、问过没。
+    // 两个事实都要：有没有可导的 cc-switch 数据（决定弹不弹/显不显按钮）、问过没。
     Promise.all([settingsApi.get(), ccSwitchImportApi.getPreview()])
       .then(([s, p]) => {
         if (cancelled) return;
         setSettings(s);
         setPreview(p);
-        if (s.ccSwitchImportPrompted === undefined && p.sourceExists) {
+        if (s.ccSwitchImportPrompted === undefined && p.canImport) {
           setIsFirstLaunch(true);
           setDialogOpen(true);
         }
@@ -72,14 +73,14 @@ export function CcSwitchImportEntry() {
     void queryClient.invalidateQueries({ queryKey: ["providers"] });
   }, [queryClient]);
 
-  const sourceExists = preview?.sourceExists === true;
+  const canImport = preview?.canImport === true;
 
   return (
     <>
       {preview === null ? (
         // 预览还没回来：占个等宽位，避免头部跳动。
         <div className="w-8" />
-      ) : sourceExists ? (
+      ) : canImport ? (
         <Button
           variant="ghost"
           size="icon"

--- a/src/components/settings/CcSwitchImportSection.tsx
+++ b/src/components/settings/CcSwitchImportSection.tsx
@@ -10,7 +10,8 @@ import { CcSwitchImportDialog } from "@/components/settings/CcSwitchImportDialog
  * 设置页 advanced → data 区里的「从 cc-switch 导入」小节。
  *
  * 检测到 `~/.cc-switch/cc-switch.db` 才给按钮（`preview.sourceExists`），否则灰显提示 ——
- * 有源可导才值得占用户一眼。
+ * 有源可导才值得占用户一眼。源库在但版本导不动（cc-switch 比当前应用新）时**整节隐藏**
+ * —— 留一个点了必报「版本过新」的按钮，不如不给。
  */
 export function CcSwitchImportSection() {
   const { t } = useTranslation();
@@ -28,6 +29,11 @@ export function CcSwitchImportSection() {
   }, [queryClient]);
 
   const sourceExists = preview?.sourceExists === true;
+
+  // cc-switch 比当前应用新（版本导不动）→ 整节隐藏，入口层面就别让用户撞报错。
+  if (preview !== null && sourceExists && !preview.canImport) {
+    return null;
+  }
 
   return (
     <section className="space-y-4">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -446,6 +446,7 @@
       "sectionHint": "Copy cc-switch providers / MCP / skills / prompts over in one go; cc-switch itself is not modified.",
       "button": "Import from cc-switch",
       "noSource": "No cc-switch data found (~/.cc-switch/cc-switch.db)",
+      "versionUnsupported": "This cc-switch data requires a newer LoongPort version to import.",
       "loading": "Reading cc-switch data…",
       "confirm": "Import now",
       "importing": "Importing…",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -446,6 +446,7 @@
       "sectionHint": "cc-switch の provider / MCP / skills / prompt を一括コピーします。cc-switch 側は変更しません。",
       "button": "cc-switch からインポート",
       "noSource": "cc-switch のデータが見つかりません（~/.cc-switch/cc-switch.db）",
+      "versionUnsupported": "この cc-switch データを取り込むには、より新しい LoongPort が必要です。",
       "loading": "cc-switch のデータを読み込み中…",
       "confirm": "インポート",
       "importing": "インポート中…",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -446,6 +446,7 @@
       "sectionHint": "把 cc-switch 的 provider / MCP / skills / prompt 一次複製過來，不動 cc-switch。",
       "button": "從 cc-switch 匯入",
       "noSource": "未偵測到 cc-switch 資料（~/.cc-switch/cc-switch.db）",
+      "versionUnsupported": "這份 cc-switch 資料需要更新版本的 LoongPort 才能匯入。",
       "loading": "正在讀取 cc-switch 資料…",
       "confirm": "一鍵匯入",
       "importing": "匯入中…",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -446,6 +446,7 @@
       "sectionHint": "把 cc-switch 的 provider / MCP / skills / prompt 一次性复制过来，不动 cc-switch。",
       "button": "从 cc-switch 导入",
       "noSource": "未检测到 cc-switch 数据（~/.cc-switch/cc-switch.db）",
+      "versionUnsupported": "这份 cc-switch 数据需要更新版本的 LoongPort 才能导入。",
       "loading": "正在读取 cc-switch 数据…",
       "confirm": "一键导入",
       "importing": "导入中…",

--- a/src/lib/api/ccSwitchImport.ts
+++ b/src/lib/api/ccSwitchImport.ts
@@ -19,10 +19,10 @@ export interface ProviderPlan {
 
 /** 从 cc-switch 导入的预览（后端 `get_cc_switch_import_preview`）。 */
 export interface CcSwitchImportPreview {
-  /** `~/.cc-switch/cc-switch.db` 是否存在 —— 前端据此决定显不显入口。 */
+  /** `~/.cc-switch/cc-switch.db` 是否存在。 */
   sourceExists: boolean;
-  /** 源库 schema 版本。 */
-  sourceVersion: number | null;
+  /** 这份源库当前应用能不能导（后端判：源库在、且 schema 版本在支持范围内）—— 入口显隐唯据。 */
+  canImport: boolean;
   providers: ProviderPlan;
   mcpServers: number;
   prompts: number;


### PR DESCRIPTION
## Summary / 概述

cc-switch 上游发版可能把 `~/.cc-switch/cc-switch.db` 的 `user_version` 推到本仓 `SCHEMA_VERSION` 之后（当前上游已到 18、本仓 17），导入路径的迁移层会拒并报「数据库版本过新」——用户点了入口才见报错。

本 PR 把这个判断前移：预览命令（本就静默只读探测）在 DTO 里给出最终事实 `canImport = user_version ≤ SCHEMA_VERSION`，前端三个入口（品牌旁按钮、首启弹窗、设置页小节）据此全部静默隐藏；判据与迁移闸共用同一个常量，跟上游吸收新 schema 后入口自动恢复，无需再改前端。

- 后端 `ImportPlan.can_import` 替换无人消费的 `source_version`
- 对话框对「预览拉取后源库被 cc-switch 升上去」的竞态留一条极简说明并禁用确认键（`versionUnsupported`，四语言）
- 新增 `plan_import_gates_on_source_schema_version` 测试（超版 / 恰好等于 / 无源三种形态）

## Related Issue / 关联 Issue

## Screenshots / 截图

纯入口显隐逻辑，无视觉改版。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
