### PR TITLE
docs(station-connect): 现代 new-api 真机实测重塑握手页 new-api 支持

### DIFF
--- a/docs/station-connect/README.md
+++ b/docs/station-connect/README.md
@@ -54,18 +54,30 @@ loongport://connect
     &user_id=<可选，newapi-session 时由页面带上>
 ```
 
-页面按站点家族自动检测凭据形状：
+页面按站点家族自动检测凭据形状（按顺序尝试，命中即止）：
 
-| kind | 家族 | 凭据来源 |
+| kind | 家族/版本 | 凭据来源 |
 |---|---|---|
 | `sub2api` | sub2api | `localStorage.auth_token`（键名事实源：sub2api `frontend/src/stores/auth.ts`） |
-| `newapi-session` | new-api | 会话 cookie `session`（仅当站点未设 `HttpOnly` 时可读） |
-| `newapi-access-token` | new-api | `localStorage.user` JSON 里的 `access_token`（one-api 血统的系统访问令牌） |
+| `newapi-session` | 旧版 new-api / one-api 形态 | 会话 cookie `session`（仅当未设 `HttpOnly` 时可读） |
+| `newapi-access-token` | 旧版 new-api | `localStorage.user` JSON 里的 `access_token`（one-api 血统的系统访问令牌） |
+| `newapi-access-token` | **现代版 new-api**（最新版真机实测） | 检测只认**非 httpOnly 的登录标志 cookie** `new_api_has_session=1`（零网络请求）；token 在点击「打开 LoongPort」时经同源 `POST /api/user/auth/refresh` **现铸一次** |
+
+现代版 new-api 的形状与边界（自建最新版实测，2026-09）：
+
+- 前端 localStorage **不存任何凭据**，会话在 httpOnly cookie 里，JWT 只在页面内存；
+- `GET /api/user/token`（铸独立系统令牌的老路）被安全验证门拦（403
+  `SECURITY_PROOF_REQUIRED`），页面走不通；
+- `POST /api/user/auth/refresh` 可以铸 token，但**每次调用都会轮换会话 cookie**，
+  短时间内多次铸会触发站点的 reuse 判定、把整个会话族连坐失效——所以检测用
+  标志 cookie、铸币只在点击时**恰好一次**，绝不轮询着铸；
+- 铸出的 token 有效期约 15 分钟（`expires_at` 是**秒**，消费端按「>1e11 才是
+  毫秒」归一）。接力产物是短期会话——但足够客户端完成档位预配（sk 长期有效）。
 
 `user_id` 只服务 `newapi-session`：客户端要拿会话 cookie 打 new-api 的
-`GET /api/user/token` 换一把 Bearer 访问令牌（只读、不消耗浏览器会话），该端点
-要求 `New-Api-User` 头，页面从 `localStorage.user.id` 读出随回调带上。
-`newapi-access-token` 与 `sub2api` 不需要它。
+`GET /api/user/token` 换一把 Bearer 访问令牌，该端点要求 `New-Api-User` 头，
+页面从 `localStorage.user.id` 读出随回调带上。`sub2api` 与现代版
+`newapi-access-token` 不需要它。
 
 用户资料（昵称等）**不在契约里**：客户端拿到凭据后自己调站点的 profile 端点
 获取，避免经手多余的个人数据（`user_id` 例外——它不是资料，是换令牌的调用参数）。
@@ -98,9 +110,8 @@ loongport://connect
 
 ## 已知边界
 
-- **new-api 家族是尽力而为**：`session` cookie 通常带 `HttpOnly`，静态页读不到；
-  `access_token` 依赖站点/用户开启。两路都不通时页面按未登录处理。new-api 的
-  可靠解是上游契约（见下），握手页只覆盖「cookie 可读或 access_token 存在」的站。
+- **new-api 已两代兼容**（旧版 cookie/localStorage 分支 + 现代版标志 cookie +
+  点击现铸，均真机验证）；再往后的可靠解仍是上游契约（见下）。
 - **客户端接收器已落地**：LoongPort 收到回调后拿凭据打一次站点 profile 验证
   （打不通拒收、不落行），成功即走与登录窗相同的落库链（合并/去重语义一致），
   toast + 自动预配档位。未安装应用的用户点击后浏览器不会有反应（页面会给出

--- a/docs/station-connect/connect.html
+++ b/docs/station-connect/connect.html
@@ -83,9 +83,13 @@
   // sub2api 家族键名（事实源：sub2api frontend src/stores/auth.ts）。
   var SUB2API_TOKEN_KEY = 'auth_token';
   var SUB2API_EXPIRES_KEY = 'token_expires_at';
-  // new-api 家族：会话 cookie 名 session；localStorage 'user' JSON 内含 access_token。
+  // new-api 家族：会话 cookie 名 session；localStorage 'user' JSON 内含 access_token；
+  // 现代版（JWT 在前端内存 + httpOnly 会话）用非 httpOnly 的登录标志 cookie 检测，
+  // 点击时经同源 refresh 端点现铸一把 token（mintNewapiToken）。
   var NEWAPI_SESSION_COOKIE = 'session';
   var NEWAPI_USER_KEY = 'user';
+  var NEWAPI_REFRESH_PATH = '/api/user/auth/refresh';
+  var NEWAPI_HAS_SESSION_COOKIE = 'new_api_has_session';
 
   function readCreds() {
     // new-api 的 user 对象里有账号 id（newapi-session 换访问令牌时客户端要放进
@@ -144,7 +148,34 @@
       } catch (_) { /* 值不完整时按未登录处理 */ }
     }
 
+    // 现代版 new-api：会话在 httpOnly cookie、JWT 只在前端内存里，上面全部读不到。
+    // 检测只认非 httpOnly 的登录标志 cookie（零副作用）；token 点击时现铸 ——
+    // refresh 会轮换会话 cookie，多铸会触发站点的 reuse 判定连坐失效，绝不能轮询着铸。
+    if (document.cookie.match(new RegExp('(?:^|;\\s*)' + NEWAPI_HAS_SESSION_COOKIE + '=1'))) {
+      return { kind: 'newapi-access-token', token: '', expiresAt: '', userId: '', needsMint: true };
+    }
     return null;
+  }
+
+  // 现代版 new-api：借同源 httpOnly 会话请站点铸一把全新 access token。
+  // 只在用户点击「打开 LoongPort」时调用一次 —— refresh 会轮换会话 cookie，
+  // 频繁铸会触发站点的 reuse 判定、把整个会话族连坐失效（真机实测），
+  // 所以检测用登录标志 cookie、铸币只此一次。
+  function mintNewapiToken() {
+    return fetch(NEWAPI_REFRESH_PATH, { method: 'POST', credentials: 'include' })
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (body) {
+        var d = body && body.data;
+        if (d && typeof d.access_token === 'string' && d.access_token.trim()) {
+          return {
+            token: d.access_token.trim(),
+            // new-api 这里是**秒**；消费端与展示层都按「>1e11 才是毫秒」归一。
+            expiresAt: d.access_expires_at > 0 ? String(d.access_expires_at) : '',
+          };
+        }
+        return null;
+      })
+      .catch(function () { return null; });
   }
 
   function render(creds) {
@@ -162,12 +193,16 @@
     }
     document.getElementById('origin').textContent = location.origin;
     document.getElementById('kind').textContent = creds.kind;
-    document.getElementById('preview').textContent = creds.token.slice(0, 8) + '…' + creds.token.slice(-4);
+    document.getElementById('preview').textContent = creds.needsMint
+      ? '点击时从本站会话现取'
+      : creds.token.slice(0, 8) + '…' + creds.token.slice(-4);
     var expiresRow = document.getElementById('expires-row');
     if (creds.expiresAt) {
-      // sub2api 存的是毫秒时间戳字符串，归一展示；原样随回调透传。
-      var ms = Number(creds.expiresAt);
-      document.getElementById('expires').textContent = Number.isSafeInteger(ms) && ms > 0
+      // 归一展示（>1e11 是毫秒，否则按秒）：sub2api 存毫秒、new-api refresh 回秒。
+      // 原样随回调透传，归一留给消费端。
+      var n = Number(creds.expiresAt);
+      var ms = Number.isSafeInteger(n) && n > 0 ? (n > 1e11 ? n : n * 1000) : 0;
+      document.getElementById('expires').textContent = ms > 0
         ? new Date(ms).toLocaleString()
         : creds.expiresAt;
     } else {
@@ -176,19 +211,38 @@
 
     document.getElementById('connect').addEventListener('click', function () {
       // 显式用户点击（也是浏览器允许跳转自定义 scheme 所需的 user activation）。
-      // 手工拼串而非 new URL()：非特殊 scheme 的解析行为各浏览器不一致。
-      var params = [
-        'origin=' + encodeURIComponent(location.origin),
-        'state=' + encodeURIComponent(state),
-        'kind=' + encodeURIComponent(creds.kind),
-        'token=' + encodeURIComponent(creds.token),
-      ];
-      if (creds.expiresAt) params.push('expires_at=' + encodeURIComponent(creds.expiresAt));
-      if (creds.userId) params.push('user_id=' + encodeURIComponent(creds.userId));
-      location.href = CALLBACK_SCHEME + '?' + params.join('&');
-      document.getElementById('fallback').hidden = false;
-      document.getElementById('connect').disabled = true;
+      if (creds.needsMint) {
+        var button = document.getElementById('connect');
+        button.disabled = true;
+        mintNewapiToken().then(function (minted) {
+          if (!minted) {
+            button.textContent = '获取凭据失败，请重试';
+            button.disabled = false;
+            return;
+          }
+          creds.token = minted.token;
+          creds.expiresAt = minted.expiresAt;
+          redirect(creds);
+        });
+        return;
+      }
+      redirect(creds);
     });
+  }
+
+  // 拼回调并跳转（手工拼串而非 new URL()：非特殊 scheme 的解析行为各浏览器不一致）。
+  function redirect(creds) {
+    var params = [
+      'origin=' + encodeURIComponent(location.origin),
+      'state=' + encodeURIComponent(state),
+      'kind=' + encodeURIComponent(creds.kind),
+      'token=' + encodeURIComponent(creds.token),
+    ];
+    if (creds.expiresAt) params.push('expires_at=' + encodeURIComponent(creds.expiresAt));
+    if (creds.userId) params.push('user_id=' + encodeURIComponent(creds.userId));
+    location.href = CALLBACK_SCHEME + '?' + params.join('&');
+    document.getElementById('fallback').hidden = false;
+    document.getElementById('connect').disabled = true;
   }
 
   var localHost = location.hostname === 'localhost' || location.hostname === '127.0.0.1';
@@ -212,6 +266,7 @@
   }
   scan();
   window.setInterval(scan, 1000);
+
 })();
 </script>
 </body>


### PR DESCRIPTION
补合真机 E2E 后的握手页重塑（此前只更新了本地 worktree，未回流 main，导致事实源落后于线上预期）。

- new-api 检测改为 cookie 标志 new_api_has_session（零网络请求，现代 new-api localStorage 已不存凭据）
- 访问令牌改为点击时经 /api/user/auth/refresh 现铸恰好一次（needsMint；多次快速铸发会触发轮换复用检测、连坐杀会话族——真机实测结论）
- 会话 cookie HttpOnly 不可读时按未登录处理；登录引导闭环与注册即登录路径说明
- README 契约/已知边界同批更新

已在最新版 new-api（自建真机）与 sub2api 生产站各走通完整接力。纯文档 PR。