### PR TITLE
fix(codex): 中转站档位 catalog 镜像官方思考档位——修 /model 强度选择器被阉割成两项

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1307,6 +1307,69 @@ fn apply_codex_reasoning_level_override(
     true
 }
 
+/// The official catalog entry whose slug matches, if any. Case-insensitive —
+/// mirrors how `official_context_for_slug` resolved slugs historically. Shared
+/// by the window-facts lookup and the reasoning-level mirror so both read the
+/// same entry.
+fn official_model_entry_for_slug<'a>(
+    slug: &str,
+    official_models: &'a [Value],
+) -> Option<&'a Value> {
+    official_models.iter().find(|model| {
+        model
+            .get("slug")
+            .and_then(Value::as_str)
+            .is_some_and(|official| official.eq_ignore_ascii_case(slug))
+    })
+}
+
+/// Mirror the OFFICIAL catalog's `supported_reasoning_levels` onto a generated
+/// entry whose slug matches an official model. Only for native `/responses`
+/// providers — official model + official wire means the official level set is
+/// the truth — and only when the row declared none of its own: explicit
+/// `reasoningLevels` keep winning (the gateway may normalize or reject levels
+/// it does not know, and curated per-vendor rows encode that), and non-official
+/// slugs keep the template's conservative none/high (an aggregator behind an
+/// official-looking name gets no authority data to widen the set with).
+///
+/// `default_reasoning_level` is deliberately NOT mirrored: the config.toml we
+/// generate pins `model_reasoning_effort`, which wins over the catalog default
+/// anyway, so importing the official default would silently change behavior
+/// for users without the pin. The template default is kept when it stays
+/// inside the mirrored set; otherwise the set's highest level replaces it so
+/// the default can never reference a level the picker does not offer.
+fn mirror_official_reasoning_levels(
+    entry_obj: &mut serde_json::Map<String, Value>,
+    template_default: Option<&str>,
+    slug: &str,
+    official_models: &[Value],
+) {
+    let Some(levels) = official_model_entry_for_slug(slug, official_models)
+        .and_then(|entry| entry.get("supported_reasoning_levels"))
+        .and_then(Value::as_array)
+        .filter(|levels| !levels.is_empty())
+    else {
+        return;
+    };
+    entry_obj.insert(
+        "supported_reasoning_levels".to_string(),
+        Value::Array(levels.clone()),
+    );
+
+    let supported_efforts: Vec<&str> = levels
+        .iter()
+        .filter_map(|level| level.get("effort").and_then(Value::as_str))
+        .collect();
+    if template_default.is_some_and(|default| supported_efforts.contains(&default)) {
+        return;
+    }
+    // Official arrays are ordered lowest → highest, so the last element is the
+    // strongest level offered.
+    if let Some(highest) = supported_efforts.last() {
+        entry_obj.insert("default_reasoning_level".to_string(), json!(highest));
+    }
+}
+
 /// Per-model window facts resolved from the official Codex catalog
 /// (`models_cache.json`) for a model whose slug matches an official entry.
 #[derive(Clone, Copy)]
@@ -1322,12 +1385,7 @@ fn official_context_for_slug(
     slug: &str,
     official_models: &[Value],
 ) -> Option<OfficialModelContext> {
-    let entry = official_models.iter().find(|model| {
-        model
-            .get("slug")
-            .and_then(Value::as_str)
-            .is_some_and(|official| official.eq_ignore_ascii_case(slug))
-    })?;
+    let entry = official_model_entry_for_slug(slug, official_models)?;
     let max = entry
         .get("max_context_window")
         .and_then(Value::as_u64)
@@ -1452,7 +1510,11 @@ fn codex_catalog_model_entry(
     let template_default = template
         .get("default_reasoning_level")
         .and_then(|value| value.as_str());
-    apply_codex_reasoning_level_override(entry_obj, template_default, spec);
+    if !apply_codex_reasoning_level_override(entry_obj, template_default, spec)
+        && profile == CodexCatalogToolProfile::NativeResponses
+    {
+        mirror_official_reasoning_levels(entry_obj, template_default, &spec.model, official_models);
+    }
 
     entry
 }
@@ -5517,6 +5579,204 @@ base_url = "https://production.api/v1"
                 .get("default_reasoning_level")
                 .and_then(|v| v.as_str()),
             Some("xhigh")
+        );
+    }
+
+    #[test]
+    fn native_responses_catalog_mirrors_official_reasoning_levels() {
+        // Relay-tier catalog rows carry no reasoningLevels, so the native
+        // template's conservative none/high collapses Codex's /model effort
+        // picker to two entries. A row whose slug is an OFFICIAL model must
+        // inherit the official level set instead (official model + official
+        // wire = official truth), while curated rows and unknown slugs keep
+        // the existing behavior.
+        let template = json!({
+            "slug": "tpl",
+            "context_window": 272000,
+            "default_reasoning_level": "high",
+            "supported_reasoning_levels": [
+                { "effort": "none", "description": "Disable Thinking" },
+                { "effort": "high", "description": "Greater reasoning depth for complex problems" }
+            ]
+        });
+        let official = vec![
+            json!({
+                "slug": "gpt-5.6-sol",
+                "context_window": 272000,
+                "max_context_window": 872000,
+                "supported_reasoning_levels": [
+                    { "effort": "low", "description": "Fast responses with lighter reasoning" },
+                    { "effort": "medium", "description": "Balances speed and reasoning depth for everyday tasks" },
+                    { "effort": "high", "description": "Greater reasoning depth for complex problems" },
+                    { "effort": "xhigh", "description": "Extra high reasoning depth for complex problems" },
+                    { "effort": "max", "description": "Maximum reasoning depth for the hardest problems" },
+                    { "effort": "ultra", "description": "Maximum reasoning with automatic task delegation" }
+                ]
+            }),
+            // An official set that does not contain the template default
+            // ("high") exercises the default-consistency fallback.
+            json!({
+                "slug": "gpt-mini-fast",
+                "context_window": 272000,
+                "supported_reasoning_levels": [
+                    { "effort": "minimal", "description": "Minimal reasoning" },
+                    { "effort": "low", "description": "Fast responses with lighter reasoning" }
+                ]
+            }),
+        ];
+        let settings = json!({
+            "modelCatalog": {
+                "models": [
+                    // Relay-tier shape: official slug, no declared levels.
+                    { "model": "gpt-5.6-sol" },
+                    // Explicit curation wins over the official mirror.
+                    {
+                        "model": "gpt-mini-fast",
+                        "reasoningLevels": ["none", "high"]
+                    },
+                    // Unknown slug: conservative template levels stay.
+                    { "model": "kimi-k2.7-code" }
+                ]
+            }
+        });
+
+        let catalog = codex_model_catalog_from_specs(
+            &codex_catalog_model_specs(&settings),
+            &template,
+            CodexCatalogToolProfile::NativeResponses,
+            None,
+            &official,
+        );
+        let models = catalog["models"].as_array().expect("models array");
+        let efforts = |index: usize| -> Vec<&str> {
+            models[index]["supported_reasoning_levels"]
+                .as_array()
+                .expect("supported_reasoning_levels array")
+                .iter()
+                .filter_map(|level| level.get("effort").and_then(|v| v.as_str()))
+                .collect()
+        };
+        let default_level = |index: usize| {
+            models[index]
+                .get("default_reasoning_level")
+                .and_then(|v| v.as_str())
+        };
+
+        // Official levels are mirrored verbatim, and the template default is
+        // kept because it stays inside the mirrored set.
+        assert_eq!(
+            efforts(0),
+            vec!["low", "medium", "high", "xhigh", "max", "ultra"]
+        );
+        assert_eq!(
+            models[0]["supported_reasoning_levels"][5]["description"],
+            json!("Maximum reasoning with automatic task delegation")
+        );
+        assert_eq!(default_level(0), Some("high"));
+
+        // The declared subset wins over the official mirror (the official
+        // gpt-mini-fast set is not consulted for this row).
+        assert_eq!(efforts(1), vec!["none", "high"]);
+        assert_eq!(default_level(1), Some("high"));
+
+        // Unknown slug: template's conservative none/high stays.
+        assert_eq!(efforts(2), vec!["none", "high"]);
+        assert_eq!(default_level(2), Some("high"));
+    }
+
+    #[test]
+    fn official_reasoning_level_mirror_fixes_inconsistent_default() {
+        // When the mirrored official set does not contain the template's
+        // default, the default falls back to the set's highest level so it can
+        // never reference an effort the picker does not offer.
+        let template = json!({
+            "slug": "tpl",
+            "default_reasoning_level": "high",
+            "supported_reasoning_levels": [
+                { "effort": "none", "description": "Disable Thinking" },
+                { "effort": "high", "description": "Greater reasoning depth for complex problems" }
+            ]
+        });
+        let official = vec![json!({
+            "slug": "gpt-mini-fast",
+            "supported_reasoning_levels": [
+                { "effort": "minimal", "description": "Minimal reasoning" },
+                { "effort": "low", "description": "Fast responses with lighter reasoning" }
+            ]
+        })];
+        let settings = json!({ "modelCatalog": { "models": [{ "model": "gpt-mini-fast" }] } });
+
+        let catalog = codex_model_catalog_from_specs(
+            &codex_catalog_model_specs(&settings),
+            &template,
+            CodexCatalogToolProfile::NativeResponses,
+            None,
+            &official,
+        );
+        let entry = &catalog["models"][0];
+        let efforts: Vec<&str> = entry["supported_reasoning_levels"]
+            .as_array()
+            .expect("supported_reasoning_levels array")
+            .iter()
+            .filter_map(|level| level.get("effort").and_then(|v| v.as_str()))
+            .collect();
+        assert_eq!(efforts, vec!["minimal", "low"]);
+        assert_eq!(
+            entry
+                .get("default_reasoning_level")
+                .and_then(|v| v.as_str()),
+            Some("low")
+        );
+    }
+
+    #[test]
+    fn proxy_chat_catalog_does_not_mirror_official_reasoning_levels() {
+        // Chat-completions providers run through the Responses→Chat converter
+        // with its own per-provider effort mapping (effortValueMode), so the
+        // official level set must not leak into their catalog entries.
+        let template = json!({
+            "slug": "tpl",
+            "default_reasoning_level": "medium",
+            "supported_reasoning_levels": [
+                { "effort": "low", "description": "Fast responses with lighter reasoning" },
+                { "effort": "medium", "description": "Balances speed and reasoning depth for everyday tasks" },
+                { "effort": "high", "description": "Greater reasoning depth for complex problems" },
+                { "effort": "xhigh", "description": "Extra high reasoning depth for complex problems" }
+            ]
+        });
+        let official = vec![json!({
+            "slug": "gpt-5.6-sol",
+            "supported_reasoning_levels": [
+                { "effort": "low", "description": "Fast responses with lighter reasoning" },
+                { "effort": "medium", "description": "Balances speed and reasoning depth for everyday tasks" },
+                { "effort": "high", "description": "Greater reasoning depth for complex problems" },
+                { "effort": "xhigh", "description": "Extra high reasoning depth for complex problems" },
+                { "effort": "max", "description": "Maximum reasoning depth for the hardest problems" },
+                { "effort": "ultra", "description": "Maximum reasoning with automatic task delegation" }
+            ]
+        })];
+        let settings = json!({ "modelCatalog": { "models": [{ "model": "gpt-5.6-sol" }] } });
+
+        let catalog = codex_model_catalog_from_specs(
+            &codex_catalog_model_specs(&settings),
+            &template,
+            CodexCatalogToolProfile::ProxyChat,
+            None,
+            &official,
+        );
+        let entry = &catalog["models"][0];
+        let efforts: Vec<&str> = entry["supported_reasoning_levels"]
+            .as_array()
+            .expect("supported_reasoning_levels array")
+            .iter()
+            .filter_map(|level| level.get("effort").and_then(|v| v.as_str()))
+            .collect();
+        assert_eq!(efforts, vec!["low", "medium", "high", "xhigh"]);
+        assert_eq!(
+            entry
+                .get("default_reasoning_level")
+                .and_then(|v| v.as_str()),
+            Some("medium")
         );
     }
 


### PR DESCRIPTION
## Summary / 概述

修复用户反馈：中转站档位默认配置下，codex `/model` 的思考强度选择器只剩「关闭思考 / high」两项，不能调整强度。

**根因**：codex 的 `/model` 档位选择器读 catalog 条目的 `supported_reasoning_levels`；catalog 一旦生成，官方目录元数据完全不参与。中转站档位生成的 catalog 行不带 `reasoningLevels`（`relay/provision.rs` 只写 `{model}`），落到中性模板的保守默认 `[none, high]`——官方模型（如 `gpt-5.6-sol`，官方 6 档 low→ultra）被我们自己的 catalog 阉割成 2 档。

**修法**：`codex_config.rs` 生成 catalog 时，slug 命中官方目录（`models_cache.json`）的行镜像官方条目的 `supported_reasoning_levels`。与已有的「官方窗口镜像」（`official_context_for_slug`）同构：官方 slug 的事实以官方目录为唯一权威。

边界（全部有单测钉住）：
- **仅 NativeResponses profile**（官方模型+官方 Responses 协议 ⇒ 官方档位可信）；ProxyChat 走 Chat 转换器的 per-provider 档位映射，不镜像；
- **仅行未显式声明 `reasoningLevels` 时**（显式策展 override-wins，既有语义不变）；
- **非官方 slug 保持保守 `[none, high]`**（aggregator 后端未知，不赌档位值）；
- **`default_reasoning_level` 不镜像**：生成的 config.toml 钉 `model_reasoning_effort`（优先于 catalog default），镜像官方 default 会静默改变未钉值用户的行为；模板默认仍在集合内则保留，否则回退集合最高档（default 永不引用选择器不提供的档）；
- 无官方条目（老 codex / 无 models_cache.json）时宁缺毋认，回落现状保守两档。

存量用户行为零变化：档位模板钉 `high`，默认档位、请求、计费全部不变——变化的只有「能选的集合」。

**用户侧效果**：升级后下次切换档位（重写 catalog）并重启 codex，中转站档位（透传官方模型名）在 `/model` 里从 2 项变官方全档（6 项），选完由 codex 持久化到 config.toml；`model_reasoning_effort` 不在切换白名单（`CODEX_OWNED_TOP_LEVEL_KEYS`），用户的选择不会被下次切换冲掉。

## Related Issue / 关联 Issue

无（用户反馈：codex 默认配置不能调思考强度）

## Screenshots / 截图

无 UI 变化（行为改动：codex 侧 /model 档位选择器选项变多）。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查（未动前端，N/A）
- [x] `pnpm format:check` passes / 通过代码格式检查（未动前端，N/A）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）（本地 fmt/test/clippy 过）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（无用户可见文本变化）

## 验证 / Verification

- 新增 3 个单测：官方镜像+显式优先+非官方保守、default 一致性回退、ProxyChat 不镜像；既有 118 个 codex_config 测试零漂移；
- 本机（有真实 `models_cache.json`）跑过 `cargo test codex_config` 全绿；CI 三平台 Backend Checks 兜编译；
- 已知边界：镜像数据源是用户本机 codex 的官方目录缓存，codex 过旧无该模型条目时回落保守两档（方向安全）；个别网关若对档位值白名单/归一，用户选非常用档可能报错，换档即愈（风险与收益已评估，见 PR 讨论）。
