### PR TITLE
应用栏：tab 条带滚轮/拖拽平移 + 默认可见集收敛为 4 个主入口

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -63,18 +63,24 @@ pub struct VisibleApps {
 }
 
 impl Default for VisibleApps {
+    /// 新装用户的默认可见集：只放 4 个主流量入口（Claude / Codex / Grok / 生图），
+    /// 其余一律藏在「+」里由用户自己补回 —— 10 个 tab 平铺对新人是噪音，且
+    /// tab 条带放不下时要靠滚动才能看全。已保存过 `visible_apps` 的用户不受
+    /// 影响（读宽写窄：字段级 serde default 只服务旧配置文件，见上方各字段）。
+    /// 与前端 `DEFAULT_VISIBLE_APPS`（appConfig.tsx）是同一事实，一致性由
+    /// `default_visible_apps_match_the_frontend_copy` 钉住。
     fn default() -> Self {
         Self {
             claude: true,
-            claude_desktop: true,
+            claude_desktop: false,
             codex: true,
             codex_image: true,
-            gemini: true,
+            gemini: false,
             grokbuild: true,
-            opencode: true,
-            openclaw: true,
-            hermes: false, // 默认不显示，需用户手动启用
-            pi: true,
+            opencode: false,
+            openclaw: false,
+            hermes: false,
+            pi: false,
         }
     }
 }
@@ -1480,8 +1486,60 @@ mod tests {
             .visible_apps
             .expect("frontend settings must include visible apps");
 
+        // 默认可见集 = Claude / Codex / Grok / 生图 四个（见 VisibleApps::default 注释）
         assert!(visible.claude);
+        assert!(visible.codex);
+        assert!(visible.grokbuild);
+        assert!(visible.codex_image);
+        assert!(!visible.claude_desktop);
+        assert!(!visible.gemini);
+        assert!(!visible.opencode);
+        assert!(!visible.openclaw);
         assert!(!visible.hermes);
+        assert!(!visible.pi);
+    }
+
+    /// 「新装用户默认看哪些 app」在 Rust（`VisibleApps::default`）与 TS
+    /// （`DEFAULT_VISIBLE_APPS`，settings 未加载瞬间的兜底）各存一份 —— 跨语言
+    /// 编译器管不到，分叉只表现为两边短暂闪不同的 tab 集。这道闸把分叉变成
+    /// `cargo test` 秒红（CLAUDE.md §三点六；hermes 曾真实分叉过）。
+    #[test]
+    fn default_visible_apps_match_the_frontend_copy() {
+        let ts = include_str!("../../src/config/appConfig.tsx");
+        let block_start = ts
+            .find("export const DEFAULT_VISIBLE_APPS")
+            .expect("appConfig.tsx 里应有 DEFAULT_VISIBLE_APPS");
+        let block = &ts[block_start
+            ..ts[block_start..]
+                .find("\n};")
+                .map(|end| block_start + end + 3)
+                .unwrap_or(ts.len())];
+
+        let defaults = VisibleApps::default();
+        for (key, value) in [
+            ("claude", defaults.claude),
+            ("claude-desktop", defaults.claude_desktop),
+            ("codex", defaults.codex),
+            ("codex-image", defaults.codex_image),
+            ("gemini", defaults.gemini),
+            ("grokbuild", defaults.grokbuild),
+            ("opencode", defaults.opencode),
+            ("openclaw", defaults.openclaw),
+            ("hermes", defaults.hermes),
+            ("pi", defaults.pi),
+        ] {
+            // 键名与 serde 序列化一致；TS 里含连字符的键带引号（"claude-desktop"）
+            let expected = if key.contains('-') {
+                format!("\"{key}\": {value}")
+            } else {
+                format!("{key}: {value}")
+            };
+            assert!(
+                block.contains(&expected),
+                "DEFAULT_VISIBLE_APPS 的 `{key}` 与 Rust 侧 VisibleApps::default 不一致\n  \
+                 Rust 侧: {value}\n  期望 TS 里出现: {expected}"
+            );
+        }
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -257,10 +257,14 @@ function App() {
   };
 
   useEffect(() => {
+    // settings 未加载前 visibleApps 只是 DEFAULT 兜底（渲染闪空用），不参与
+    // 裁决 —— 否则 lastApp 恰好是默认隐藏 app 的用户会在加载前被弹回 claude，
+    // 加载后真实可见集到了也不弹回去，「恢复上次应用」静默失效。
+    if (!settingsData) return;
     if (!visibleApps[activeApp]) {
       setActiveApp(getFirstVisibleApp());
     }
-  }, [visibleApps, activeApp]);
+  }, [visibleApps, activeApp, settingsData]);
 
   // tab 上的 ×：与设置页「主页面显示」同一开关，就地隐藏一个应用。
   // 发送与 DEFAULT_VISIBLE_APPS 合并后的完整对象（后端 visible_apps 是整体替换）；
@@ -1527,8 +1531,8 @@ function App() {
                   <ProfileSwitcher activeApp={activeApp} />
                 </div>
               )}
-            {/* 弹性中段：tab 不做自动折叠，放不下时由 overflow-hidden 裁剪左侧；
-                可见集由用户显式控制（tab 上的 × 或设置页「主页面显示」） */}
+            {/* 弹性中段：tab 不做自动折叠，放不下时在条带内滚轮 / 拖拽平移
+                （见 AppSwitcher）；可见集由用户显式控制（tab 上的 × 或设置页「主页面显示」） */}
             <div className="flex flex-1 min-w-0 items-center justify-end overflow-hidden py-4">
               {currentView === "providers" && (
                 <AppSwitcher

--- a/src/components/AppSwitcher.tsx
+++ b/src/components/AppSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { AppId } from "@/lib/api";
 import type { VisibleApps } from "@/types";
@@ -101,6 +101,9 @@ function AppGlyph({ app, isActive }: { app: AppId; isActive: boolean }) {
   );
 }
 
+/** 位移超过该值才算拖拽（在此之前松手照常触发 click 切换 tab）。 */
+const DRAG_START_THRESHOLD_PX = 4;
+
 export function AppSwitcher({
   activeApp,
   onSwitch,
@@ -110,6 +113,96 @@ export function AppSwitcher({
 }: AppSwitcherProps) {
   const { t } = useTranslation();
   const [addOpen, setAddOpen] = useState(false);
+  const [dragging, setDragging] = useState(false);
+
+  const stripRef = useRef<HTMLDivElement>(null);
+  const activeTabRef = useRef<HTMLButtonElement>(null);
+  const dragStateRef = useRef<{
+    pointerId: number;
+    startX: number;
+    startScrollLeft: number;
+    dragging: boolean;
+  } | null>(null);
+  // 拖拽结束的那次 pointerup 会紧接着派发一次 click；不拦下它就会在松手瞬间
+  // 切到指针底下恰好停着的那个 tab。pointerdown 时清零、消费时清零。
+  const suppressClickRef = useRef(false);
+
+  // 纵向滚轮在条带上转成横向滚动（App 全局隐藏滚动条，滚轮/拖拽是仅有的两个
+  // 平移手段）。React 的 onWheel 是 passive 监听，preventDefault 不生效，须挂原生。
+  useEffect(() => {
+    const el = stripRef.current;
+    if (!el) return;
+    const onWheel = (event: WheelEvent) => {
+      if (event.deltaY === 0 || event.deltaX !== 0) return;
+      if (el.scrollWidth <= el.clientWidth) return;
+      const before = el.scrollLeft;
+      el.scrollLeft = before + event.deltaY;
+      if (el.scrollLeft !== before) event.preventDefault();
+    };
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  }, []);
+
+  // 拖拽平移：pointerdown 不立即 capture（会把子按钮的 click 吞掉），超过阈值
+  // 才对条带 setPointerCapture —— 出窗后 move/up 仍能送达，非拖拽点击不受影响。
+  useEffect(() => {
+    const onPointerMove = (event: PointerEvent) => {
+      const state = dragStateRef.current;
+      const el = stripRef.current;
+      if (!state || !el || state.pointerId !== event.pointerId) return;
+      const dx = event.clientX - state.startX;
+      if (!state.dragging) {
+        if (Math.abs(dx) < DRAG_START_THRESHOLD_PX) return;
+        state.dragging = true;
+        setDragging(true);
+        el.setPointerCapture(state.pointerId);
+      }
+      el.scrollLeft = state.startScrollLeft - dx;
+    };
+    const endDrag = (event: PointerEvent) => {
+      const state = dragStateRef.current;
+      if (!state || state.pointerId !== event.pointerId) return;
+      dragStateRef.current = null;
+      if (state.dragging) {
+        setDragging(false);
+        suppressClickRef.current = true;
+      }
+    };
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", endDrag);
+    window.addEventListener("pointercancel", endDrag);
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", endDrag);
+      window.removeEventListener("pointercancel", endDrag);
+    };
+  }, []);
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    suppressClickRef.current = false;
+    dragStateRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startScrollLeft: stripRef.current?.scrollLeft ?? 0,
+      dragging: false,
+    };
+  };
+
+  const handleClickCapture = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (!suppressClickRef.current) return;
+    suppressClickRef.current = false;
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  // 切到条带视野外的 tab（或激活 app 被隐藏后的自动回退）时把它滚进来。
+  useEffect(() => {
+    activeTabRef.current?.scrollIntoView({
+      block: "nearest",
+      inline: "nearest",
+    });
+  }, [activeApp]);
 
   const handleSwitch = (app: AppId) => {
     if (app === activeApp) return;
@@ -131,53 +224,66 @@ export function AppSwitcher({
 
   return (
     <div
-      className="inline-flex bg-muted rounded-xl p-1 gap-1"
+      className="inline-flex max-w-full min-w-0 items-center gap-1 rounded-xl bg-muted p-1"
       style={{ WebkitAppRegion: "no-drag" } as any}
     >
-      {appsToShow.map((app) => {
-        const isActive = activeApp === app;
-        const name = getAppDisplayName(app, t);
-        return (
-          <div key={app} className="group relative">
-            <button
-              type="button"
-              onClick={() => handleSwitch(app)}
-              title={name}
-              aria-label={name}
-              className={cn(
-                "inline-flex items-center px-3 h-8 rounded-md text-sm font-medium transition-all duration-200",
-                isActive
-                  ? "bg-background text-foreground shadow-sm"
-                  : "text-muted-foreground hover:text-foreground hover:bg-background/50",
-              )}
-            >
-              <AppGlyph app={app} isActive={isActive} />
-            </button>
-            {canHide && (
+      {/* 可滚动 tab 条带：tab 多到放不下时不再被静默裁剪，滚轮 / 拖拽平移
+          （App 全局隐藏滚动条）；负 margin 抵掉为 × 角标留的溢出空间。 */}
+      <div
+        ref={stripRef}
+        onPointerDown={handlePointerDown}
+        onClickCapture={handleClickCapture}
+        className={cn(
+          "-mx-2 -my-2 flex min-w-0 touch-pan-x gap-1 overflow-x-auto px-2 py-2",
+          dragging && "cursor-grabbing",
+        )}
+      >
+        {appsToShow.map((app) => {
+          const isActive = activeApp === app;
+          const name = getAppDisplayName(app, t);
+          return (
+            <div key={app} className="group relative">
               <button
+                ref={isActive ? activeTabRef : undefined}
                 type="button"
-                title={t("appSwitcher.hide")}
-                aria-label={`${t("appSwitcher.hide")}: ${name}`}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onHideApp?.(app);
-                }}
+                onClick={() => handleSwitch(app)}
+                title={name}
+                aria-label={name}
                 className={cn(
-                  "absolute -top-1.5 -right-1 z-10 flex h-3.5 w-3.5 items-center justify-center",
-                  "rounded-full border border-border bg-background text-muted-foreground shadow-sm",
-                  "opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 hover:text-foreground",
+                  "inline-flex items-center px-3 h-8 rounded-md text-sm font-medium transition-all duration-200",
+                  isActive
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground hover:bg-background/50",
                 )}
               >
-                <X
-                  aria-hidden="true"
-                  className="h-[9px] w-[9px]"
-                  strokeWidth={2.5}
-                />
+                <AppGlyph app={app} isActive={isActive} />
               </button>
-            )}
-          </div>
-        );
-      })}
+              {canHide && (
+                <button
+                  type="button"
+                  title={t("appSwitcher.hide")}
+                  aria-label={`${t("appSwitcher.hide")}: ${name}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onHideApp?.(app);
+                  }}
+                  className={cn(
+                    "absolute -top-1.5 -right-1 z-10 flex h-3.5 w-3.5 items-center justify-center",
+                    "rounded-full border border-border bg-background text-muted-foreground shadow-sm",
+                    "opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 hover:text-foreground",
+                  )}
+                >
+                  <X
+                    aria-hidden="true"
+                    className="h-[9px] w-[9px]"
+                    strokeWidth={2.5}
+                  />
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
       {onShowApp && (
         <Popover open={addOpen} onOpenChange={setAddOpen}>
           <PopoverTrigger asChild>
@@ -186,7 +292,7 @@ export function AppSwitcher({
               title={t("appSwitcher.add")}
               aria-label={t("appSwitcher.add")}
               className={cn(
-                "inline-flex items-center px-3 h-8 rounded-md transition-all duration-200",
+                "inline-flex shrink-0 items-center px-3 h-8 rounded-md transition-all duration-200",
                 addOpen
                   ? "bg-background text-foreground shadow-sm"
                   : "text-muted-foreground hover:text-foreground hover:bg-background/50",

--- a/src/config/appConfig.tsx
+++ b/src/config/appConfig.tsx
@@ -50,18 +50,21 @@ export function getAppDisplayName(app: AppId, t: TFunction): string {
   return app === "codex-image" ? t("apps.codex-image") : APP_DISPLAY_NAME[app];
 }
 
+// 默认只展示 4 个主流量入口（Claude / Codex / Grok / 生图），其余藏在「+」里由
+// 用户自己补回 —— settings 未加载的瞬间才会用到这份兜底，加载后以后端
+// VisibleApps::default 为准（两侧一致性由 settings.rs 的比对测试钉住）。
+// 生图保持默认可见：入口藏起来后，买了生图分组的用户会找不到（上一版踩过）。
 export const DEFAULT_VISIBLE_APPS: VisibleApps = {
   claude: true,
-  "claude-desktop": true,
+  "claude-desktop": false,
   codex: true,
-  // 生图标签默认可见（与后端 VisibleApps::codex_image 的默认一致）。
   "codex-image": true,
-  gemini: true,
+  gemini: false,
   grokbuild: true,
-  opencode: true,
-  openclaw: true,
-  hermes: true,
-  pi: true,
+  opencode: false,
+  openclaw: false,
+  hermes: false,
+  pi: false,
 };
 
 /** App IDs shown in Skills panels. */

--- a/tests/components/AppSwitcher.test.tsx
+++ b/tests/components/AppSwitcher.test.tsx
@@ -1,10 +1,21 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { AppSwitcher } from "@/components/AppSwitcher";
-import { DEFAULT_VISIBLE_APPS } from "@/config/appConfig";
 import type { VisibleApps } from "@/types";
 
-const allVisible = DEFAULT_VISIBLE_APPS;
+// 显式写全可见的夹具（产品默认集会随版本变，别拿 DEFAULT_VISIBLE_APPS 当测试前提）
+const allVisible: VisibleApps = {
+  claude: true,
+  "claude-desktop": true,
+  codex: true,
+  "codex-image": true,
+  gemini: true,
+  grokbuild: true,
+  opencode: true,
+  openclaw: true,
+  hermes: true,
+  pi: true,
+};
 
 /** 测试环境 i18n 资源为空，t() 回落成键名本身；× 的 title 即 "appSwitcher.hide" */
 const hideButtonSelector = "button[title='appSwitcher.hide']";

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -7,6 +7,9 @@ import { server } from "./msw/server";
 import { resetProviderState } from "./msw/state";
 import "./msw/tauriMocks";
 
+// jsdom 未实现 scrollIntoView；AppSwitcher 切换 tab 时会把活动 tab 滚进条带视野。
+Element.prototype.scrollIntoView = vi.fn();
+
 beforeAll(async () => {
   server.listen({ onUnhandledRequest: "warn" });
   await i18n.use(initReactI18next).init({


### PR DESCRIPTION
## Summary / 概述

应用栏两个改动：

1. **tab 条带支持滚轮 / 拖拽平移**：tab 多到放不下时不再被 `overflow-hidden` 静默裁剪左侧——鼠标悬停条带后纵向滚轮转横向滚动、按住拖拽平移；切换 tab 时活动 tab 自动滚入视野。「+」固定在条带末尾不参与滚动，恢复入口任何时刻可见。App 全局隐藏滚动条（既有设计），滚轮 / 拖拽即平移手段。
2. **默认可见集收敛为 4 个主入口**（Claude / Codex / Grok / 生图）：新装用户不再面对 10 个平铺 tab，其余应用经「+」自行补回。已保存过 `visible_apps` 的老用户不受影响（字段级 serde default 保持读宽写窄，仅服务旧配置文件解析）。

连带修复一个被 2 暴露的回归：settings 加载前不再用前端 DEFAULT 兜底裁决 `activeApp`——否则「恢复上次应用」对上次停在默认隐藏 app 的用户静默失效（加载前被弹回 claude，加载后不弹回）。

另加跨语言一致性闸：`DEFAULT_VISIBLE_APPS`（TS）与 `VisibleApps::default`（Rust）是同一事实的两份拷贝（hermes 曾真实分叉过），现在 `cargo test` 秒红。

## Related Issue / 关联 Issue

无

## Screenshots / 截图

滚轮 / 拖拽是交互行为，截图无法表达；默认集变化即 tab 数量变化。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（无新增文案）
