### PR TITLE
ci(windows-build): 打包步骤显式 shell: bash，修 --config JSON 被 shim 剥引号

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -98,6 +98,10 @@ jobs:
       - name: 打包
         # 手动测试包不参与自动更新，所以显式关闭 updater artifact；否则没有 release
         # signing secret 的 workflow 会在安装包已生成后因缺私钥返回失败。
+        # shell: bash 必须显式指定：Windows 默认 pwsh 经 cmd shim 调 pnpm 时不保
+        # 单引号，--config 的 JSON 会被剥成 `{bundle:{...}}` 直接解析失败
+        #（release.yml 各步早已显式 bash，只有这条漏了）。
+        shell: bash
         run: pnpm tauri build --target ${{ matrix.target }} --bundles nsis --config '{"bundle":{"createUpdaterArtifacts":false}}'
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
一行 CI 修复，独立成 PR（#360 收尾时发现）：

「打包」步骤的 `--config '{"bundle":...}'` 在 Windows 默认 pwsh 下经 cmd shim 调 pnpm，单引号不保、内层双引号被剥，tauri CLI 收到 `{bundle:{...}}` 直接解析失败（实测 run 34316257532：`key must be a string at line 1 column 2`）。该 workflow 声称 2026-08-04 演练跑绿过，之后工具链 shim 行为变了没人再跑过它。

修法与 `release.yml` 一致（各步早已显式 `shell: bash`，只有这条漏了）：显式 `shell: bash`。
