### PR TITLE
fix(ui): 档位倍率改高亮小标签并紧贴分组名

### DIFF
--- a/src/components/easymode/TierList.tsx
+++ b/src/components/easymode/TierList.tsx
@@ -35,6 +35,7 @@ import { useResetCircuitBreaker } from "@/lib/query/failover";
 import { cn } from "@/lib/utils";
 import { fmtInt, fmtUsd } from "@/components/usage/format";
 import { BoardVerdictDot } from "@/components/relay/model-verification/TierVerdictChip";
+import { TierRateChip } from "@/components/relay/TierRateChip";
 import type { TierBoardTier } from "@/lib/api/autoMode";
 import type { DraggableAttributes } from "@dnd-kit/core";
 import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
@@ -192,6 +193,9 @@ function TierCard({
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <span className="truncate text-sm font-medium">{tier.name}</span>
+          {/* 倍率紧贴档位名（挑档位第一个要看的数字）；样式与 null 纪律
+              （不显示，原来的「×?」一并废掉）唯源 TierRateChip。 */}
+          <TierRateChip rate={tier.rateMultiplier} />
           {isCurrentTier ? (
             <Badge
               variant="outline"
@@ -223,11 +227,6 @@ function TierCard({
           <BoardVerdictDot verdict={tier.verificationVerdict} />
         </div>
         <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-          <span className="tabular-nums">
-            ×
-            {tier.rateMultiplier ??
-              t("autoMode.board.unknown", { defaultValue: "?" })}
-          </span>
           <span className="tabular-nums">
             {tier.unitPricePerMillion != null
               ? `${fmtUsd(tier.unitPricePerMillion, 2)}/M`

--- a/src/components/relay/ImagegenPlayground.tsx
+++ b/src/components/relay/ImagegenPlayground.tsx
@@ -29,6 +29,8 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 
+import { TierRateChip } from "./TierRateChip";
+
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -240,9 +242,10 @@ export function ImagegenPlayground() {
                       </span>
                       <span className="ml-2 shrink-0 text-xs text-muted-foreground">
                         {tier.model}
-                        {tier.rateMultiplier !== null &&
-                          ` · ${t("loongport.tier.rate", { value: tier.rateMultiplier })}`}
                       </span>
+                      {/* 倍率与另两处档位展示同款标签（唯源 TierRateChip），
+                          不再混进灰色的模型名后缀里。 */}
+                      <TierRateChip rate={tier.rateMultiplier} />
                     </CommandItem>
                   ))}
                 </CommandGroup>

--- a/src/components/relay/RelayRow.tsx
+++ b/src/components/relay/RelayRow.tsx
@@ -34,6 +34,7 @@ import { ReconcileDialog } from "./ReconcileDialog";
 import { RowBalance } from "./RowBalance";
 import { SiteConfigDialog } from "./SiteConfigDialog";
 import { TierVerifyButton } from "./model-verification/TierVerifyButton";
+import { TierRateChip } from "./TierRateChip";
 import { TierVerdictChip } from "./model-verification/TierVerdictChip";
 import { useTierVerification } from "./model-verification/TierVerificationProvider";
 
@@ -628,9 +629,8 @@ function StatusAction({
 /**
  * 一个档位。
  *
- * ⚠️ **`rateMultiplier` 为 null 时不显示倍率，绝不能显示成 0 或「免费」** ——
- * 列表命令只读本地，倍率是服务端定价，要 provision 才有值
- * （`relay.rs` 的 `TierInfo` 注释钉过这条）。显示成 0 会让用户以为这是最便宜的一档。
+ * 倍率的显示纪律（null 不渲染、绝不显示成 0/「免费」）和样式在
+ * `TierRateChip` —— 那是三处倍率展示的唯一形状源。
  */
 function TierItem({
   tier,
@@ -698,6 +698,9 @@ function TierItem({
       <div className="min-w-0 flex-1">
         <div className="flex min-w-0 items-center gap-1.5">
           <span className="truncate text-sm">{tier.groupName}</span>
+          {/* 倍率紧贴分组名（用户扫档位行第一个要找的数字），比其余
+              状态 chip 更靠左；样式与 null 纪律唯源 TierRateChip。 */}
+          <TierRateChip rate={tier.rateMultiplier} />
           {/* 「已手动维护」标记。**常驻不藏进 hover** —— 它是状态不是动作，
               藏起来用户就得逐行 hover 才知道哪些档位脱离了自动维护。
               与「N 个档位」「余额」同一条判据（信息常驻、动作 hover）。 */}
@@ -724,10 +727,6 @@ function TierItem({
           )}
           {/* 验真结论 chip：模型验证模块自持（下线/无结论时不渲染）。 */}
           <TierVerdictChip providerId={tier.providerId} />
-        </div>
-        <div className="text-xs text-muted-foreground">
-          {tier.rateMultiplier !== null &&
-            t("loongport.tier.rate", { value: tier.rateMultiplier })}
         </div>
       </div>
 

--- a/src/components/relay/TierRateChip.tsx
+++ b/src/components/relay/TierRateChip.tsx
@@ -1,0 +1,28 @@
+/**
+ * 档位倍率标签：分组名右侧那枚高亮小 chip 的唯一形状源。
+ *
+ * 三处消费共用（provider 页档位行 `RelayRow`、省心看板档位卡 `TierList`、
+ * 生图档位选择器 `ImagegenPlayground`），改样式只改这里。
+ *
+ * ⚠️ **`rate` 为 null 时整体不渲染，绝不能显示成 0 或「免费」** ——
+ * 列表命令只读本地，倍率是服务端定价，要 provision 才有值
+ * （`relay.rs` 的 `TierInfo` 注释钉过这条）。显示成 0 会让用户以为这是
+ * 最便宜的一档。省心看板原来 null 显示「×?」，与档位行「不显示」是同一
+ * 事实两套纪律，这次一并对齐到不显示。
+ *
+ * 配色是**中性高亮**：蓝=在用、绿=代理接管、琥珀=需留意、紫=生图/OMO，
+ * 都有主了；倍率是定价事实，不抢任何语义色，靠实底 + 半粗 + 全前景色
+ * 提对比度（原来散在各处的 `text-muted-foreground` 灰小字看不清）。
+ * 暗色模式实底单独提亮一档（`bg-muted` 在暗色下和卡片底几乎同色）。
+ */
+import { useTranslation } from "react-i18next";
+
+export function TierRateChip({ rate }: { rate: number | null }) {
+  const { t } = useTranslation();
+  if (rate === null) return null;
+  return (
+    <span className="inline-flex shrink-0 items-center rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold tabular-nums text-foreground dark:bg-muted-foreground/20">
+      {t("loongport.tier.rate", { value: rate })}
+    </span>
+  );
+}

--- a/src/components/relay/TierRateChip.tsx
+++ b/src/components/relay/TierRateChip.tsx
@@ -22,7 +22,9 @@ export function TierRateChip({ rate }: { rate: number | null }) {
   if (rate === null) return null;
   return (
     <span className="inline-flex shrink-0 items-center rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold tabular-nums text-foreground dark:bg-muted-foreground/20">
-      {t("loongport.tier.rate", { value: rate })}
+      {/* defaultValue 与 zh 资源同串：看板测试的全局 i18n 资源为空（TierList
+          全组件都用 defaultValue 出中文，同一习语）；生产恒走 zh.json。 */}
+      {t("loongport.tier.rate", { value: rate, defaultValue: "{{value}} 倍" })}
     </span>
   );
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2616,7 +2616,6 @@
       "dragHint": "Drag cards to set priority; failures fall through and switch back on recovery",
       "dragHandle": "Drag to reorder",
       "current": "Current",
-      "unknown": "?",
       "priceUnknown": "Unknown price",
       "balance": "Balance",
       "ttft": "TTFT",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2616,7 +2616,6 @@
       "dragHint": "カードをドラッグして優先度を調整。障害時は次のティアへ切替、復旧後に戻ります",
       "dragHandle": "ドラッグで並べ替え",
       "current": "現在使用中",
-      "unknown": "?",
       "priceUnknown": "価格不明",
       "balance": "残高",
       "ttft": "初字",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2617,7 +2617,6 @@
       "dragHint": "拖動卡片調整優先級，故障自動落下一家並回切",
       "dragHandle": "拖動排序",
       "current": "當前",
-      "unknown": "?",
       "priceUnknown": "價格未知",
       "balance": "餘額",
       "ttft": "首字",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2616,7 +2616,6 @@
       "dragHint": "拖动卡片调整优先级，故障自动落下一家并回切",
       "dragHandle": "拖动排序",
       "current": "当前",
-      "unknown": "?",
       "priceUnknown": "价格未知",
       "balance": "余额",
       "ttft": "首字",

--- a/tests/components/EasyBoard.test.tsx
+++ b/tests/components/EasyBoard.test.tsx
@@ -228,7 +228,9 @@ describe("EasyBoard", () => {
     setupBoard(boardFixture());
     expect(screen.getByText("便宜档")).toBeDefined();
     expect(screen.getByText("贵档")).toBeDefined();
-    expect(screen.getByText("×0.5")).toBeDefined();
+    // 倍率现在是紧贴档位名的 TierRateChip（i18n 模板「{{value}} 倍」），
+    // 不再是指标行里的内联「×0.5」。
+    expect(screen.getByText("0.5 倍")).toBeDefined();
     expect(screen.getByText("$2.00/M")).toBeDefined();
     expect(screen.getByText("余额 $10.35")).toBeDefined();
     expect(screen.getByText("价格未知")).toBeDefined();


### PR DESCRIPTION
## 问题

provider 页档位行的倍率是第二行的灰色小字（`text-xs text-muted-foreground`），看不清；省心看板里 ×N 混在六项灰色指标行里、生图选择器里贴在灰色模型名后面，同样不显眼。

## 改法

三处倍率展示统一收进新组件 `TierRateChip`（唯一形状源）：紧贴分组名/档位名右侧的实底小标签，半粗 + 全前景色提对比；颜色保持中性——蓝=在用、绿=代理接管、琥珀=需留意、紫=生图，语义色都有主了，倍率是定价事实不抢色。暗色模式实底单独提亮一档（`bg-muted` 在暗色下和卡片底几乎同色）。

- `RelayRow` TierItem：第二行灰字 → 分组名右侧标签
- `TierList` TierCard：×N 从指标行提到档位名右侧
- `ImagegenPlayground`：不再混在模型名后缀里

顺带对齐一处纪律分叉：看板原来 null 显示「×?」、档位行不显示，同一事实两套纪律；统一为 null 一律不渲染（显示成 0/「免费」会误导，`relay.rs` `TierInfo` 注释钉过）。死掉的 `autoMode.board.unknown` i18n key 四语言一并清除。

## 验证

- `tsc --noEmit` / prettier / vitest（relay 全套 + localeCoverage，61 用例）全绿
- 视觉：真实挂法（`.dark` 于 `<html>`）亮暗两主题逐区块截图评审——暗色下标签清晰、分组名浅色正常、无黑字残留