### PR TITLE
fix(codex): 启动即刷新当前档位的 catalog 投影——升级/重装后修复不再等用户再切一次档位

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -2294,6 +2294,13 @@ fn codex_model_catalog_from_settings(
     let configured_context_window =
         extract_codex_top_level_u64(config_text, "model_context_window");
     let official_models = load_codex_official_models();
+    if official_models.is_empty() {
+        // bundled 与 models_cache.json 都没拿到官方数据（最常见：本机找不到
+        // codex CLI）。官方 slug 将落保守档位——这应当可见，而不是静默降级。
+        log::warn!(
+            "官方 codex 目录不可用（codex CLI 未发现且无 models_cache.json）：官方模型将使用保守档位"
+        );
+    }
 
     // Native providers use the bundled clean template (no freeform apply_patch,
     // no cache dependency); proxy-chat providers keep cloning Codex's gpt-5.5
@@ -2311,6 +2318,57 @@ fn codex_model_catalog_from_settings(
         configured_context_window,
         &official_models,
     )))
+}
+
+/// 启动时刷新**当前** codex 供应商的 catalog 投影。
+///
+/// catalog 是 provider 设置的投影产物，但重写触发只有切换/保存——升级带来
+/// 的生成器变化（镜像逻辑、官方数据源）不会自己落盘，用户不碰巧再切一次
+/// 档位就永远拿着旧文件，「修复不生效」（两例真实反馈的根因）。刷新的
+/// owner 是应用启动：每次启动都跑、无需用户仪式、幂等。
+///
+/// 外科式边界：只动 catalog 文件，以及（live 未被代理接管时）config.toml
+/// 里的 `model_catalog_json` 指针键。`auth.json`、`model`、
+/// `model_reasoning_effort` 与所有非 owned 键一概不碰——尤其启动做全量
+/// live 同步会把用户在 codex 侧 `/model` 选的模型打回档位默认，绝不可以。
+/// 投影不出 catalog 的供应商（无 `modelCatalog` 或空 specs）直接 no-op：
+/// 摘指针是切换路径的语义，启动不做删除。
+///
+/// 返回是否写了任何东西。
+pub fn refresh_codex_catalog_projection(
+    settings: &Value,
+    config_text: &str,
+    profile: CodexCatalogToolProfile,
+    live_taken_over: bool,
+) -> Result<bool, AppError> {
+    if settings.get("modelCatalog").is_none() {
+        return Ok(false);
+    }
+    let Some(catalog) = codex_model_catalog_from_settings(settings, config_text, profile)? else {
+        return Ok(false);
+    };
+
+    let mut changed = false;
+    let catalog_path = get_codex_model_catalog_path();
+    let contents = crate::config::serialize_json_bytes(&catalog)?;
+    let existing = fs::read(&catalog_path).unwrap_or_default();
+    if existing != contents {
+        if let Some(parent) = catalog_path.parent() {
+            fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+        }
+        crate::config::atomic_write(&catalog_path, &contents)?;
+        changed = true;
+    }
+
+    if !live_taken_over {
+        let updated = set_codex_model_catalog_json_field(config_text, Some(&catalog_path))?;
+        if updated != config_text {
+            write_text_file(&get_codex_config_path(), &updated)?;
+            changed = true;
+        }
+    }
+
+    Ok(changed)
 }
 
 fn set_codex_model_catalog_json_field(
@@ -5904,6 +5962,117 @@ base_url = "https://production.api/v1"
         assert_eq!(source_of("gpt-5.6-sol"), Some("bundled"));
         assert_eq!(source_of("gpt-6-astra"), Some("bundled"));
         assert_eq!(source_of("gpt-brand-new"), Some("cache"));
+    }
+
+    #[test]
+    #[serial]
+    fn startup_catalog_refresh_writes_file_and_pointer_surgically() {
+        // 隔离 home 下无 models_cache.json 且测试构建不 spawn codex ⇒ 无官方
+        // 数据 ⇒ 用非官方 slug 保证档位是确定性模板默认（none/high）。
+        let _home = CodexLiveTestHome::new();
+        let settings = json!({
+            "modelCatalog": { "models": [{ "model": "vendor-model-x" }] }
+        });
+        let config_text = r#"model_provider = "custom"
+model = "vendor-model-x"
+model_reasoning_effort = "low"
+approval_policy = "never"
+
+[model_providers.custom]
+name = "x"
+base_url = "https://example.invalid/v1"
+wire_api = "responses"
+"#;
+
+        let changed = refresh_codex_catalog_projection(
+            &settings,
+            config_text,
+            CodexCatalogToolProfile::NativeResponses,
+            false,
+        )
+        .expect("refresh should succeed");
+
+        assert!(changed, "first refresh must write the catalog and pointer");
+        let catalog_path = get_codex_model_catalog_path();
+        let catalog: Value = serde_json::from_str(
+            &std::fs::read_to_string(&catalog_path).expect("catalog file written"),
+        )
+        .expect("catalog is valid JSON");
+        assert_eq!(
+            catalog["models"][0]["slug"],
+            json!("vendor-model-x"),
+            "catalog carries the tier model"
+        );
+
+        let live = std::fs::read_to_string(get_codex_config_path()).expect("config.toml written");
+        assert!(
+            live.contains("model_catalog_json = \"loongport-model-catalog.json\""),
+            "pointer key must be added: {live}"
+        );
+        // 外科式：owned 之外的用户键与 codex 侧选择一概不动。
+        assert!(live.contains("model_reasoning_effort = \"low\""));
+        assert!(live.contains("approval_policy = \"never\""));
+        assert!(live.contains("model = \"vendor-model-x\""));
+
+        // 幂等：内容一致时第二次刷新零写入。
+        let changed_again = refresh_codex_catalog_projection(
+            &settings,
+            &live,
+            CodexCatalogToolProfile::NativeResponses,
+            false,
+        )
+        .expect("second refresh should succeed");
+        assert!(!changed_again, "identical projection must not rewrite");
+    }
+
+    #[test]
+    #[serial]
+    fn startup_catalog_refresh_skips_pointer_during_live_takeover() {
+        let _home = CodexLiveTestHome::new();
+        let settings = json!({
+            "modelCatalog": { "models": [{ "model": "vendor-model-x" }] }
+        });
+        let config_text = "model = \"vendor-model-x\"\n";
+
+        let changed = refresh_codex_catalog_projection(
+            &settings,
+            config_text,
+            CodexCatalogToolProfile::NativeResponses,
+            true,
+        )
+        .expect("refresh should succeed");
+
+        assert!(changed, "catalog file itself is still refreshed");
+        assert!(
+            !get_codex_config_path().exists(),
+            "config.toml must stay untouched while live is under proxy takeover"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn startup_catalog_refresh_is_noop_without_model_catalog() {
+        let _home = CodexLiveTestHome::new();
+        let settings = json!({ "auth": {} });
+        let config_text = "model = \"whatever\"\n";
+
+        let changed = refresh_codex_catalog_projection(
+            &settings,
+            config_text,
+            CodexCatalogToolProfile::NativeResponses,
+            false,
+        )
+        .expect("refresh should succeed");
+
+        assert!(!changed);
+        assert!(
+            !get_codex_model_catalog_path().exists(),
+            "no catalog projection ⇒ nothing written; removal is switch-time semantics"
+        );
+        assert!(
+            !get_codex_config_path().exists(),
+            "config.toml must not be created either"
+        );
     }
 
     #[test]

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -328,6 +328,16 @@ fn sort_json_keys(value: &Value) -> Value {
     }
 }
 
+/// 序列化为落盘 JSON 的规范字节（键排序 + pretty）——所有 JSON 写入共用，
+/// 使「生成内容与磁盘比对」与写入格式逐字节一致。
+pub fn serialize_json_bytes<T: Serialize>(data: &T) -> Result<Vec<u8>, AppError> {
+    let value = serde_json::to_value(data).map_err(|e| AppError::JsonSerialize { source: e })?;
+    let sorted_value = sort_json_keys(&value);
+    serde_json::to_string_pretty(&sorted_value)
+        .map(|json| json.into_bytes())
+        .map_err(|e| AppError::JsonSerialize { source: e })
+}
+
 /// 写入 JSON 配置文件并返回实际写入的字节。
 pub fn write_json_file_with_contents<T: Serialize>(
     path: &Path,
@@ -338,12 +348,7 @@ pub fn write_json_file_with_contents<T: Serialize>(
         fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
     }
 
-    let value = serde_json::to_value(data).map_err(|e| AppError::JsonSerialize { source: e })?;
-    let sorted_value = sort_json_keys(&value);
-    let json = serde_json::to_string_pretty(&sorted_value)
-        .map_err(|e| AppError::JsonSerialize { source: e })?;
-
-    let contents = json.into_bytes();
+    let contents = serialize_json_bytes(data)?;
     atomic_write(path, &contents)?;
     Ok(contents)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1383,6 +1383,24 @@ pub fn run() {
                 });
             }
 
+            // 启动即刷新当前 codex 档位的 catalog 投影：catalog 是投影产物，
+            // 升级带来的生成器变化必须下次启动就落盘，而不是等用户碰巧再切
+            // 一次档位（两例「升级/重装后修复不生效」反馈的根因）。外科式：
+            // 只动 catalog 文件与指针键，不碰 auth/model/effort。延迟几秒，
+            // 让开更新闸门与 maintenance 先行。
+            {
+                let handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                    let state = handle.state::<AppState>();
+                    if let Err(e) =
+                        crate::services::provider::refresh_current_codex_catalog_projection(&state)
+                    {
+                        log::warn!("启动刷新 codex catalog 投影失败: {e}");
+                    }
+                });
+            }
+
             // 初始化 SkillService
             let skill_service = SkillService::new();
             app.manage(commands::skill::SkillServiceState(Arc::new(skill_service)));

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -369,6 +369,37 @@ fn provider_uses_official_subscription_usage(app_type: &AppType, provider: &Prov
     }
 }
 
+/// 启动时刷新当前 Codex 供应商的 catalog 投影（外科式，语义见
+/// [`crate::codex_config::refresh_codex_catalog_projection`]）。无当前供应商、
+/// 投影不出 catalog、或内容与磁盘一致时为 no-op。
+pub fn refresh_current_codex_catalog_projection(state: &AppState) -> Result<bool, AppError> {
+    let current_id = ProviderService::current(state, AppType::Codex)?;
+    if current_id.is_empty() {
+        return Ok(false);
+    }
+    let providers = state.db.get_all_providers(AppType::Codex.as_str())?;
+    let Some(provider) = providers.get(&current_id) else {
+        return Ok(false);
+    };
+
+    let config_text = crate::codex_config::read_codex_config_text()?;
+    let profile = crate::proxy::providers::resolve_codex_catalog_tool_profile(provider);
+    // 接管期间 config.toml 归代理所有（备份/占位符机制，同
+    // reapply_current_codex_official_live 的所有权判定）；catalog 文件仍可
+    // 刷新（两条配置指向同一文件），但指针键不写。
+    let live_taken_over =
+        futures::executor::block_on(state.db.get_live_backup(AppType::Codex.as_str()))
+            .ok()
+            .flatten()
+            .is_some();
+    crate::codex_config::refresh_codex_catalog_projection(
+        &provider.settings_config,
+        &config_text,
+        profile,
+        live_taken_over,
+    )
+}
+
 /// 统一会话开关变更后，立即按新开关状态重写当前官方 Codex 供应商的
 /// live 配置，使开关即时生效（无需等下一次切换）。
 /// 当前供应商非官方（或不存在）时为 no-op：注入只作用于官方配置，


### PR DESCRIPTION
## Summary / 概述

修复一类流程性失效：**升级/重装 LoongPort 后，codex 思考档位修复不生效**——除非用户碰巧再切换一次档位。

**根因（触发归属错误）**：catalog 是 provider 设置的投影产物，但重写触发只有「切换/保存」——升级带来的生成器变化（#354 镜像机制、#364 bundled 数据源）不会自己落盘，磁盘上的旧两档 catalog 一直被 codex 引用。投影刷新的 owner 应是**应用启动**，不是用户的无关操作（全局准则 §1.4 触发归属）。两例真实反馈（升级版/全新安装版）都折在这条腿上。

**修法**：启动后延迟 3 秒，对**当前 codex 供应商**外科式刷新 catalog 投影：
- 只重写 **catalog 文件**（内容有变化才写，逐字节比对、确定性序列化）和 **`model_catalog_json` 指针键**（复用既有所有权规则：仅缺失或已属我们时才写；live 被代理接管时连指针也不碰）；
- **绝不碰** `auth.json`、`model`、`model_reasoning_effort` 与任何非 owned 键——尤其启动做全量 live 同步会把用户在 codex 侧 `/model` 选的模型打回档位默认，此 PR 刻意避开；
- 无 `modelCatalog` 的供应商（投影不出 catalog）为 no-op，摘指针仍归切换路径管；
- 官方数据完全拿不到时（codex CLI 未发现且无 models_cache.json）从静默降级改为 **warn 日志**，使该长尾可诊断。

配套小抽取：`config.rs` 的确定性 JSON 序列化收为 `serialize_json_bytes` 公共函数（写入与内容比对共用同一格式，幂等比对逐字节成立）。

## Related Issue / 关联 Issue

无（用户反馈：全新安装最新版仍无思考强度选择——待其诊断日志区分「启动刷新覆盖」与「codex 发现长尾」）

## Screenshots / 截图

无 UI 变化。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查（未动前端，N/A）
- [x] `pnpm format:check` passes / 通过代码格式检查（未动前端，N/A）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（无）

## 验证 / Verification

- 新增 3 个密封单测（隔离 home）：外科式写入+指针+用户键不动+幂等 / 接管期只刷文件不碰 config / 无 catalog 投影 no-op；既有 122 个 codex_config 测试零漂移
- 用户侧效果：升级到含本 PR 的版本后**打开一次应用**即自动应用新 catalog（无需再切档位），重启 codex 后 `/model` 生效
