### PR TITLE
fix: port upstream stability fixes (mask_url UTF-8, journal ghost sessions, exit capability)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -14,6 +14,7 @@
     "core:window:allow-is-maximized",
     "core:window:allow-close",
     "core:window:allow-set-decorations",
+    "process:allow-exit",
     "process:allow-restart",
     "dialog:default"
   ]

--- a/src-tauri/src/proxy/http_client.rs
+++ b/src-tauri/src/proxy/http_client.rs
@@ -325,9 +325,14 @@ pub fn mask_url(url: &str) -> String {
             None => format!("{}://{}", parsed.scheme(), host),
         }
     } else {
-        // URL 解析失败，返回部分内容
+        // URL 解析失败，返回部分内容。截断点回退到最近的字符边界，
+        // 避免在多字节 UTF-8 字符中间切割导致 panic。
         if url.len() > 20 {
-            format!("{}...", &url[..20])
+            let cut = (0..=20)
+                .rev()
+                .find(|&i| url.is_char_boundary(i))
+                .unwrap_or(0);
+            format!("{}...", &url[..cut])
         } else {
             url.to_string()
         }
@@ -364,6 +369,15 @@ mod tests {
             mask_url("https://user:pass@proxy.example.com"),
             "https://proxy.example.com"
         );
+    }
+
+    #[test]
+    fn test_mask_url_does_not_panic_on_multibyte_boundary() {
+        // 一个无法被 Url::parse 解析、且在字节 20 处正好切在多字节字符中间的字符串。
+        let bad = "这是一个无效的代理地址不能解析";
+        assert!(bad.len() > 20 && !bad.is_char_boundary(20));
+        let masked = mask_url(bad);
+        assert!(masked.ends_with("..."));
     }
 
     #[test]

--- a/src-tauri/src/session_manager/providers/claude.rs
+++ b/src-tauri/src/session_manager/providers/claude.rs
@@ -255,7 +255,7 @@ fn parse_session(path: &Path) -> Option<SessionMeta> {
 fn is_agent_session(path: &Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())
-        .map(|name| name.starts_with("agent-"))
+        .map(|name| name.starts_with("agent-") || name == "journal.jsonl")
         .unwrap_or(false)
 }
 
@@ -496,5 +496,42 @@ mod tests {
 
         let meta = parse_session(&path).unwrap();
         assert_eq!(meta.title.as_deref(), Some("帮我看看工作区的改动"));
+    }
+
+    #[test]
+    fn workflow_journal_log_is_excluded_from_sessions() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("journal.jsonl");
+        std::fs::write(
+            &path,
+            "{\"type\":\"started\",\"key\":\"k\",\"agentId\":\"a\"}\n",
+        )
+        .expect("write");
+
+        assert!(is_agent_session(&path));
+    }
+
+    #[test]
+    fn agent_session_files_are_still_excluded() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("agent-abc123.jsonl");
+        std::fs::write(&path, "{\"type\":\"user\",\"isSidechain\":true}\n").expect("write");
+
+        assert!(is_agent_session(&path));
+    }
+
+    #[test]
+    fn real_session_file_is_not_excluded() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp
+            .path()
+            .join("8f8e7c8e-0000-0000-0000-000000000000.jsonl");
+        std::fs::write(
+            &path,
+            "{\"sessionId\":\"8f8e7c8e-0000-0000-0000-000000000000\"}\n",
+        )
+        .expect("write");
+
+        assert!(!is_agent_session(&path));
     }
 }


### PR DESCRIPTION
## Summary

Three small stability fixes ported from the upstream v3.20.x backlog:

1. **proxy: mask_url char-boundary truncation** — the fallback masking branch (proxy URL that fails `Url::parse`) sliced at byte 20 and panicked when a multi-byte UTF-8 character straddled the offset, e.g. a CJK string pasted into the global proxy address.
2. **claude: workflow journal.jsonl ghost sessions** — the workflow feature writes `subagents/workflows/wf_*/journal.jsonl` inside session directories; the scanner only excluded `agent-*` files, so each journal parsed as an empty ghost session titled "journal".
3. **capabilities: process:allow-exit** — the db-version-too-new recovery screen and the config-load-failure path call `exit()` from `@tauri-apps/plugin-process`, but the default capability only granted `process:allow-restart`; the IPC call was denied and silently swallowed, leaving the app impossible to quit from those screens.

## Testing

- `cargo fmt` / `cargo clippy --all-targets -- -D warnings` / `cargo test` pass locally; 4 new regression tests green.
- Note: two site_balance tests fail deterministically on the maintainer machine but fail identically on pristine `main` (local environment, unrelated to this change); CI on a clean runner is authoritative.