### PR TITLE
feat(imagegen): add quality selector (low/medium/high; xhigh/max on gpt-image-2.5)

### DIFF
--- a/src-tauri/src/commands/relay/imagegen.rs
+++ b/src-tauri/src/commands/relay/imagegen.rs
@@ -42,11 +42,13 @@ pub struct ImagegenGenerateResult {
 /// `n` = 张数（批量，1-50 自由输入），范围判据的唯一源在核心层
 /// （`imagegen::validate_count`）；`parallel` = 并发提交开关（生成视图的勾选框，
 /// 缺省开）——两种模式的形状与取舍见 `imagegen::split_batch` 的表，本层只做缺省补全。
+/// `quality` = 质量档（`None` 不发该参数，用站点默认；透传语义见核心层的请求组装）。
 #[tauri::command]
 pub async fn relay_imagegen_generate(
     app_handle: tauri::AppHandle,
     prompt: String,
     size: Option<String>,
+    quality: Option<String>,
     n: Option<u32>,
     parallel: Option<bool>,
 ) -> Result<ImagegenGenerateResult, String> {
@@ -60,6 +62,7 @@ pub async fn relay_imagegen_generate(
         &tier,
         prompt,
         size.as_deref(),
+        quality.as_deref(),
         count,
         parallel.unwrap_or(true),
     )

--- a/src-tauri/src/relay/imagegen.rs
+++ b/src-tauri/src/relay/imagegen.rs
@@ -440,6 +440,7 @@ pub(crate) async fn generate_batch(
     tier: &Tier,
     prompt: &str,
     size: Option<&str>,
+    quality: Option<&str>,
     total: u32,
     parallel: bool,
 ) -> Result<(Vec<GeneratedImage>, usize), String> {
@@ -453,7 +454,7 @@ pub(crate) async fn generate_batch(
             batches
                 .iter()
                 .copied()
-                .map(|n| generate_image(tier, prompt, size, n, request_timeout(n))),
+                .map(|n| generate_image(tier, prompt, size, quality, n, request_timeout(n))),
         )
         .buffered(concurrency)
         .collect()
@@ -489,6 +490,7 @@ pub(crate) async fn generate_image(
     tier: &Tier,
     prompt: &str,
     size: Option<&str>,
+    quality: Option<&str>,
     n: u32,
     timeout: std::time::Duration,
 ) -> Result<Vec<GeneratedImage>, String> {
@@ -513,12 +515,19 @@ pub(crate) async fn generate_image(
     // 站点对 `gpt-image-2` 回 `data[].url`（另一个模型才回 b64），其官方教程也明确
     // 「两种形态都可能出现、客户端都要兼容」。只认 b64 的解析在这种站点上必报
     // 「data 项里没有 b64_json」—— [`read_image_bytes`] 对两种形态都处理，url 走下载。
-    let body = serde_json::json!({
+    // `quality` 与 `response_format` 同一条纪律：**不发 = 站点默认**。App 内入口的
+    // 选项按当前档位模型过滤（`xhigh`/`max` 仅 gpt-image-2.5），但本层不做白名单 ——
+    // 与 `size` 一样原样透传：值域由上游模型代际决定，写死会随代际演进过期
+    // （2.5 的 `xhigh`/`max` 就是 2026-09-10 才出现的）。
+    let mut body = serde_json::json!({
         "model": tier.model,
         "prompt": prompt,
         "n": n,
         "size": size.unwrap_or(DEFAULT_SIZE),
     });
+    if let Some(q) = quality.map(str::trim).filter(|q| !q.is_empty()) {
+        body["quality"] = serde_json::Value::String(q.to_string());
+    }
 
     let resp = client
         .post(images_url(&tier.base_url))

--- a/src-tauri/src/relay/imagegen_mcp.rs
+++ b/src-tauri/src/relay/imagegen_mcp.rs
@@ -188,6 +188,10 @@ fn tools_list() -> Value {
                     "type": "string",
                     "description": "图片尺寸，形如 1024x1024 或 1536x1024。省略则用 1024x1024。注意上游可能返回与请求不同的实际尺寸。"
                 },
+                "quality": {
+                    "type": "string",
+                    "description": "图片质量：low / medium / high；gpt-image-2.5 系另有 xhigh / max。省略则不发该参数（用站点默认）。仅 gpt-image 系模型支持。"
+                },
                 "n": {
                     "type": "integer",
                     "description": "一次生成几张（1-50，默认 1）。按张数计费；多张会自动拆成并发单张请求。大批量耗时更长，宿主的工具超时（codex 默认 300 秒）可能在完成前先到 —— 超大批量时并发多次调用本工具（每次各自计时）通常更稳。"
@@ -245,6 +249,7 @@ async fn handle_tool_call(req: &Value) -> Result<Value, String> {
         .filter(|s| !s.is_empty())
         .ok_or("generate_image 需要非空的 prompt")?;
     let size = args.get("size").and_then(Value::as_str);
+    let quality = args.get("quality").and_then(Value::as_str);
     // 张数由宿主 agent 传，默认 1。校验放在读档位**之前**：越界是调用方的错，
     // 该先报它（没配档位的机器上也能得到这条而不是「还没选定档位」）。
     // 范围判据的唯一源在核心层（`imagegen::validate_count`），与 App 内入口共用。
@@ -256,7 +261,7 @@ async fn handle_tool_call(req: &Value) -> Result<Value, String> {
     let tier = imagegen::load_current_tier()?;
     // MCP 入口恒为并发：agent 想串行有自己的表达（逐次调用工具天然串行），
     // 不为它加 schema 噪音。见 `imagegen::split_batch` 的表。
-    let (images, failed) = imagegen::generate_batch(&tier, prompt, size, n, true).await?;
+    let (images, failed) = imagegen::generate_batch(&tier, prompt, size, quality, n, true).await?;
     let list = images
         .iter()
         .map(|i| i.path.display().to_string())

--- a/src/components/relay/ImagegenPlayground.tsx
+++ b/src/components/relay/ImagegenPlayground.tsx
@@ -78,6 +78,17 @@ import {
 /** 尺寸档位：gpt-image 的三档（与 MCP 工具的 size 语义一致，不给「自动」）。 */
 const SIZE_OPTIONS = ["1024x1024", "1536x1024", "1024x1536"] as const;
 
+/** 质量档的 gpt-image 基础值域；2.5 代际另加 xhigh/max（对老模型发会被站点拒）。
+ *  判据用宽松 contains（trim + 小写后），自定义变体名（如 xxx-gpt-image-2.5-proxy）也认，
+ *  与上游 gpt_image_playground 的 isGptImage25Model 同口径。 */
+const BASE_QUALITY_OPTIONS = ["low", "medium", "high"] as const;
+const QUALITY_DEFAULT = "default"; // Select 的「默认」哨兵值（Radix 不允许空串 value）
+
+const isGptImageModel = (model: string) =>
+  model.trim().toLowerCase().includes("gpt-image-");
+const isGptImage25Model = (model: string) =>
+  model.trim().toLowerCase().includes("gpt-image-2.5");
+
 export function ImagegenPlayground() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -88,6 +99,8 @@ export function ImagegenPlayground() {
   const [prompt, setPrompt] = useState("");
   const [size, setSize] = useState<string>("1024x1024");
   const [count, setCount] = useState<string>("1");
+  // 质量档：与尺寸/张数同为本次会话偏好（默认「不发 = 站点默认」），不落设置。
+  const [quality, setQuality] = useState<string>(QUALITY_DEFAULT);
   // 并发提交是本次会话的生成偏好（默认开），不落设置 —— 折叠态这类 UI 偏好归前端。
   const [parallel, setParallel] = useState(true);
   const [preview, setPreview] = useState<ImagegenGalleryEntry | null>(null);
@@ -135,6 +148,21 @@ export function ImagegenPlayground() {
   );
   const currentTier = tiers.find((tier) => tier.isCurrent);
 
+  // 质量选择器只对 gpt-image 系档位有意义（nano-banana / grok-imagine 走别的
+  // 参数语义）；档位切到不支持当前质量档的模型时，就地回落「默认」而非发非法值。
+  const tierModel = currentTier?.model ?? "";
+  const qualityOptions = isGptImage25Model(tierModel)
+    ? [...BASE_QUALITY_OPTIONS, "xhigh", "max"]
+    : [...BASE_QUALITY_OPTIONS];
+  const qualityValue =
+    quality !== QUALITY_DEFAULT && qualityOptions.includes(quality)
+      ? quality
+      : QUALITY_DEFAULT;
+  const submitQuality =
+    isGptImageModel(tierModel) && qualityValue !== QUALITY_DEFAULT
+      ? qualityValue
+      : null;
+
   const switchTier = async (providerId: string, name: string) => {
     try {
       const result = await relayApi.switchTier(providerId, "codex-image");
@@ -154,7 +182,13 @@ export function ImagegenPlayground() {
     const parsed = Number.parseInt(count, 10);
     const safe = Number.isNaN(parsed) ? 1 : Math.min(50, Math.max(1, parsed));
     generate.mutate(
-      { prompt: prompt.trim(), size, count: safe, parallel },
+      {
+        prompt: prompt.trim(),
+        size,
+        quality: submitQuality,
+        count: safe,
+        parallel,
+      },
       {
         onSuccess: (result) => {
           // 部分失败：成功的图已落盘画廊，warning 说明有几张没成，别当整体失败。
@@ -284,6 +318,28 @@ export function ImagegenPlayground() {
                 ))}
               </SelectContent>
             </Select>
+            {/* 质量档：只对 gpt-image 系档位显示。默认 = 不发该参数（站点默认），
+                选项随当前档位模型代际过滤（xhigh/max 仅 2.5）。 */}
+            {isGptImageModel(tierModel) && (
+              <Select value={qualityValue} onValueChange={setQuality}>
+                <SelectTrigger
+                  className="w-[110px]"
+                  aria-label={t("loongport.imagegenPlayground.qualityLabel")}
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={QUALITY_DEFAULT}>
+                    {t("loongport.imagegenPlayground.qualityDefault")}
+                  </SelectItem>
+                  {qualityOptions.map((option) => (
+                    <SelectItem key={option} value={option}>
+                      {option}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
             {/* 批量张数：自由输入（1-50，后端闸）。一次点下去就是 n 张的钱，
                 hint 把后果写在点上；提交节奏（并发/串行）由旁边的勾选框决定。 */}
             <Input

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3402,6 +3402,8 @@
       "tierFilterEmpty": "No matching connection profiles",
       "promptPlaceholder": "Describe the image to generate…",
       "sizeLabel": "Size",
+      "qualityLabel": "Quality",
+      "qualityDefault": "Default",
       "countLabel": "Count",
       "parallelLabel": "Submit in parallel",
       "countHint": "Generate several at once (1-50): billed per image",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3402,6 +3402,8 @@
       "tierFilterEmpty": "一致する接続プロファイルはありません",
       "promptPlaceholder": "生成する画像を説明してください…",
       "sizeLabel": "サイズ",
+      "qualityLabel": "品質",
+      "qualityDefault": "デフォルト",
       "countLabel": "枚数",
       "parallelLabel": "並列送信",
       "countHint": "一度に複数枚生成（1-50）：枚数分の課金になります",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3403,6 +3403,8 @@
       "tierFilterEmpty": "沒有符合的連線設定檔",
       "promptPlaceholder": "描述要生成的圖片…",
       "sizeLabel": "尺寸",
+      "qualityLabel": "品質",
+      "qualityDefault": "預設",
       "countLabel": "張數",
       "parallelLabel": "並行提交",
       "countHint": "一次生成多張（1-50）：按張數計費",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -3402,6 +3402,8 @@
       "tierFilterEmpty": "没有匹配的接入配置",
       "promptPlaceholder": "描述要生成的图片…",
       "sizeLabel": "尺寸",
+      "qualityLabel": "质量",
+      "qualityDefault": "默认",
       "countLabel": "张数",
       "parallelLabel": "并发提交",
       "countHint": "一次生成多张（1-50）：按张数计费",

--- a/src/lib/api/relay.ts
+++ b/src/lib/api/relay.ts
@@ -647,6 +647,7 @@ export const relayApi = {
   /**
    * App 内直接生图（生图页「生成」视图）。`count` = 张数（后端闸 1..=50），
    * `parallel` = 并发提交开关（缺省开；两种模式的形状见后端 `split_batch` 的表）。
+   * `quality` = 质量档（`null` 不发该参数，用站点默认；后端原样透传）。
    * 慢请求：后端超时按张数放大（每张 240s 封顶），前端勿再叠加短超时。
    */
   imagegenGenerate: (
@@ -654,12 +655,14 @@ export const relayApi = {
     size?: string | null,
     count?: number,
     parallel?: boolean,
+    quality?: string | null,
   ): Promise<ImagegenGenerateResult> =>
     invoke("relay_imagegen_generate", {
       prompt,
       size: size ?? null,
       n: count ?? 1,
       parallel: parallel ?? true,
+      quality: quality ?? null,
     }),
 
   /** 出图目录的画廊清单（MCP 与直接生图的产物同目录），mtime 从新到旧。 */

--- a/src/lib/query/imagegen.ts
+++ b/src/lib/query/imagegen.ts
@@ -40,14 +40,16 @@ export const useImagegenGenerate = () => {
     mutationFn: ({
       prompt,
       size,
+      quality,
       count,
       parallel,
     }: {
       prompt: string;
       size: string | null;
+      quality: string | null;
       count: number;
       parallel: boolean;
-    }) => relayApi.imagegenGenerate(prompt, size, count, parallel),
+    }) => relayApi.imagegenGenerate(prompt, size, count, parallel, quality),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: imagegenKeys.gallery });
     },

--- a/tests/config/loongportLocales.test.ts
+++ b/tests/config/loongportLocales.test.ts
@@ -362,6 +362,8 @@ const requiredKeys = [
   "imagegenPlayground.tierFilterEmpty",
   "imagegenPlayground.promptPlaceholder",
   "imagegenPlayground.sizeLabel",
+  "imagegenPlayground.qualityLabel",
+  "imagegenPlayground.qualityDefault",
   // 批量张数的计费/耗时提示是知情前提 —— 缺了它自由输入就是个不知价格的框；
   // 部分失败 toast 是「成功的已到手、几张没成」的唯一交代；
   // 并发开关的两句是快/稳取舍的知情前提。


### PR DESCRIPTION
## Summary

GPT Image 2.5 landed with new quality tiers (xhigh / max on top of low / medium / high). The generate view now has a quality selector, and the MCP image tool accepts the same optional parameter.

- **Default = don't send the parameter** (site default applies) — same discipline as `size`.
- The selector only appears for gpt-image tiers (nano-banana / grok-imagine have different parameter semantics); options are low / medium / high, plus xhigh / max when the current tier's model is gpt-image-2.5 (loose `contains` match, so custom variant names count).
- Switching to a tier whose model doesn't support the picked level falls back to "default" at submit time instead of sending a value the site would reject.
- The MCP tool schema gains an optional `quality` property mirroring `size`.
- The backend passes the value through verbatim with no allowlist: the valid set evolves with model generations and a hardcoded list would rot (xhigh/max appeared with 2.5).

## Testing

- Backend: cargo fmt / clippy --all-targets / cargo test pass locally (the two site_balance failures are the known maintainer-machine environment pair that also fails on pristine main).
- Frontend: tsc / prettier / vitest (1301 tests) pass; i18n keys added to all four locales and to the requiredKeys gate.