### PR TITLE
fix(proxy): port upstream proxy fixes (#7263 implicit-openai base_url, #7210 per-app settings preservation)

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -3963,9 +3963,9 @@ pub fn restore_codex_settings_for_backfill(
 ///
 /// Supported fields:
 /// - `"base_url"`: writes to `[model_providers.<current>].base_url` if `model_provider` exists,
-///   otherwise falls back to top-level `base_url`.
+///   otherwise uses `openai_base_url` for Codex's default built-in provider.
 /// - `"wire_api"`: writes to `[model_providers.<current>].wire_api` if `model_provider` exists,
-///   otherwise falls back to top-level `wire_api`.
+///   otherwise leaves the built-in provider's Responses protocol unchanged.
 /// - `"model"` / `"model_catalog_json"`: writes to top-level field.
 ///
 /// Empty value removes the field.
@@ -3981,7 +3981,9 @@ pub fn update_codex_toml_field(toml_str: &str, field: &str, value: &str) -> Resu
             let model_provider = doc
                 .get("model_provider")
                 .and_then(|item| item.as_str())
-                .map(str::to_string);
+                .map(str::to_string)
+                // Codex 在 selector 缺省时回落内置 openai——同走它的正统改址机制。
+                .or_else(|| (!doc.contains_key("model_provider")).then(|| "openai".to_string()));
 
             if let Some(provider_key) = model_provider {
                 // validate_reserved_model_provider_ids（0.148 起）对配置里出现
@@ -5147,7 +5149,7 @@ model = "gpt-4"
     }
 
     #[test]
-    fn base_url_falls_back_to_top_level_without_model_provider() {
+    fn base_url_uses_openai_override_without_model_provider() {
         let input = r#"model = "gpt-4"
 "#;
 
@@ -5155,10 +5157,18 @@ model = "gpt-4"
         let parsed: toml::Value = toml::from_str(&result).unwrap();
 
         let base_url = parsed
-            .get("base_url")
+            .get("openai_base_url")
             .and_then(|v| v.as_str())
-            .expect("should set top-level base_url");
+            .expect("should set the built-in provider's URL override");
         assert_eq!(base_url, "https://fallback.api/v1");
+        assert!(parsed.get("base_url").is_none());
+        let responses = update_codex_toml_field(&result, "wire_api", "responses").unwrap();
+        assert_eq!(responses, result);
+        let cleared = update_codex_toml_field(&result, "base_url", "").unwrap();
+        assert_eq!(
+            toml::from_str::<toml::Value>(&cleared).unwrap(),
+            toml::from_str::<toml::Value>(input).unwrap()
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -1020,10 +1020,15 @@ impl ProxyService {
             return Ok(());
         }
 
-        let mut resolved_config = config.clone();
+        // 端口是全局字段，不能通过旧接口回写各应用独立的重试和超时配置。
+        let mut resolved_config = self
+            .db
+            .get_global_proxy_config()
+            .await
+            .map_err(|e| format!("获取全局代理配置失败: {e}"))?;
         resolved_config.listen_port = actual_port;
         self.db
-            .update_proxy_config(resolved_config)
+            .update_global_proxy_config(resolved_config)
             .await
             .map_err(|e| format!("保存动态代理端口失败: {e}"))
     }
@@ -1886,23 +1891,17 @@ impl ProxyService {
         // 2. 恢复原始 Live 配置
         self.restore_live_configs().await?;
 
-        // 3. 更新 proxy_config 表中的 live_takeover_active 标志（兼容旧版）
-        //    注意：保留 proxy_config.enabled 状态，下次启动时自动恢复
-        if let Ok(mut config) = self.db.get_proxy_config().await {
-            config.live_takeover_active = false;
-            self.db.update_proxy_config(config).await.warn_on_err(
-                DiagnosticEvent::new("proxy.shutdown", "persist_state_failed")
-                    .field("phase", "restore_keep_state"),
-            );
-        }
+        // 保留各应用的 enabled 和故障转移配置，下次启动时自动恢复。
+        // live_takeover_active 已废弃：旧接口的回写不带 WHERE，会把 Claude 行的
+        // 重试/超时字段盖到其余应用上（#7204），死写回直接删掉。
 
-        // 4. 删除备份（Live 配置已恢复，备份不再需要）
+        // 3. 删除备份（Live 配置已恢复，备份不再需要）
         self.db
             .delete_all_live_backups()
             .await
             .map_err(|e| format!("删除备份失败: {e}"))?;
 
-        // 5. 重置健康状态
+        // 4. 重置健康状态
         self.db
             .clear_all_provider_health()
             .await
@@ -4242,6 +4241,100 @@ mod tests {
         db.update_proxy_config(proxy_config)
             .await
             .expect("set test proxy config to an ephemeral port");
+    }
+
+    /// 给四个应用种下互不相同的代理配置（#7204 的回归底料：任何一个应用的
+    /// 字段被别的应用盖掉都会被逐字段比对抓到）。
+    async fn seed_distinct_app_proxy_configs(db: &Database) -> Vec<Value> {
+        let mut configs = Vec::new();
+        for (app, retries) in [("claude", 6), ("codex", 0), ("gemini", 2), ("grokbuild", 3)] {
+            let mut config = db.get_proxy_config_for_app(app).await.unwrap();
+            config.enabled = retries % 2 == 0;
+            config.auto_failover_enabled = retries % 2 != 0;
+            config.max_retries = retries;
+            config.streaming_first_byte_timeout = 30 + retries;
+            config.streaming_idle_timeout = 90 + retries;
+            config.non_streaming_timeout = 300 + retries;
+            config.circuit_failure_threshold = 5 + retries;
+            configs.push(serde_json::to_value(&config).unwrap());
+            db.update_proxy_config_for_app(config).await.unwrap();
+        }
+        configs
+    }
+
+    async fn assert_app_proxy_configs_unchanged(db: &Database, configs: &[Value]) {
+        for expected in configs {
+            let app = expected["appType"].as_str().unwrap();
+            let actual = db.get_proxy_config_for_app(app).await.unwrap();
+            assert_eq!(serde_json::to_value(actual).unwrap(), *expected, "{app}");
+        }
+    }
+
+    /// 正常退出的关停路径不得把 Claude 行的重试/超时字段盖到其他应用上（#7204）。
+    #[tokio::test]
+    #[serial]
+    async fn shutdown_preserves_app_proxy_configs() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().unwrap();
+        let db = Arc::new(Database::memory().unwrap());
+        let configs = seed_distinct_app_proxy_configs(&db).await;
+        let service = ProxyService::new(
+            db.clone(),
+            crate::relay::model_verification::passive::PassiveIngress::channel(1).0,
+        );
+
+        let backup = json!({"env": {"ANTHROPIC_BASE_URL": "https://example.com"}});
+        db.save_live_backup("claude", &backup.to_string())
+            .await
+            .unwrap();
+
+        service.stop_with_restore_keep_state().await.unwrap();
+
+        assert_app_proxy_configs_unchanged(&db, &configs).await;
+        assert_eq!(
+            crate::config::read_json_file::<Value>(&crate::config::get_claude_settings_path())
+                .unwrap(),
+            backup
+        );
+        assert!(db.get_live_backup("claude").await.unwrap().is_none());
+    }
+
+    /// 动态端口的落盘只许碰全局的 listen 字段，各应用独立配置原样保留（#7204）。
+    #[tokio::test]
+    async fn ephemeral_port_preserves_app_proxy_configs() {
+        let db = Arc::new(Database::memory().unwrap());
+        let configs = seed_distinct_app_proxy_configs(&db).await;
+        let service = ProxyService::new(
+            db.clone(),
+            crate::relay::model_verification::passive::PassiveIngress::channel(1).0,
+        );
+        let mut config = db.get_proxy_config().await.unwrap();
+        config.listen_port = 0;
+        let mut expected_global = db.get_global_proxy_config().await.unwrap();
+        expected_global.listen_port = 23456;
+
+        service
+            .persist_ephemeral_listen_port_if_needed(&config, 23456)
+            .await
+            .unwrap();
+
+        assert_app_proxy_configs_unchanged(&db, &configs).await;
+        assert_eq!(
+            serde_json::to_value(db.get_global_proxy_config().await.unwrap()).unwrap(),
+            serde_json::to_value(expected_global).unwrap()
+        );
+
+        // 已固定的端口不再重复落盘。
+        config.listen_port = 23456;
+        service
+            .persist_ephemeral_listen_port_if_needed(&config, 34567)
+            .await
+            .unwrap();
+        assert_eq!(
+            db.get_global_proxy_config().await.unwrap().listen_port,
+            23456
+        );
+        assert_app_proxy_configs_unchanged(&db, &configs).await;
     }
 
     #[tokio::test]
@@ -6885,24 +6978,68 @@ wire_api = "responses"
     }
 
     #[test]
-    fn update_toml_base_url_falls_back_to_top_level_base_url() {
+    fn update_toml_base_url_uses_implicit_openai_override() {
         let input = r#"
 model = "gpt-5.1-codex"
 "#;
 
         let new_url = "http://127.0.0.1:5000/v1";
         let output = crate::codex_config::update_codex_toml_field(input, "base_url", new_url)
-            .expect("update top-level base_url");
+            .expect("update implicit openai base_url");
 
         let parsed: toml::Value =
             toml::from_str(&output).expect("updated config should be valid TOML");
 
         let base_url = parsed
-            .get("base_url")
+            .get("openai_base_url")
             .and_then(|v| v.as_str())
-            .expect("base_url should exist");
+            .expect("openai_base_url should exist");
 
         assert_eq!(base_url, new_url);
+    }
+
+    /// selector 缺省的 Codex 接管也必须落到本地带鉴权的路由上（#7263）：
+    /// 走内置 openai 的 `openai_base_url` 改址，而不是写一个 Codex 根本不读的
+    /// 顶层 `base_url` 让请求直连 api.openai.com。
+    #[test]
+    fn codex_takeover_without_provider_selects_a_local_authenticated_route() {
+        for input in [
+            "",
+            "model = \"gpt-5\"\nbase_url = \"https://old.example/v1\"\n",
+            "model_providers = { cc-switch = { name = \"Existing\", base_url = \"https://keep.example/v1\" } }\n",
+        ] {
+            let url = "http://127.0.0.1:15721/v1";
+            let projected =
+                ProxyService::apply_codex_proxy_toml_config_for_provider(input, url, None).unwrap();
+            let auth = json!({"OPENAI_API_KEY": PROXY_TOKEN_PLACEHOLDER});
+            let live =
+                crate::codex_config::prepare_codex_provider_live_config(&auth, &projected).unwrap();
+            let doc: toml::Value = toml::from_str(&live).unwrap();
+            let id = doc["model_provider"].as_str().expect("explicit provider");
+            assert_ne!(id, "openai");
+            let table = &doc["model_providers"][id];
+            assert_eq!(table["base_url"].as_str(), Some(url));
+            assert_eq!(table["wire_api"].as_str(), Some("responses"));
+            assert_eq!(
+                table["experimental_bearer_token"].as_str(),
+                Some(PROXY_TOKEN_PLACEHOLDER)
+            );
+            if input.contains("Existing") {
+                assert_eq!(
+                    doc["model_providers"]["cc-switch"]["base_url"].as_str(),
+                    Some("https://keep.example/v1")
+                );
+            }
+            let repeated =
+                ProxyService::apply_codex_proxy_toml_config_for_provider(&live, url, None).unwrap();
+            let repeated =
+                crate::codex_config::prepare_codex_provider_live_config(&auth, &repeated).unwrap();
+            assert_eq!(
+                toml::from_str::<toml::Value>(&repeated).unwrap(),
+                doc,
+                "重复投影必须幂等"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Two upstream proxy fixes ported from the v3.20.x backlog:

1. **Honor the proxy URL when model_provider is omitted** (#7263, upstream 99f9dd2c): with no provider selector, Codex uses its built-in openai provider — takeover previously wrote the proxy address as a top-level `base_url` that Codex never reads, so requests bypassed the local proxy. The missing selector is now treated as the built-in provider and the address goes to `openai_base_url`, resolving to the same local authenticated route other takeovers use.

2. **Preserve per-app settings on shutdown and ephemeral port allocation** (#7210, upstream 11317c62): the shutdown path's legacy write-back ran a WHERE-less UPDATE that copied Claude's retry/timeout fields onto the Codex / Gemini / Grok Build rows on every exit (and never touched the flag it claimed to clear); the ephemeral-port path did the same on every proxy start. The dead write-back is dropped and the resolved port is persisted through the global-config interface, which only touches shared columns.

## Testing

- cargo fmt / clippy --all-targets / cargo test: 3867 passed, 0 failed locally, including the four ported/new regression tests (takeover round-trip on the implicit route, per-app settings surviving shutdown and ephemeral port allocation).