### PR TITLE
fix(provider): 切换提交顺序对齐 live 先行 + auth.json 残留清理收口 config-only 判据

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1140,33 +1140,30 @@ pub fn codex_live_auth_is_stale_third_party_residue(live_auth: &Value) -> bool {
         .is_some_and(|key| !key.is_empty())
 }
 
-/// After a normal switch to an official provider that carries no login
-/// material of its own, delete a live `auth.json` that only holds a stale
-/// third-party API key, so Codex shows its login screen instead of sending
-/// the wrong key to the official endpoint (401 with no way to re-login).
+/// After a normal switch whose live write was config-only (see
+/// [`codex_live_write_replaces_auth`] — a material-less official provider, or a
+/// third-party tier while the preserve toggle keeps the ChatGPT login), delete
+/// a live `auth.json` that only holds a stale third-party API key, so the file
+/// stops claiming a credential that belongs to no active tier. For official
+/// targets this also restores Codex's login screen instead of sending the
+/// wrong key to the official endpoint (401 with no way to re-login).
 ///
 /// Deleting the file — not writing `{}` — is deliberate: Codex resolves an
 /// empty object to ChatGPT mode without tokens and errors at bootstrap,
 /// while a missing file yields NotAuthenticated and the login screen,
 /// matching Codex's own logout.
 ///
-/// Callers must only invoke this after the outgoing provider was
-/// successfully backfilled into the DB — that backfill holds the only other
-/// copy of the third-party key. The switch backfill intentionally lacks the
-/// proxy-side "no credentials in the builtin official row" guard
+/// Callers must only invoke this when the live write did NOT replace
+/// auth.json (same predicate, same instant) and after the outgoing provider
+/// was successfully backfilled into the DB — that backfill holds the only
+/// other copy of the third-party key. The switch backfill intentionally lacks
+/// the proxy-side "no credentials in the builtin official row" guard
 /// (`services/proxy.rs` `sync_live_config_to_provider`): that asymmetry is
 /// what heals official API-key logins into the DB row, and this cleanup's
 /// safety depends on it — do not align the two guards.
 ///
 /// Returns Ok(true) when the file was deleted.
-pub fn clear_stale_codex_live_auth_after_official_switch(
-    db_auth: &Value,
-) -> Result<bool, AppError> {
-    if codex_auth_has_login_material(db_auth) {
-        // A material-carrying official provider gets a full auth write;
-        // nothing stale can remain.
-        return Ok(false);
-    }
+pub fn clear_stale_codex_live_auth_after_config_only_switch() -> Result<bool, AppError> {
     let auth_path = get_codex_auth_path();
     if !auth_path.exists() {
         return Ok(false);
@@ -3325,6 +3322,23 @@ pub fn strip_codex_mcp_servers_from_settings(settings: &mut Value) -> Result<(),
     Ok(())
 }
 
+/// 判定一次 Codex live 写入会不会重写 `auth.json`（auth+config 分支），
+/// 还是只动 `config.toml`、把 auth.json 原样留在盘上（config-only 分支）。
+///
+/// 唯一判据源：写入分支（[`write_codex_live_for_provider`]）与切换后的
+/// 残留清理闸（`clear_stale_codex_live_auth_after_config_only_switch` 的调用方）
+/// 回答的是同一个问题——「这次写入动没动 auth.json」——必须消费同一份答案，
+/// 各自重推一遍就是两处判据漂移的起点（官方目标的旧清理闸正是这么长出来的）。
+pub fn codex_live_write_replaces_auth(category: Option<&str>, auth: &Value) -> bool {
+    (category == Some("official") && codex_auth_has_login_material(auth))
+        || (category != Some("official")
+            && (!crate::settings::preserve_codex_official_auth_on_switch()
+                // live auth 带 ownership marker = 它是托管 Codex 账号的登录，不是用户
+                // 自己的 ChatGPT 登录缓存 ——「preserve」不适用，切走时按托管事务
+                // 语义整体替换 auth.json，随后的 clear_outgoing 才能收干净。
+                || get_codex_managed_oauth_live_auth_marker_path().exists()))
+}
+
 /// Route a Codex live write between full auth+config or config-only.
 ///
 /// Official providers with usable login material own `auth.json`. Third-party
@@ -3395,13 +3409,7 @@ pub fn write_codex_live_for_provider(
     let third_party_carries_key =
         category != Some("official") && extract_codex_auth_api_key(auth).is_some();
 
-    let should_write_auth = (category == Some("official") && codex_auth_has_login_material(auth))
-        || (category != Some("official")
-            && (!crate::settings::preserve_codex_official_auth_on_switch()
-                // live auth 带 ownership marker = 它是托管 Codex 账号的登录，不是用户
-                // 自己的 ChatGPT 登录缓存 ——「preserve」不适用，切走时按托管事务
-                // 语义整体替换 auth.json，随后的 clear_outgoing 才能收干净。
-                || get_codex_managed_oauth_live_auth_marker_path().exists()));
+    let should_write_auth = codex_live_write_replaces_auth(category, auth);
 
     if should_write_auth {
         // 第三方档把 sk 写进 auth.json 时补 requires_openai_auth（不变式见本函数

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1153,6 +1153,14 @@ pub fn codex_live_auth_is_stale_third_party_residue(live_auth: &Value) -> bool {
 /// while a missing file yields NotAuthenticated and the login screen,
 /// matching Codex's own logout.
 ///
+/// Ownership: third-party targets pass the outgoing tier's **pre-backfill
+/// stored auth** (`Some`) — residue is inert there (the active tier's key
+/// rides the bearer), so only the copy provably owned by the outgoing tier
+/// (live key == stored key) is deleted; a codex CLI API-key login or an
+/// ownerless legacy key falls under the preserve contract and stays.
+/// Official targets pass `None` — the residue would be sent to the official
+/// endpoint regardless of who owns it, so it is cleared unconditionally.
+///
 /// Callers must only invoke this when the live write did NOT replace
 /// auth.json (same predicate, same instant) and after the outgoing provider
 /// was successfully backfilled into the DB — that backfill holds the only
@@ -1163,7 +1171,9 @@ pub fn codex_live_auth_is_stale_third_party_residue(live_auth: &Value) -> bool {
 /// safety depends on it — do not align the two guards.
 ///
 /// Returns Ok(true) when the file was deleted.
-pub fn clear_stale_codex_live_auth_after_config_only_switch() -> Result<bool, AppError> {
+pub fn clear_stale_codex_live_auth_after_config_only_switch(
+    outgoing_stored_auth: Option<&Value>,
+) -> Result<bool, AppError> {
     let auth_path = get_codex_auth_path();
     if !auth_path.exists() {
         return Ok(false);
@@ -1171,6 +1181,11 @@ pub fn clear_stale_codex_live_auth_after_config_only_switch() -> Result<bool, Ap
     let live_auth: Value = read_json_file(&auth_path)?;
     if !codex_live_auth_is_stale_third_party_residue(&live_auth) {
         return Ok(false);
+    }
+    if let Some(outgoing_auth) = outgoing_stored_auth {
+        if extract_codex_auth_api_key(&live_auth) != extract_codex_auth_api_key(outgoing_auth) {
+            return Ok(false);
+        }
     }
     delete_file(&auth_path)?;
     Ok(true)

--- a/src-tauri/src/commands/relay/official.rs
+++ b/src-tauri/src/commands/relay/official.rs
@@ -41,7 +41,7 @@ pub struct RestoreOfficialLoginResult {
 /// 各不相同且都很糟：只删 `auth.json` ⇒ 仍走中转站（token 还在 `config.toml` 里）；
 /// 只切 provider ⇒ 走 ChatGPT auth 模式但没登录态 ⇒ codex 报 credentials incomplete。
 ///
-/// **2 不可省**：`ProviderService::switch` 自己那套清理（`clear_stale_codex_live_auth_after_official_switch`）
+/// **2 不可省**：`ProviderService::switch` 自己那套清理（`clear_stale_codex_live_auth_after_config_only_switch`）
 /// **有意不删带 OAuth 的 auth.json**（见 `codex_config::codex_auth_has_credential_login_material`）——
 /// 用户的 ChatGPT 登录正是它拒绝碰的那一类，所以第 4 步必须自己动手，而动手之前必须留后路。
 #[tauri::command]

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -5804,6 +5804,11 @@ impl ProviderService {
             .and_then(|current_id| providers.get(current_id))
             .and_then(Self::managed_codex_oauth_account_id);
         let mut backfill_completed = false;
+        // 旧档**回填前**的存储 auth：第三方目标的 auth.json 残留清理用它做归属
+        // 判别（live key 与旧档存储 key 相等才算「旧档的钥匙」，见
+        // clear_stale_codex_live_auth_after_config_only_switch）。不能用回填后的
+        // 行——那份 auth 来自 live，与 live auth.json 天然同源，判别恒真。
+        let mut outgoing_stored_auth: Option<Value> = None;
         if let Some(current_id) = current_id {
             if current_id != id {
                 // Additive mode apps - all providers coexist in the same file,
@@ -5812,6 +5817,8 @@ impl ProviderService {
                     // Only backfill when switching to a different provider
                     if let Ok(live_config) = read_live_settings(app_type.clone()) {
                         if let Some(mut current_provider) = providers.get(&current_id).cloned() {
+                            outgoing_stored_auth =
+                                current_provider.settings_config.get("auth").cloned();
                             // 切走前先把 live 里的可共享改动（含用户直接在应用内
                             // 装插件/加 hook/改偏好）同步进通用配置片段，再做剥离回填。
                             // 详见 sync_common_config_snippet_from_live 的文档。
@@ -5853,15 +5860,17 @@ impl ProviderService {
         // 会把「marker 在场时整体替换过 auth.json」误判成 config-only，进而把
         // 刚写入的活 key 当残留删掉（managed_codex_switch_adopts_outgoing_cli_rotation
         // 测试盯住这条）。
+        let target_codex_category = if crate::proxy::providers::is_codex_official_provider(provider)
+        {
+            // 写入路径会把这个形状归一化成 official（apply_codex_official_auth），
+            // 判据必须看到同一个 category。
+            Some("official")
+        } else {
+            provider.category.as_deref()
+        };
         let target_live_write_replaces_auth = matches!(app_type, AppType::Codex)
             && crate::codex_config::codex_live_write_replaces_auth(
-                if crate::proxy::providers::is_codex_official_provider(provider) {
-                    // 写入路径会把这个形状归一化成 official（apply_codex_official_auth），
-                    // 判据必须看到同一个 category。
-                    Some("official")
-                } else {
-                    provider.category.as_deref()
-                },
+                target_codex_category,
                 provider
                     .settings_config
                     .get("auth")
@@ -5965,7 +5974,17 @@ impl ProviderService {
             && target_managed_codex_account_id.is_none()
             && !target_live_write_replaces_auth
         {
-            match crate::codex_config::clear_stale_codex_live_auth_after_config_only_switch() {
+            // 第三方目标：residue 是惰性的（活档 key 走 bearer），只清可证明属于
+            // 旧档的副本（live key == 旧档回填前存储 key）；codex CLI API-key
+            // 登录与无主历史 key 归 preserve 契约保护，不动。official 目标传
+            // None：residue 无论归属都会被发去 official 端点，无条件清。
+            match crate::codex_config::clear_stale_codex_live_auth_after_config_only_switch(
+                if target_codex_category == Some("official") {
+                    None
+                } else {
+                    outgoing_stored_auth.as_ref()
+                },
+            ) {
                 Ok(true) => log::info!(
                     "Removed stale third-party auth.json after config-only Codex switch to '{}'",
                     provider.id

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -3976,6 +3976,153 @@ wire_api = "responses"
         });
     }
 
+    /// 第三方 Codex 档的最小合法形状：preserve 路 bearer 注入要求 config 可解析
+    /// 且带自定义 provider 表；wire_api 用 responses（chat wire 在 codex 0.149
+    /// 已移除）。
+    fn third_party_codex_provider(id: &str, api_key: &str) -> Provider {
+        let mut provider = Provider::with_id(
+            id.to_string(),
+            format!("Provider {id}"),
+            json!({
+                "auth": { "OPENAI_API_KEY": api_key },
+                "config": format!(
+                    "model_provider = \"custom\"\n\n[model_providers.custom]\nname = \"Custom\"\nbase_url = \"https://{id}.example/v1\"\nwire_api = \"responses\"\n"
+                )
+            }),
+            None,
+        );
+        provider.category = Some("custom".to_string());
+        provider
+    }
+
+    /// 非托管切换的提交纪律与托管分支对齐：live 写失败时 current 不得已经
+    /// 挪到新档（否则 UI 打 ✓ 而 CLI 还在旧档跑）。
+    #[test]
+    #[serial]
+    fn non_managed_switch_live_failure_keeps_current_unchanged() {
+        with_test_home(|state, home| {
+            crate::settings::reload_settings().expect("reload settings");
+
+            let baseline = third_party_codex_provider("baseline", "sk-baseline");
+            let target = third_party_codex_provider("target", "sk-target");
+
+            state
+                .db
+                .save_provider(AppType::Codex.as_str(), &baseline)
+                .expect("save baseline");
+            state
+                .db
+                .save_provider(AppType::Codex.as_str(), &target)
+                .expect("save target");
+
+            ProviderService::switch(state, AppType::Codex, "baseline").expect("switch to baseline");
+
+            // 基线切换已建立 ~/.codex；先拆掉再用同名文件占位，让下一次 live
+            // 写入在目录创建处失败。
+            let codex_dir = home.join(".codex");
+            fs::remove_dir_all(&codex_dir).expect("remove codex dir");
+            fs::write(&codex_dir, "not a directory").expect("block codex dir");
+
+            let result = ProviderService::switch(state, AppType::Codex, "target");
+            assert!(
+                result.is_err(),
+                "switch must fail when the live write fails"
+            );
+
+            assert_eq!(
+                crate::settings::get_current_provider(&AppType::Codex).as_deref(),
+                Some("baseline"),
+                "local settings current must stay on the previous provider"
+            );
+            assert_eq!(
+                state
+                    .db
+                    .get_current_provider(AppType::Codex.as_str())
+                    .expect("read DB current")
+                    .as_deref(),
+                Some("baseline"),
+                "DB is_current must stay on the previous provider"
+            );
+        });
+    }
+
+    /// preserve 默认开的第三方互切走 config-only 分支，auth.json 原样留在盘上
+    /// ——残留的旧档 key（无登录态形状）必须被切走后清掉，不能永久滞留。
+    #[test]
+    #[serial]
+    fn third_party_switch_cleans_stale_auth_json_residue() {
+        with_test_home(|state, _| {
+            crate::settings::reload_settings().expect("reload settings");
+
+            let baseline = third_party_codex_provider("baseline", "sk-baseline");
+            let target = third_party_codex_provider("target", "sk-target");
+
+            state
+                .db
+                .save_provider(AppType::Codex.as_str(), &baseline)
+                .expect("save baseline");
+            state
+                .db
+                .save_provider(AppType::Codex.as_str(), &target)
+                .expect("save target");
+
+            ProviderService::switch(state, AppType::Codex, "baseline").expect("switch to baseline");
+
+            // 模拟 preserve 关闭时代（或 codex CLI `login --api-key`）留下的
+            // residue 形状 auth.json：只有旧档 key、没有任何登录态。
+            write_json_file(
+                &crate::codex_config::get_codex_auth_path(),
+                &json!({ "OPENAI_API_KEY": "sk-baseline" }),
+            )
+            .expect("seed stale third-party auth.json");
+
+            ProviderService::switch(state, AppType::Codex, "target").expect("switch to target");
+
+            assert!(
+                !crate::codex_config::get_codex_auth_path().exists(),
+                "config-only switch must remove the orphaned third-party key from auth.json"
+            );
+        });
+    }
+
+    /// preserve 关闭的第三方互切走 auth+config 分支（key 写进 auth.json），
+    /// 同一清理不得误删**当前档自己的** key——闸门必须复用写入分支的判据。
+    #[test]
+    #[serial]
+    fn auth_json_switch_keeps_target_key_written_by_auth_branch() {
+        with_test_home(|state, _| {
+            crate::settings::update_settings(crate::settings::AppSettings {
+                preserve_codex_official_auth_on_switch: false,
+                ..Default::default()
+            })
+            .expect("disable preserve for this test");
+            crate::settings::reload_settings().expect("reload settings");
+
+            let baseline = third_party_codex_provider("baseline", "sk-baseline");
+            let target = third_party_codex_provider("target", "sk-target");
+
+            state
+                .db
+                .save_provider(AppType::Codex.as_str(), &baseline)
+                .expect("save baseline");
+            state
+                .db
+                .save_provider(AppType::Codex.as_str(), &target)
+                .expect("save target");
+
+            ProviderService::switch(state, AppType::Codex, "baseline").expect("switch to baseline");
+            ProviderService::switch(state, AppType::Codex, "target").expect("switch to target");
+
+            let live_auth: Value = read_json_file(&crate::codex_config::get_codex_auth_path())
+                .expect("read live auth.json");
+            assert_eq!(
+                live_auth["OPENAI_API_KEY"].as_str(),
+                Some("sk-target"),
+                "auth+config switch wrote the target's own key; the residue cleanup must not delete it"
+            );
+        });
+    }
+
     #[test]
     #[serial]
     fn import_opencode_providers_from_live_marks_provider_as_live_managed() {
@@ -5700,6 +5847,27 @@ impl ProviderService {
         }
 
         let target_managed_codex_account_id = Self::managed_codex_oauth_account_id(provider);
+
+        // 求值一次、写入与清理共用：目标档这次 live 写入会不会重写 auth.json。
+        // 必须在托管事务动手（写入后清 ownership marker）**之前**求值——事后重评
+        // 会把「marker 在场时整体替换过 auth.json」误判成 config-only，进而把
+        // 刚写入的活 key 当残留删掉（managed_codex_switch_adopts_outgoing_cli_rotation
+        // 测试盯住这条）。
+        let target_live_write_replaces_auth = matches!(app_type, AppType::Codex)
+            && crate::codex_config::codex_live_write_replaces_auth(
+                if crate::proxy::providers::is_codex_official_provider(provider) {
+                    // 写入路径会把这个形状归一化成 official（apply_codex_official_auth），
+                    // 判据必须看到同一个 category。
+                    Some("official")
+                } else {
+                    provider.category.as_deref()
+                },
+                provider
+                    .settings_config
+                    .get("auth")
+                    .unwrap_or(&serde_json::Value::Null),
+            );
+
         let outgoing_managed_codex_account_id = current_managed_codex_account_id
             .as_ref()
             .filter(|account_id| target_managed_codex_account_id.as_ref() != Some(*account_id))
@@ -5765,12 +5933,8 @@ impl ProviderService {
                 ));
             }
         } else {
-            // Additive mode apps skip setting is_current (no such concept).
-            if !app_type.is_additive_mode() {
-                crate::settings::set_current_provider(&app_type, Some(id))?;
-                state.db.set_current_provider(app_type.as_str(), id)?;
-            }
-
+            // Live 先行，与上面托管分支同一纪律：live 写失败时 current 还在旧档，
+            // UI 与 CLI 保持一致（先前 current-first 会在报错的同时把 ✓ 打到新档）。
             // Sync to live (write_gemini_live handles security flag internally for Gemini).
             Self::write_preflighted_or_current_live(
                 state,
@@ -5778,27 +5942,32 @@ impl ProviderService {
                 provider,
                 preflighted_provider.as_ref(),
             )?;
+
+            // Additive mode apps skip setting is_current (no such concept).
+            if !app_type.is_additive_mode() {
+                crate::settings::set_current_provider(&app_type, Some(id))?;
+                state.db.set_current_provider(app_type.as_str(), id)?;
+            }
         }
 
-        // A material-less official Codex provider gets a config-only live
-        // write, which can leave the previous third-party key in
-        // ~/.codex/auth.json and strand the user on a 401 with no login
-        // screen. Only clean up after a successful backfill — the DB copy
-        // made above is what keeps that key recoverable. Failures degrade to
-        // a log entry: config.toml and is_current are already committed, so
-        // failing the switch here would report a switch that in fact happened.
+        // A config-only Codex live write (material-less official, or a
+        // third-party tier while the preserve toggle keeps the ChatGPT login)
+        // leaves ~/.codex/auth.json untouched, where the previous tier's key
+        // can linger as an orphaned credential. Gate on the same
+        // single-evaluation answer the write branch used
+        // (target_live_write_replaces_auth). Only clean up after a successful
+        // backfill — the DB copy made above is what keeps that key recoverable.
+        // Failures degrade to a log entry: config.toml and is_current are
+        // already committed, so failing the switch here would report a switch
+        // that in fact happened.
         if matches!(app_type, AppType::Codex)
             && backfill_completed
-            && (provider.category.as_deref() == Some("official")
-                || crate::proxy::providers::is_codex_official_provider(provider))
             && target_managed_codex_account_id.is_none()
+            && !target_live_write_replaces_auth
         {
-            let db_auth = provider.settings_config.get("auth");
-            match crate::codex_config::clear_stale_codex_live_auth_after_official_switch(
-                db_auth.unwrap_or(&serde_json::Value::Null),
-            ) {
+            match crate::codex_config::clear_stale_codex_live_auth_after_config_only_switch() {
                 Ok(true) => log::info!(
-                    "Removed stale third-party auth.json after switching to official Codex provider '{}'",
+                    "Removed stale third-party auth.json after config-only Codex switch to '{}'",
                     provider.id
                 ),
                 Ok(false) => {}


### PR DESCRIPTION
## 背景

review 留下的两个问题（switch_normal 两种提交纪律 + auth.json 残留旧档钥匙）。

## 修复 1：非托管分支对齐 live 先行

`switch_normal` 里托管 codex 分支是「先写 live + 四文件快照回滚」，非托管分支（含 Claude/Gemini/普通 Codex）却是先提交 settings/DB current、后写 live——live 写失败时 `?` 抛错，但 current 已指向新档：**UI 打 ✓ 而 CLI 还在旧档跑**。

非托管分支改为 live 先行（additive 模式应用不受影响，本就不设 current）：

- live 写失败 → current 留在旧档，UI/CLI 一致，报错可重试；
- 与托管分支同一纪律，同函数不再两种顺序。

## 修复 2：auth.json 残留清理收口到「config-only 写入」判据

Codex 默认开启「保留官方登录」时，第三方切换走 config-only 分支（key 进 `experimental_bearer_token`），auth.json 完全不动——若其中残留旧档 `OPENAI_API_KEY`（无登录态的 residue 形状，来自 preserve 关闭时代或 `codex login --api-key`），会永久滞留：一个活配置文件长期持有不属于任何在用档位的凭据（唯源气味）。原清理 `clear_stale_codex_live_auth_after_official_switch` 只挂在 official 目标上，第三方目标这条分叉没人清。

修根而非加补丁：

- 「这次 live 写入动没动 auth.json」抽成 `codex_live_write_replaces_auth` 唯源谓词，写入分支与切换后清理闸消费同一份答案（原清理函数内的 db_auth 前置判断是同一事实的二次推导，删掉）；
- 清理从「official 目标」泛化为「config-only 写入」，official 行为不变；
- 谓词在**托管事务动 ownership marker 之前单点求值**：托管→第三方切换时写入分支在 marker 在场瞬间决策「整体替换 auth.json」，事务结束后 marker 已被清掉——事后重评会把刚写入的活 key 误判成残留删掉（`managed_codex_switch_adopts_outgoing_cli_rotation` 测试实抓过这一手）。

## 测试

- `non_managed_switch_live_failure_keeps_current_unchanged`：live 写失败（目录被文件占位）→ settings/DB current 均留在旧档；
- `third_party_switch_cleans_stale_auth_json_residue`：preserve 默认开第三方互切 → 残留 auth.json 被清；
- `auth_json_switch_keeps_target_key_written_by_auth_branch`：preserve 关第三方互切（auth+config 分支写入目标 key）→ 同一清理不误删活 key。

cargo fmt / clippy --all-targets --all-features 干净；全量 lib 测试 3845 通过。