### PR TITLE
chore(release): v6.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cc-switch",
-  "version": "6.23.0-beta.2",
+  "version": "6.23.0",
   "description": "All-in-One Assistant for Claude Code, Codex & Gemini CLI",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "cc-switch"
-version = "6.23.0-beta.2"
+version = "6.23.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3072,7 +3072,7 @@ checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "loongport-cli"
-version = "6.23.0-beta.2"
+version = "6.23.0"
 dependencies = [
  "cc-switch",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,7 +9,7 @@ members = ["cli"]
 [workspace.package]
 # 版本唯源：两个 crate 都从这里继承（`version.workspace = true`）。
 # 发版 bump 时改这一处 + package.json + tauri.conf.json。
-version = "6.23.0-beta.2"
+version = "6.23.0"
 
 [package]
 # ⚠️ crate name 保持上游的 `cc-switch`，别改 —— 118 处引用、改了收益为零

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LoongPort",
   "mainBinaryName": "LoongPort",
-  "version": "6.23.0-beta.2",
+  "version": "6.23.0",
   "identifier": "dev.loongport.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
版本号 bump 到 6.23.0（正式版：UI 改版转正 beta.1+beta.2 + beta 更新通道开关 #379 + proxy 两修 #382 + 切换提交纪律 #383）。合并后在 merge commit 打 annotated tag。