### PR TITLE
fix: port upstream v3.20.3 fixes (max_tokens clamp, SSE empty reasoning, universal-sync child metadata)

### DIFF
--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -267,7 +267,17 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                         }
 
                                         // 处理 reasoning（thinking）
-                                        if let Some(reasoning) = &choice.delta.reasoning {
+                                        // 某些上游始终填充 reasoning_content，输出正文时也带上空字符串。空值会匹配
+                                        // Some("") 进入本分支，与下方 content 分支轮流改写 current_non_tool_block_type，
+                                        // 导致单个 chunk 内 text/thinking 块被反复关闭重开，正文碎片化。
+                                        // 非流式路径 openai_to_anthropic 已对 reasoning_content 做同样的空值过滤，
+                                        // 此处与之保持一致（也与下方 content 分支的 !content.is_empty() 对称）。
+                                        if let Some(reasoning) = choice
+                                            .delta
+                                            .reasoning
+                                            .as_ref()
+                                            .filter(|r| !r.is_empty())
+                                        {
                                             if current_non_tool_block_type != Some("thinking") {
                                                 if let Some(index) = current_non_tool_block_index.take() {
                                                     let event = json!({
@@ -746,6 +756,24 @@ mod tests {
 
     fn event_type(event: &Value) -> Option<&str> {
         event.get("type").and_then(|v| v.as_str())
+    }
+
+    /// 收集某一类 content_block_delta 的文本字段并拼接，用于断言流式增量的最终内容。
+    fn collect_delta_text(events: &[Value], delta_type: &str, field: &str) -> String {
+        events
+            .iter()
+            .filter(|event| {
+                event_type(event) == Some("content_block_delta")
+                    && event.pointer("/delta/type").and_then(|v| v.as_str()) == Some(delta_type)
+            })
+            .map(|event| {
+                event
+                    .pointer(field)
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string()
+            })
+            .collect()
     }
 
     #[test]
@@ -1244,5 +1272,99 @@ mod tests {
         assert!(!events
             .iter()
             .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_stop")));
+    }
+
+    #[tokio::test]
+    async fn test_empty_reasoning_alongside_content_does_not_fragment_blocks() {
+        // 回归：某些上游输出正文时仍会填充 reasoning_content 字段（值为空字符串）。
+        // 修复前 reasoning 分支无空值保护，空字符串会进入分支并与 content 分支轮流
+        // 改写 current_non_tool_block_type，使 text/thinking 块被反复关闭重开，正文
+        // 被切成多个碎片且夹带空 thinking 块。修复后应只有一个 text 块，且不产生
+        // 任何 thinking 块。
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_frag\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{\"content\":\"某个历史\",\"reasoning_content\":\"\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_frag\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{\"content\":\"？\",\"reasoning_content\":\"\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_frag\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2}}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let events = collect_anthropic_events(input).await;
+
+        // 锁死块的 index、类型与顺序：整条流只应有一个 text 块，位于 index 0。
+        let block_starts: Vec<(Option<u64>, &str)> = events
+            .iter()
+            .filter(|event| event_type(event) == Some("content_block_start"))
+            .map(|event| {
+                (
+                    event.get("index").and_then(|v| v.as_u64()),
+                    event
+                        .pointer("/content_block/type")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            block_starts,
+            vec![(Some(0), "text")],
+            "empty reasoning_content must not open any thinking block, and all content \
+             chunks must append to a single text block"
+        );
+
+        // 不应产生任何 thinking_delta（包括空的）
+        let thinking: String = collect_delta_text(&events, "thinking_delta", "/delta/thinking");
+        assert!(
+            thinking.is_empty(),
+            "no thinking_delta should be emitted, got: {:?}",
+            thinking
+        );
+
+        // 所有 text_delta 应落在同一个块上，拼接后是完整句子
+        assert_eq!(
+            collect_delta_text(&events, "text_delta", "/delta/text"),
+            "某个历史？"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_non_empty_reasoning_still_creates_thinking_block() {
+        // 保护性测试：确保上面的修复没有误伤——真正带内容的 reasoning 仍应产出
+        // thinking 块。断言同时锁死块的 index、类型、顺序与 thinking 内容。
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_think\",\"model\":\"glm-5.1\",\"choices\":[{\"delta\":{\"reasoning_content\":\"让我想想\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_think\",\"model\":\"glm-5.1\",\"choices\":[{\"delta\":{\"content\":\"答案是 42\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_think\",\"model\":\"glm-5.1\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let events = collect_anthropic_events(input).await;
+
+        let block_starts: Vec<(Option<u64>, &str)> = events
+            .iter()
+            .filter(|event| event_type(event) == Some("content_block_start"))
+            .map(|event| {
+                (
+                    event.get("index").and_then(|v| v.as_u64()),
+                    event
+                        .pointer("/content_block/type")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            block_starts,
+            vec![(Some(0), "thinking"), (Some(1), "text")],
+            "real reasoning must yield exactly one thinking block followed by one text block"
+        );
+
+        assert_eq!(
+            collect_delta_text(&events, "thinking_delta", "/delta/thinking"),
+            "让我想想"
+        );
+        assert_eq!(
+            collect_delta_text(&events, "text_delta", "/delta/text"),
+            "答案是 42"
+        );
     }
 }

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -24,6 +24,11 @@ use super::reasoning_bridge::{
 
 pub(crate) const TOOL_RESULT_ERROR_MARKER: &str = "[cc-switch:tool-result-error]";
 
+/// OpenAI Responses API 拒绝 `max_output_tokens` 小于 16。Anthropic 侧的合法
+/// 小预算探测请求（如 Claude Desktop 的模型可用性探测发 `max_tokens=1`）
+/// 会被严格网关整体拒绝，转换时把低于下限的预算抬到最小值而不是让请求失败。
+pub(crate) const RESPONSES_MIN_MAX_OUTPUT_TOKENS: u64 = 16;
+
 fn has_http_url_scheme(value: &str) -> bool {
     value
         .get(.."http://".len())
@@ -1805,9 +1810,19 @@ pub fn anthropic_to_responses(
         result["input"] = json!(input);
     }
 
-    // max_tokens → max_output_tokens (Responses API uses max_output_tokens for all models)
+    // max_tokens → max_output_tokens (Responses API uses max_output_tokens for
+    // all models). The Responses API rejects values below 16, while Anthropic
+    // clients legitimately send tiny probe budgets (Claude Desktop's
+    // model-availability probe uses max_tokens=1), so sub-floor budgets are
+    // clamped up to the minimum instead of failing the whole request. 0 and
+    // non-integer values keep their existing pass-through semantics.
     if let Some(v) = body.get("max_tokens") {
-        result["max_output_tokens"] = v.clone();
+        result["max_output_tokens"] = match v.as_u64() {
+            Some(n) if (1..RESPONSES_MIN_MAX_OUTPUT_TOKENS).contains(&n) => {
+                json!(RESPONSES_MIN_MAX_OUTPUT_TOKENS)
+            }
+            _ => v.clone(),
+        };
     }
 
     // 直接透传的参数
@@ -5005,6 +5020,33 @@ mod tests {
         let result = anthropic_to_responses(input, None, false, false).unwrap();
 
         assert_eq!(result["max_output_tokens"], json!(1024));
+    }
+
+    #[test]
+    fn test_anthropic_to_responses_clamps_sub_floor_max_tokens() {
+        // Responses API 拒绝 max_output_tokens < 16（"The number must be >= 16"）。
+        // Claude Desktop 的模型可用性探测发 max_tokens=1，原样转发会让整个
+        // 探测请求 400，客户端因此判定"配置的模型不可用"。
+        for budget in [1u64, 8, 15] {
+            let input = json!({
+                "model": "claude-haiku-4-5",
+                "max_tokens": budget,
+                "messages": [{"role": "user", "content": "ping"}]
+            });
+            let result = anthropic_to_responses(input, None, false, false).unwrap();
+            assert_eq!(result["max_output_tokens"], json!(16));
+        }
+
+        // 下限本身与正常预算保持原样
+        for budget in [16u64, 1024] {
+            let input = json!({
+                "model": "claude-haiku-4-5",
+                "max_tokens": budget,
+                "messages": [{"role": "user", "content": "ping"}]
+            });
+            let result = anthropic_to_responses(input, None, false, false).unwrap();
+            assert_eq!(result["max_output_tokens"], json!(budget));
+        }
     }
 
     // ==================== 第二轮：P0 + P1 字段对齐 ====================

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -4533,6 +4533,100 @@ wire_api = "responses"
             );
         });
     }
+
+    /// 统一供应商同步不得清空子供应商的应用专属配置（用量脚本/通用配置开关/
+    /// 端点自动选择等）与排序/创建时间——那些字段不归统一供应商管（#7134）。
+    #[test]
+    #[serial]
+    fn sync_universal_to_apps_preserves_child_metadata() {
+        with_test_home(|state, _home| {
+            let mut universal = UniversalProvider::new(
+                "metadata".into(),
+                "Original".into(),
+                "custom".into(),
+                "https://old.example".into(),
+                "old-key".into(),
+            );
+            universal.apps.claude = true;
+            universal.apps.codex = true;
+            universal.apps.gemini = true;
+            universal.meta = Some(
+                serde_json::from_value(json!({
+                    "usage_script": {"enabled": false, "language": "javascript", "code": "parent"}
+                }))
+                .unwrap(),
+            );
+            state.db.save_universal_provider(&universal).unwrap();
+            ProviderService::sync_universal_to_apps(state, &universal.id).unwrap();
+
+            let mut expected = Vec::new();
+            for (index, app) in ["claude", "codex", "gemini"].iter().enumerate() {
+                let id = format!("universal-{app}-metadata");
+                let mut child = state.db.get_provider_by_id(&id, app).unwrap().unwrap();
+                child.meta = Some(
+                    serde_json::from_value(json!({
+                        "usage_script": {"enabled": true, "language": "javascript", "code": app,
+                            "apiKey": "usage-only-key", "autoQueryInterval": 15},
+                        "commonConfigEnabled": false,
+                        "endpointAutoSelect": true
+                    }))
+                    .unwrap(),
+                );
+                child.created_at = Some(123 + index as i64);
+                child.sort_index = Some(10 + index);
+                child.settings_config["local_setting"] = json!(app);
+                state.db.save_provider(app, &child).unwrap();
+                state
+                    .db
+                    .add_custom_endpoint(app, &id, "https://extra.example")
+                    .unwrap();
+                expected.push(child);
+            }
+
+            universal.name = "Updated".into();
+            universal.base_url = "https://new.example".into();
+            universal.api_key = "new-key".into();
+            universal.notes = Some("shared note".into());
+            universal.models = serde_json::from_value(json!({
+                "claude": {"model": "claude-new"},
+                "codex": {"model": "codex-new", "reasoningEffort": "low"},
+                "gemini": {"model": "gemini-new"}
+            }))
+            .unwrap();
+            // 父级 meta 无论缺省还是存在，都不得覆盖子供应商的应用专属配置。
+            for parent_meta in [None, universal.meta.clone()] {
+                universal.meta = parent_meta;
+                state.db.save_universal_provider(&universal).unwrap();
+                ProviderService::sync_universal_to_apps(state, &universal.id).unwrap();
+                for (app, before) in ["claude", "codex", "gemini"].iter().zip(&expected) {
+                    let after = state
+                        .db
+                        .get_provider_by_id(&before.id, app)
+                        .unwrap()
+                        .unwrap();
+                    assert_eq!(
+                        serde_json::to_value(&after.meta).unwrap(),
+                        serde_json::to_value(&before.meta).unwrap(),
+                        "{app}"
+                    );
+                    assert_eq!(after.created_at, before.created_at, "{app}");
+                    assert_eq!(after.sort_index, before.sort_index, "{app}");
+                    assert_eq!(after.name, "Updated");
+                    assert_eq!(after.notes.as_deref(), Some("shared note"));
+                    assert_eq!(after.settings_config["local_setting"], json!(app));
+                    assert_eq!(
+                        state.db.get_all_providers(app).unwrap()[&before.id]
+                            .meta
+                            .as_ref()
+                            .unwrap()
+                            .custom_endpoints
+                            .len(),
+                        1
+                    );
+                }
+            }
+        });
+    }
 }
 
 impl ProviderService {
@@ -7570,6 +7664,10 @@ impl ProviderService {
                 let mut merged = existing.settings_config.clone();
                 Self::merge_json(&mut merged, &claude_provider.settings_config);
                 claude_provider.settings_config = merged;
+                // 已有子供应商的应用专属配置与排序不属于统一供应商管理的字段。
+                claude_provider.meta = existing.meta;
+                claude_provider.created_at = existing.created_at;
+                claude_provider.sort_index = existing.sort_index;
             }
             state.db.save_provider("claude", &claude_provider)?;
         } else {
@@ -7589,6 +7687,10 @@ impl ProviderService {
                 let mut merged = existing.settings_config.clone();
                 Self::merge_json(&mut merged, &codex_provider.settings_config);
                 codex_provider.settings_config = merged;
+                // 已有子供应商的应用专属配置与排序不属于统一供应商管理的字段。
+                codex_provider.meta = existing.meta;
+                codex_provider.created_at = existing.created_at;
+                codex_provider.sort_index = existing.sort_index;
             }
             state.db.save_provider("codex", &codex_provider)?;
         } else {
@@ -7607,6 +7709,10 @@ impl ProviderService {
                 let mut merged = existing.settings_config.clone();
                 Self::merge_json(&mut merged, &gemini_provider.settings_config);
                 gemini_provider.settings_config = merged;
+                // 已有子供应商的应用专属配置与排序不属于统一供应商管理的字段。
+                gemini_provider.meta = existing.meta;
+                gemini_provider.created_at = existing.created_at;
+                gemini_provider.sort_index = existing.sort_index;
             }
             state.db.save_provider("gemini", &gemini_provider)?;
         } else {


### PR DESCRIPTION
## Summary

Three fixes ported from upstream v3.20.3:

1. **Clamp sub-floor max_tokens to the Responses API minimum** (upstream #7287): the Responses API rejects `max_output_tokens < 16` while Anthropic clients legitimately send tiny probe budgets (Claude Desktop's availability probe sends `max_tokens=1`); strict upstreams 400'd the whole probe and the model showed as unavailable. Values 1..=15 are clamped up to 16 during conversion.
2. **Skip empty reasoning_content placeholders in Anthropic SSE streaming** (upstream #7227): upstreams that keep `reasoning_content: ""` in every chunk fragmented output into 2N blocks (empty Thought blocks between every text fragment). Empty reasoning is now filtered before the branch, mirroring the content branch's guard.
3. **Preserve child metadata during universal sync** (upstream #7212): re-syncing a universal provider wiped each child's usage script / common-config opt-out / endpoint auto-select and reset its sort index (card jumped to the bottom as if recreated). The existing child's `meta` / `created_at` / `sort_index` are now kept.

## Testing

- cargo fmt / clippy --all-targets / cargo test: 3874 passed, 0 failed locally, including the four ported regression tests.