### PR TITLE
feat(crowd): token reconcile triples in model buckets (1/3)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -577,6 +577,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +794,7 @@ dependencies = [
  "tauri-plugin-window-state",
  "tempfile",
  "thiserror 2.0.20",
+ "tiktoken-rs",
  "tokio",
  "tokio-rustls",
  "toml 1.1.4+spec-1.1.0",
@@ -1603,6 +1615,17 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fastrand"
@@ -2928,6 +2951,12 @@ dependencies = [
  "indexmap 2.14.0",
  "selectors 0.24.0",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -6215,6 +6244,21 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "tiktoken-rs"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "027853bbf8c7763b77c5c595f1c271c7d536ced7d6f83452911b944621e57fc2"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bstr",
+ "fancy-regex",
+ "lazy_static",
+ "regex",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -145,6 +145,7 @@ json5 = "1.3"
 json-five = "0.3.1"
 sys-locale = "0.3"
 psl = "2.1.229"
+tiktoken-rs = "0.12.0"
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))'.dependencies]
 tauri-plugin-single-instance = { version = "2", optional = true }

--- a/src-tauri/src/crowd/bucket.rs
+++ b/src-tauri/src/crowd/bucket.rs
@@ -55,6 +55,16 @@ const SITE_SIDE_ERROR_EXPR: &str = "(l.status_code < 200 OR l.status_code >= 400
 ///   必须先过「口径与代理观测一致」的审视，而不是静默混进同一张直方图。
 const PROXY_OBSERVED_EXPR: &str = "l.data_source = 'proxy'";
 
+/// crowd 计数对账的配对资格（宁缺毋认从采集口径开始）。首条与
+/// [`PROXY_OBSERVED_EXPR`] 同判据但**自包含**——format! 参数不会嵌套展开
+/// 占位符，引用别的常量字面量会把 `{}` 残留进 SQL：本机代理亲历的成功
+/// 交互，且本地计数与上游回显计数**都**为正 —— 任何一侧缺失就不进对账样本
+/// （`local_input_tokens` 的 0 即「未采」，错误行天然出局）。判定不在客户端：
+/// 桶只带三元组事实，比值/跳变/样本门槛全在服务端。
+const TOKEN_PAIR_EXPR: &str = "l.data_source = 'proxy' \
+     AND l.status_code >= 200 AND l.status_code < 400 \
+     AND l.local_input_tokens > 0 AND l.input_tokens > 0";
+
 /// 一个待上传的小时聚合桶。字段集合就是上传载荷的字段集合 ——
 /// 加字段前先回模块文档那张「传/不传」的表过一遍。
 #[derive(Debug, Clone, PartialEq)]
@@ -112,6 +122,12 @@ pub struct ModelBucket {
     /// `crowd::events::record_model_anomaly`）。恒 ≤ `samples`（异常响应
     /// 必然是被计数的请求之一）。
     pub anomalies: i64,
+    /// 计数对账三元组（配对口径见 [`TOKEN_PAIR_EXPR`]）：本地计数的和、
+    /// 上游回显 input 计数的和、配对行数。比值 = local_sum / remote_sum，
+    /// 服务端按「同站同模型」窗口看稳定性，样本不足不结论。
+    pub tok_local_sum: i64,
+    pub tok_remote_sum: i64,
+    pub tok_pair_count: i64,
 }
 
 /// SQL 切出的 provider 维度桶（站点归属尚未解析）。
@@ -149,6 +165,9 @@ struct RawModelBucket {
     cache_read_tokens: i64,
     cache_creation_tokens: i64,
     cost_usd_micros: i64,
+    tok_local_sum: i64,
+    tok_remote_sum: i64,
+    tok_pair_count: i64,
 }
 
 /// 查询并切桶（provider 维度）。`after_epoch`（不含）到 `before_epoch`（含）限定行窗口；
@@ -233,11 +252,15 @@ fn query_raw_model_buckets(
                 {tps_exprs}, \
                 SUM({fresh_input}), \
                 SUM(l.output_tokens), SUM(l.cache_read_tokens), SUM(l.cache_creation_tokens), \
-                CAST(ROUND(SUM(CAST(l.total_cost_usd AS REAL)) * 1000000.0) AS INTEGER) \
+                CAST(ROUND(SUM(CAST(l.total_cost_usd AS REAL)) * 1000000.0) AS INTEGER), \
+                SUM(CASE WHEN {token_pair} THEN l.local_input_tokens ELSE 0 END), \
+                SUM(CASE WHEN {token_pair} THEN l.input_tokens ELSE 0 END), \
+                SUM(CASE WHEN {token_pair} THEN 1 ELSE 0 END) \
          FROM proxy_request_logs l \
          WHERE l.created_at > ?1 AND l.created_at <= ?2 \
          GROUP BY hour_epoch, l.provider_id, l.app_type, l.model",
         fresh_input = fresh_input_sql("l"),
+        token_pair = TOKEN_PAIR_EXPR,
         site_side_error = SITE_SIDE_ERROR_EXPR,
         proxy_observed = PROXY_OBSERVED_EXPR,
     );
@@ -252,15 +275,19 @@ fn query_raw_model_buckets(
 
     let mut raws = Vec::new();
     while let Some(row) = rows.next().map_err(|e| AppError::Database(e.to_string()))? {
+        // 列起点 = 7：hour/provider/app/model/COUNT/errors/err_samples 之后才是
+        // ttft 直方图（顶层桶没有 model 列所以从 6 起——两处的起点不同，历史
+        // 上这里跟着顶层写成 6，模型桶所有列错位一格：err_samples 被当 ttft[0]、
+        // fresh 被当 output……随三元组测试一并修根。
         let mut ttft_bins = Vec::with_capacity(TTFT_BIN_COUNT);
         for i in 0..TTFT_BIN_COUNT {
-            ttft_bins.push(row.get::<_, i64>(6 + i)?);
+            ttft_bins.push(row.get::<_, i64>(7 + i)?);
         }
         let mut tps_bins = Vec::with_capacity(TPS_BIN_COUNT);
         for i in 0..TPS_BIN_COUNT {
-            tps_bins.push(row.get::<_, i64>(6 + TTFT_BIN_COUNT + i)?);
+            tps_bins.push(row.get::<_, i64>(7 + TTFT_BIN_COUNT + i)?);
         }
-        let base = 6 + TTFT_BIN_COUNT + TPS_BIN_COUNT;
+        let base = 7 + TTFT_BIN_COUNT + TPS_BIN_COUNT;
         raws.push(RawModelBucket {
             hour_epoch: row.get(0)?,
             provider_id: row.get(1)?,
@@ -276,6 +303,9 @@ fn query_raw_model_buckets(
             cache_read_tokens: row.get(base + 2)?,
             cache_creation_tokens: row.get(base + 3)?,
             cost_usd_micros: row.get(base + 4)?,
+            tok_local_sum: row.get(base + 5)?,
+            tok_remote_sum: row.get(base + 6)?,
+            tok_pair_count: row.get(base + 7)?,
         });
     }
     Ok(raws)
@@ -418,6 +448,9 @@ fn merge_by_site(
             cache_creation_tokens: 0,
             cost_usd_micros: 0,
             anomalies: 0,
+            tok_local_sum: 0,
+            tok_remote_sum: 0,
+            tok_pair_count: 0,
         });
         entry.samples += raw.samples;
         entry.errors += raw.errors;
@@ -433,6 +466,9 @@ fn merge_by_site(
         entry.cache_read_tokens += raw.cache_read_tokens;
         entry.cache_creation_tokens += raw.cache_creation_tokens;
         entry.cost_usd_micros += raw.cost_usd_micros;
+        entry.tok_local_sum += raw.tok_local_sum;
+        entry.tok_remote_sum += raw.tok_remote_sum;
+        entry.tok_pair_count += raw.tok_pair_count;
     }
     for ((hour_epoch, site, app, _), model_bucket) in models {
         if let Some(hour_bucket) = merged.get_mut(&(hour_epoch, site.clone(), app.clone())) {
@@ -567,6 +603,40 @@ mod tests {
         // `Database::memory()` 已按生产 schema 建齐全部表 —— 这里不再自建
         // （自建会撞「table already exists」，且形状迟早与生产漂移）。
         Database::memory().expect("内存库")
+    }
+
+    /// 计数对账三元组的采集口径：只收「proxy 亲历 + 2xx/3xx + 两侧计数都为正」
+    /// 的行 —— 错误行、session 回填、未采（local=0）与无回显（remote=0）全部
+    /// 出局，比值分母不被污染（宁缺毋认从采集端开始）。
+    #[test]
+    fn token_pair_triples_only_admit_fully_observed_success_rows() {
+        let db = setup_db();
+        {
+            let conn = db.conn.lock().unwrap();
+            let seed = |id: &str, status: i64, source: &str, local: i64, remote: i64| {
+                conn.execute(
+                    "INSERT INTO proxy_request_logs (
+                        request_id, provider_id, app_type, model, status_code,
+                        input_tokens, local_input_tokens, latency_ms, created_at, data_source
+                     ) VALUES (?1, 'p', 'codex', 'gpt-6', ?2, ?3, ?4, 0, 1000, ?5)",
+                    params![id, status, remote, local, source],
+                )
+                .unwrap();
+            };
+            seed("ok-1", 200, "proxy", 110, 100);
+            seed("ok-2", 302, "proxy", 230, 200); // 3xx 也是成功交互
+            seed("err", 500, "proxy", 999, 900); // 失败行出局
+            seed("session", 200, "session_log", 50, 50); // 非代理观测出局
+            seed("unlocal", 200, "proxy", 0, 100); // 本地未采出局
+            seed("unremote", 200, "proxy", 80, 0); // 上游未回显出局
+        }
+        let raws = query_raw_model_buckets(&db, 0, 2000).expect("切桶");
+        assert_eq!(raws.len(), 1);
+        let m = &raws[0];
+        assert_eq!(m.model, "gpt-6");
+        assert_eq!(m.tok_local_sum, 110 + 230);
+        assert_eq!(m.tok_remote_sum, 100 + 200);
+        assert_eq!(m.tok_pair_count, 2);
     }
 
     #[allow(clippy::too_many_arguments)] // 测试播种器：一列一参，比构造器结构直白

--- a/src-tauri/src/crowd/uploader.rs
+++ b/src-tauri/src/crowd/uploader.rs
@@ -88,6 +88,11 @@ pub(crate) struct ModelBucketPayload<'a> {
     /// P5：被动观察到的模型真伪异常次数（Anomaly 级，v2 追加，旧服务端
     /// 忽略未知字段向后兼容）。
     pub anomalies: i64,
+    /// 计数对账三元组（v2 追加，向后兼容同上）：本地计数和、上游回显 input
+    /// 计数和、配对行数。判定（比值稳定性/样本门槛）全在服务端。
+    pub tok_local_sum: i64,
+    pub tok_remote_sum: i64,
+    pub tok_pair_count: i64,
 }
 
 fn payload_from_bucket<'a>(source_id: &'a str, buckets: &'a [HourBucket]) -> IngestPayload<'a> {
@@ -127,6 +132,9 @@ fn payload_from_bucket<'a>(source_id: &'a str, buckets: &'a [HourBucket]) -> Ing
                         cache_creation_tokens: m.cache_creation_tokens,
                         cost_usd_micros: m.cost_usd_micros,
                         anomalies: m.anomalies,
+                        tok_local_sum: m.tok_local_sum,
+                        tok_remote_sum: m.tok_remote_sum,
+                        tok_pair_count: m.tok_pair_count,
                     })
                     .collect(),
             })
@@ -278,6 +286,9 @@ mod tests {
                 cache_creation_tokens: 100,
                 cost_usd_micros: 12_345,
                 anomalies: 2,
+                tok_local_sum: 0,
+                tok_remote_sum: 0,
+                tok_pair_count: 0,
             }],
         }
     }
@@ -360,6 +371,9 @@ mod tests {
                 "model",
                 "outputTokens",
                 "samples",
+                "tokLocalSum",
+                "tokPairCount",
+                "tokRemoteSum",
                 "tpsBins",
                 "ttftBins",
             ],

--- a/src-tauri/src/database/loongport_schema.rs
+++ b/src-tauri/src/database/loongport_schema.rs
@@ -48,7 +48,7 @@ use crate::error::AppError;
 /// LoongPort 自己的 schema 版本。加迁移时 +1。
 ///
 /// **与 `SCHEMA_VERSION`（上游那个）无关**，两者各自独立计数。
-pub(crate) const LOONGPORT_SCHEMA_VERSION: i32 = 21;
+pub(crate) const LOONGPORT_SCHEMA_VERSION: i32 = 22;
 
 /// 存版本号的表。**只有一行**（`id = 1`）。
 ///
@@ -317,6 +317,23 @@ pub(crate) fn apply(conn: &Connection) -> Result<(), AppError> {
                     crate::relay::model_catalog::seed_legacy_inventories(conn)?;
                 }
                 set_version(conn, 21)?;
+            }
+            21 => {
+                log::info!("LoongPort 数据迁移 v21 → v22（请求日志添加本地 token 计数）");
+                // crowd 计数对账的采集列（0 = 未采）。新库已由 create_tables
+                // 建成最终形态，这里只服务已存在的库；幂等加列。
+                if table_exists(conn, "proxy_request_logs")?
+                    && !column_exists(conn, "proxy_request_logs", "local_input_tokens")?
+                {
+                    conn.execute(
+                        "ALTER TABLE proxy_request_logs ADD COLUMN local_input_tokens INTEGER NOT NULL DEFAULT 0",
+                        [],
+                    )
+                    .map_err(|error| {
+                        AppError::Database(format!("加 local_input_tokens 列失败: {error}"))
+                    })?;
+                }
+                set_version(conn, 22)?;
             }
             other => {
                 return Err(AppError::Database(format!(

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -206,7 +206,7 @@ impl Database {
             pricing_model TEXT,
             input_tokens INTEGER NOT NULL DEFAULT 0, output_tokens INTEGER NOT NULL DEFAULT 0,
             cache_read_tokens INTEGER NOT NULL DEFAULT 0, cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
-            input_token_semantics INTEGER NOT NULL DEFAULT 0,
+            input_token_semantics INTEGER NOT NULL DEFAULT 0, local_input_tokens INTEGER NOT NULL DEFAULT 0,
             input_cost_usd TEXT NOT NULL DEFAULT '0', output_cost_usd TEXT NOT NULL DEFAULT '0',
             cache_read_cost_usd TEXT NOT NULL DEFAULT '0', cache_creation_cost_usd TEXT NOT NULL DEFAULT '0',
             total_cost_usd TEXT NOT NULL DEFAULT '0', latency_ms INTEGER NOT NULL, first_token_ms INTEGER,

--- a/src-tauri/src/proxy/handler_context.rs
+++ b/src-tauri/src/proxy/handler_context.rs
@@ -78,6 +78,10 @@ pub struct RequestContext {
     pub session_id: String,
     /// Session ID 是否由客户端提供。生成的 UUID 不能作为上游缓存 key，否则每个请求都会换 key。
     pub session_client_provided: bool,
+    /// 请求体的本地 token 计数（口径见 [`crate::proxy::local_tokens`]，0 = 未采）。
+    /// crowd 计数对账的采集事实：与上游回显的 `usage.input_tokens` 在桶里配对，
+    /// 判定在服务端。
+    pub local_input_tokens: u64,
     /// 整流器配置
     pub rectifier_config: RectifierConfig,
     /// 优化器配置
@@ -138,6 +142,10 @@ impl RequestContext {
             .unwrap_or("unknown")
             .to_string();
 
+        // 请求体本地 token 计数（crowd 对账事实，0 = 未采）。构造点手上
+        // 有完整 body，是整条链路里唯一无痛的 tokenize 挂点；落库点从这里取。
+        let local_input_tokens = crate::proxy::local_tokens::count_request_tokens(body);
+
         // 提取 Session ID
         let session_result = extract_session_id(headers, body, app_type_str);
         let session_id = session_result.session_id.clone();
@@ -193,6 +201,7 @@ impl RequestContext {
             app_type,
             session_id,
             session_client_provided: session_result.client_provided,
+            local_input_tokens,
             rectifier_config,
             optimizer_config,
             copilot_optimizer_config,

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -309,6 +309,7 @@ struct ClaudeUsageLog {
     latency_ms: u64,
     status_code: u16,
     is_streaming: bool,
+    local_input_tokens: u64,
 }
 
 fn prepare_claude_usage_log(
@@ -338,6 +339,7 @@ fn prepare_claude_usage_log(
         app_type: ctx.app_type_str,
         provider_id: ctx.provider.id.clone(),
         session_id: ctx.session_id.clone(),
+        local_input_tokens: ctx.local_input_tokens,
         usage,
         latency_ms: ctx.latency_ms(),
         status_code,
@@ -359,6 +361,7 @@ async fn write_claude_usage_log(state: &ProxyState, log: ClaudeUsageLog) {
         log.is_streaming,
         log.status_code,
         Some(log.session_id),
+        log.local_input_tokens,
     )
     .await;
 }
@@ -469,6 +472,7 @@ async fn handle_claude_transform(
             // "claude" 会把 claude-desktop 的行错记到 claude 名下
             let app_type_str = ctx.app_type_str;
 
+            let local_input_tokens = ctx.local_input_tokens;
             Some(SseUsageCollector::new(
                 start_time,
                 Some(claude_stream_usage_event_filter),
@@ -500,6 +504,7 @@ async fn handle_claude_transform(
                                 true,
                                 status_code,
                                 Some(session_id),
+                                local_input_tokens,
                             )
                             .await;
                         });
@@ -1260,6 +1265,7 @@ async fn handle_codex_responses_namespace_restore(
                     let provider_id = ctx.provider.id.clone();
                     let session_id = ctx.session_id.clone();
                     let latency_ms = ctx.latency_ms();
+                    let local_input_tokens = ctx.local_input_tokens;
                     async move {
                         log_usage(
                             &state,
@@ -1274,6 +1280,7 @@ async fn handle_codex_responses_namespace_restore(
                             false,
                             status.as_u16(),
                             Some(session_id),
+                            local_input_tokens,
                         )
                         .await;
                     }
@@ -1344,6 +1351,7 @@ async fn handle_codex_chat_to_responses_transform(
             let start_time = ctx.attempt_started_at;
             let session_id = ctx.session_id.clone();
 
+            let local_input_tokens = ctx.local_input_tokens;
             Some(SseUsageCollector::new(
                 start_time,
                 Some(codex_stream_usage_event_filter),
@@ -1386,6 +1394,7 @@ async fn handle_codex_chat_to_responses_transform(
                             true,
                             status.as_u16(),
                             Some(session_id),
+                            local_input_tokens,
                         )
                         .await;
                     });
@@ -1494,6 +1503,7 @@ async fn handle_codex_chat_to_responses_transform(
             let provider_id = ctx.provider.id.clone();
             let session_id = ctx.session_id.clone();
             let latency_ms = ctx.latency_ms();
+            let local_input_tokens = ctx.local_input_tokens;
             async move {
                 log_usage(
                     &state,
@@ -1508,6 +1518,7 @@ async fn handle_codex_chat_to_responses_transform(
                     false,
                     status.as_u16(),
                     Some(session_id),
+                    local_input_tokens,
                 )
                 .await;
             }
@@ -1658,6 +1669,7 @@ async fn handle_codex_anthropic_to_responses_transform(
             let provider_id = ctx.provider.id.clone();
             let session_id = ctx.session_id.clone();
             let latency_ms = ctx.latency_ms();
+            let local_input_tokens = ctx.local_input_tokens;
             async move {
                 log_usage(
                     &state,
@@ -1672,6 +1684,7 @@ async fn handle_codex_anthropic_to_responses_transform(
                     false,
                     status.as_u16(),
                     Some(session_id),
+                    local_input_tokens,
                 )
                 .await;
             }
@@ -1723,6 +1736,7 @@ fn build_codex_anthropic_sse_response(
         let start_time = ctx.attempt_started_at;
         let session_id = ctx.session_id.clone();
 
+        let local_input_tokens = ctx.local_input_tokens;
         Some(SseUsageCollector::new(
             start_time,
             Some(codex_stream_usage_event_filter),
@@ -1759,6 +1773,7 @@ fn build_codex_anthropic_sse_response(
                         true,
                         status.as_u16(),
                         Some(session_id),
+                        local_input_tokens,
                     )
                     .await;
                 });
@@ -2798,6 +2813,7 @@ async fn log_usage(
     is_streaming: bool,
     status_code: u16,
     session_id: Option<String>,
+    local_input_tokens: u64,
 ) {
     use super::usage::logger::UsageLogger;
 
@@ -2833,6 +2849,7 @@ async fn log_usage(
         session_id,
         None, // provider_type
         is_streaming,
+        local_input_tokens,
     ) {
         log::warn!("[USG-001] 记录使用量失败: {e}");
     }

--- a/src-tauri/src/proxy/local_tokens.rs
+++ b/src-tauri/src/proxy/local_tokens.rs
@@ -1,0 +1,69 @@
+//! 请求体本地 token 计数（crowd 对账的采集原语）。
+//!
+//! 用途：与上游响应 `usage.input_tokens` 对账，众测「同站同模型的计数口径
+//! 比值是否跳变」（站点换模型家族时，远端口径变、本地口径不变 ⇒ 比值跳）。
+//! **判据不在客户端**：这里只产出事实（一个 u64），聚合与判定在服务端
+//! （宁缺毋认：样本不足就不出结论，见 crowd 模块文档）。
+//!
+//! 口径取舍：**对整个请求体 JSON 的紧凑序列化计数**，不解析 messages 结构。
+//! 判据只依赖「同一把尺子量所有请求」的口径恒定，不依赖与上游计费口径
+//! 对齐——JSON 结构开销（键名、转义）在同 app 同模型下是常数偏移，不影响
+//! 比值稳定性判据；解析 messages 反而引入各家族格式分支。
+
+use std::sync::OnceLock;
+
+/// o200k 分词器进程级单例：首次构造要加载 BPE 表（几十毫秒），
+/// 之后每次调用纯 CPU（百 KB 文本毫秒级），代理热路径可承受。
+/// 存 `Option`：初始化失败时固化「停用」，失败行返回 0（未采语义）。
+static TOKENIZER: OnceLock<Option<tiktoken_rs::CoreBPE>> = OnceLock::new();
+
+fn tokenizer() -> Option<&'static tiktoken_rs::CoreBPE> {
+    TOKENIZER
+        .get_or_init(|| {
+            tiktoken_rs::o200k_base()
+                .map_err(|e| {
+                    log::warn!("[crowd-tokens] o200k 分词器初始化失败，本地计数停用: {e}");
+                    e
+                })
+                .ok()
+        })
+        .as_ref()
+}
+
+/// 数请求体的本地 token 数。任何失败（序列化/分词器不可用/文本非法）返回 0
+/// —— 0 语义即「未采」，桶 SQL 的配对条件以 `> 0` 收口，失败行天然出局，
+/// 不会以假数据参与对账。
+pub fn count_request_tokens(body: &serde_json::Value) -> u64 {
+    let Some(bpe) = tokenizer() else {
+        return 0;
+    };
+    // `&Value` 的序列化对合法 JSON 不失败；失败返回 0（未采语义）。
+    let Ok(compact) = serde_json::to_string(body) else {
+        return 0;
+    };
+    bpe.encode_ordinary(&compact).len() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::count_request_tokens;
+    use serde_json::json;
+
+    #[test]
+    fn counts_grow_with_input() {
+        let small = count_request_tokens(&json!({"model": "gpt-6", "input": "hi"}));
+        let large = count_request_tokens(&json!({
+            "model": "gpt-6",
+            "input": "这是一段长得多的请求内容，token 数必须显著大于短请求。".repeat(50)
+        }));
+        assert!(small > 0, "合法请求必须产出正计数");
+        assert!(large > small * 10, "长文本计数应显著大于短文本");
+    }
+
+    #[test]
+    fn same_body_is_deterministic() {
+        // 口径恒定是对账判据的前提：同一 body 两次计数必须一致。
+        let body = json!({"model": "claude-5", "messages": [{"role": "user", "content": "ping"}]});
+        assert_eq!(count_request_tokens(&body), count_request_tokens(&body));
+    }
+}

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -23,6 +23,7 @@ mod handlers;
 pub mod http_client;
 pub mod hyper_client;
 pub(crate) mod json_canonical;
+pub mod local_tokens;
 pub mod log_codes;
 pub mod media_sanitizer;
 pub mod model_mapper;

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -493,6 +493,7 @@ pub(crate) fn create_usage_collector(
     let state = state.clone();
     let provider_id = ctx.provider.id.clone();
     let request_model = ctx.request_model.clone();
+    let local_input_tokens = ctx.local_input_tokens;
     // 流式事件缺失模型名时的归因兜底：映射后的出站模型（路由接管真值）优先，
     // 其次才是客户端请求别名
     let fallback_model = ctx
@@ -537,6 +538,7 @@ pub(crate) fn create_usage_collector(
                         true, // is_streaming
                         status_code,
                         Some(session_id),
+                        local_input_tokens,
                     )
                     .await;
                 });
@@ -563,6 +565,7 @@ pub(crate) fn create_usage_collector(
                         true, // is_streaming
                         status_code,
                         Some(session_id),
+                        local_input_tokens,
                     )
                     .await;
                 });
@@ -601,6 +604,7 @@ fn spawn_log_usage(
         .unwrap_or_else(|| ctx.request_model.clone());
     let latency_ms = ctx.latency_ms();
     let session_id = ctx.session_id.clone();
+    let local_input_tokens = ctx.local_input_tokens;
 
     tokio::spawn(async move {
         log_usage_internal(
@@ -616,6 +620,7 @@ fn spawn_log_usage(
             is_streaming,
             status_code,
             Some(session_id),
+            local_input_tokens,
         )
         .await;
     });
@@ -649,6 +654,7 @@ async fn log_usage_internal(
     is_streaming: bool,
     status_code: u16,
     session_id: Option<String>,
+    local_input_tokens: u64,
 ) {
     use super::usage::logger::UsageLogger;
 
@@ -688,6 +694,7 @@ async fn log_usage_internal(
         session_id,
         None, // provider_type
         is_streaming,
+        local_input_tokens,
     ) {
         log::warn!("[USG-001] 记录使用量失败: {e}");
     }
@@ -1175,6 +1182,7 @@ mod tests {
             false,
             200,
             None,
+            0,
         )
         .await;
 
@@ -1245,6 +1253,7 @@ mod tests {
             false,
             200,
             None,
+            0,
         )
         .await;
 
@@ -1325,6 +1334,7 @@ mod tests {
             false,
             200,
             None,
+            0,
         )
         .await;
 

--- a/src-tauri/src/proxy/usage/logger.rs
+++ b/src-tauri/src/proxy/usage/logger.rs
@@ -85,6 +85,9 @@ pub struct RequestLog {
     pub is_streaming: bool,
     /// 成本倍数
     pub cost_multiplier: String,
+    /// 请求体本地 token 计数（crowd 对账事实，0 = 未采；口径见
+    /// [`crate::proxy::local_tokens`]）。错误行为 0。
+    pub local_input_tokens: u64,
 }
 
 /// 使用量记录器
@@ -170,11 +173,11 @@ impl<'a> UsageLogger<'a> {
             "{insert_verb} INTO proxy_request_logs (
                 request_id, provider_id, app_type, model, request_model, pricing_model,
                 input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
-                input_token_semantics,
+                input_token_semantics, local_input_tokens,
                 input_cost_usd, output_cost_usd, cache_read_cost_usd, cache_creation_cost_usd, total_cost_usd,
                 latency_ms, first_token_ms, status_code, error_message, session_id,
                 provider_type, is_streaming, cost_multiplier, created_at
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25)"
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26)"
         );
         let affected_rows = conn
             .execute(
@@ -191,6 +194,7 @@ impl<'a> UsageLogger<'a> {
                     log.usage.cache_read_tokens,
                     log.usage.cache_creation_tokens,
                     input_token_semantics,
+                    log.local_input_tokens as i64,
                     input_cost,
                     output_cost,
                     cache_read_cost,
@@ -286,6 +290,8 @@ impl<'a> UsageLogger<'a> {
             provider_type: None,
             is_streaming: false,
             cost_multiplier: "1.0".to_string(),
+            // 错误行没有 usage 可对账，不采本地计数。
+            local_input_tokens: 0,
         };
 
         self.log_request(&log)
@@ -327,6 +333,8 @@ impl<'a> UsageLogger<'a> {
             provider_type,
             is_streaming,
             cost_multiplier: "1.0".to_string(),
+            // 错误行没有 usage 可对账，不采本地计数。
+            local_input_tokens: 0,
         };
 
         self.log_request(&log)
@@ -459,6 +467,7 @@ impl<'a> UsageLogger<'a> {
         session_id: Option<String>,
         provider_type: Option<String>,
         is_streaming: bool,
+        local_input_tokens: u64,
     ) -> Result<(), AppError> {
         let pricing = self.get_model_pricing(&pricing_model)?;
 
@@ -495,6 +504,7 @@ impl<'a> UsageLogger<'a> {
             provider_type,
             is_streaming,
             cost_multiplier: cost_multiplier.to_string(),
+            local_input_tokens,
         };
 
         self.log_request(&log)
@@ -530,6 +540,7 @@ mod tests {
             provider_type: Some("codex".to_string()),
             is_streaming: true,
             cost_multiplier: "1".to_string(),
+            local_input_tokens: 0,
         }
     }
 
@@ -574,6 +585,7 @@ mod tests {
             None,
             Some("claude".to_string()),
             false,
+            0,
         )?;
 
         // 验证记录已插入
@@ -788,6 +800,7 @@ mod tests {
             provider_type: Some("grokbuild".to_string()),
             is_streaming: false,
             cost_multiplier: "1".to_string(),
+            local_input_tokens: 0,
         };
 
         logger.log_request(&log)?;


### PR DESCRIPTION
## Summary

crowd 计数对账批 1（客户端全链）：检测模型掺水的被动信号——请求体本地 token 计数（o200k）与上游回显 usage.input_tokens 配对，模型子桶带三元组事实（tokLocalSum / tokRemoteSum / tokPairCount）。判定（比值稳定性/跳变/样本门槛）全在服务端，批 2/3 跟进；宁缺毋认从采集端收口（失败行/回填行/未采/无回显全部出局）。

- 采集：tiktoken o200k tokenize 整个请求体 JSON（口径恒定，不解析 messages），RequestContext 构造点一次计数、全链穿线（含 SSE 'static 回调提前 Copy 捕获）
- 落库：新列 local_input_tokens（loongport_schema v22，不占上游 user_version 号段）
- 桶：TOKEN_PAIR_EXPR 配对条件 + 模型桶三聚合，含口径测试（六种行形态只有全观测成功行进样本）
- **修根存量 bug**：query_raw_model_buckets 行读取起点沿用顶层桶的 6，但模型 SELECT 多 model 列——模型子桶直方图与 token 列自始错位一格（err_samples 被当 ttft[0]、fresh 被当 output）。起点改 7 修根，三元组测试暴露。历史已上报的模型桶数据错位无法追溯，顶层桶/站点级不受影响

## Validation

- cargo fmt / clippy --all-targets 干净；全量 cargo test --lib 3873 passed（含新增 token_pair_triples 口径测试）
- 纯后端改动（src-tauri），前端不涉及
- spec 与分批计划见 design 私库 spec-crowd-token-reconcile.md